### PR TITLE
Prevent channel shutdown if still active

### DIFF
--- a/src/RawRabbit/Common/PublishAcknowledger.cs
+++ b/src/RawRabbit/Common/PublishAcknowledger.cs
@@ -62,6 +62,10 @@ namespace RawRabbit.Common
 				}
 
 			};
+			_channel.FlowControl += (sender, args) =>
+			{
+				_logger.LogInformation($"The flow control event has been raised on channel '{_channel.ChannelNumber}'. Active: {args.Active}.");
+			};
 			channel.ConfirmSelect();
 		}
 

--- a/src/RawRabbit/Operations/Publisher.cs
+++ b/src/RawRabbit/Operations/Publisher.cs
@@ -17,7 +17,7 @@ namespace RawRabbit.Operations
 		private readonly IMessageContextProvider<TMessageContext> _contextProvider;
 		private readonly IPublishAcknowledger _acknowledger;
 		private readonly IBasicPropertiesProvider _propertiesProvider;
-		private IModel _channel;
+		protected IModel _channel;
 		private Timer _channelTimer;
 		private readonly ILogger _logger = LogManager.GetLogger<Publisher<TMessageContext>>();
 
@@ -45,7 +45,7 @@ namespace RawRabbit.Operations
 			return publishAckTask;
 		}
 
-		private IModel GetOrCreateChannel(PublishConfiguration config)
+		protected virtual IModel GetOrCreateChannel(PublishConfiguration config)
 		{
 			if (_channel?.IsOpen ?? false)
 			{


### PR DESCRIPTION
I've updated the code in `Publisher` so that where it previously closed the channel after 10 seconds no matter what, it will now see if there are still publishing going on on the channel and if that's the case wait for another 10 seconds before checking again.

While looking at the publishing flow, I had a look at the `PublishAcknowledger` and made sure that the entities in the dictionary existed before accessing them.