### PR TITLE
Corrected typo in NamingConventions for #28

### DIFF
--- a/src/RawRabbit.vNext/IServiceCollectionExtensions.cs
+++ b/src/RawRabbit.vNext/IServiceCollectionExtensions.cs
@@ -70,7 +70,7 @@ namespace RawRabbit.vNext
 				.AddTransient<IPublishAcknowledger, PublishAcknowledger>(
 					p => new PublishAcknowledger(p.GetService<RawRabbitConfiguration>().PublishConfirmTimeout)
 				)
-				.AddSingleton<INamingConvetions, NamingConvetions>()
+				.AddSingleton<INamingConventions, NamingConventions>()
 				.AddTransient<ISubscriber<TMessageContext>, Subscriber<TMessageContext>>()
 				.AddTransient<IPublisher, Publisher<TMessageContext>>()
 				.AddTransient<IResponder<TMessageContext>, Responder<TMessageContext>>()

--- a/src/RawRabbit/Common/ConfigurationEvaluator.cs
+++ b/src/RawRabbit/Common/ConfigurationEvaluator.cs
@@ -20,27 +20,27 @@ namespace RawRabbit.Common
 	public class ConfigurationEvaluator : IConfigurationEvaluator
 	{
 		private readonly RawRabbitConfiguration _clientConfig;
-		private readonly INamingConvetions _convetions;
+		private readonly INamingConventions _conventions;
 		private readonly string _directReplyTo = "amq.rabbitmq.reply-to";
 
-		public ConfigurationEvaluator(RawRabbitConfiguration clientConfig, INamingConvetions convetions)
+		public ConfigurationEvaluator(RawRabbitConfiguration clientConfig, INamingConventions conventions)
 		{
 			_clientConfig = clientConfig;
-			_convetions = convetions;
+			_conventions = conventions;
 		}
 
 		public SubscriptionConfiguration GetConfiguration<TMessage>(Action<ISubscriptionConfigurationBuilder> configuration = null)
 		{
-			var routingKey = _convetions.QueueNamingConvention(typeof(TMessage));
+			var routingKey = _conventions.QueueNamingConvention(typeof(TMessage));
 				var queueConfig = new QueueConfiguration(_clientConfig.Queue)
 			{
 				QueueName = routingKey,
-				NameSuffix = _convetions.SubscriberQueueSuffix(typeof(TMessage))
+				NameSuffix = _conventions.SubscriberQueueSuffix(typeof(TMessage))
 			};
 
 			var exchangeConfig = new ExchangeConfiguration(_clientConfig.Exchange)
 			{
-				ExchangeName = _convetions.ExchangeNamingConvention(typeof(TMessage))
+				ExchangeName = _conventions.ExchangeNamingConvention(typeof(TMessage))
 			};
 
 			var builder = new SubscriptionConfigurationBuilder(queueConfig, exchangeConfig, routingKey);
@@ -52,9 +52,9 @@ namespace RawRabbit.Common
 		{
 			var exchangeConfig = new ExchangeConfiguration(_clientConfig.Exchange)
 			{
-				ExchangeName = _convetions.ExchangeNamingConvention(typeof(TMessage))
+				ExchangeName = _conventions.ExchangeNamingConvention(typeof(TMessage))
 			};
-			var routingKey = _convetions.QueueNamingConvention(typeof(TMessage));
+			var routingKey = _conventions.QueueNamingConvention(typeof(TMessage));
 			var builder = new PublishConfigurationBuilder(exchangeConfig, routingKey);
 			configuration?.Invoke(builder);
 			return builder.Configuration;
@@ -64,12 +64,12 @@ namespace RawRabbit.Common
 		{
 			var queueConfig = new QueueConfiguration(_clientConfig.Queue)
 			{
-				QueueName = _convetions.QueueNamingConvention(typeof(TRequest))
+				QueueName = _conventions.QueueNamingConvention(typeof(TRequest))
 			};
 
 			var exchangeConfig = new ExchangeConfiguration(_clientConfig.Exchange)
 			{
-				ExchangeName = _convetions.RpcExchangeNamingConvention(typeof(TRequest), typeof(TResponse)),
+				ExchangeName = _conventions.RpcExchangeNamingConvention(typeof(TRequest), typeof(TResponse)),
 			};
 
 			var builder = new ResponderConfigurationBuilder(queueConfig, exchangeConfig);
@@ -90,14 +90,14 @@ namespace RawRabbit.Common
 
 			var exchangeConfig = new ExchangeConfiguration(_clientConfig.Exchange)
 			{
-				ExchangeName = _convetions.RpcExchangeNamingConvention(typeof(TRequest), typeof(TResponse))
+				ExchangeName = _conventions.RpcExchangeNamingConvention(typeof(TRequest), typeof(TResponse))
 			};
 
 			var defaultConfig = new RequestConfiguration
 			{
 				ReplyQueue = replyQueueConfig,
 				Exchange = exchangeConfig,
-				RoutingKey = _convetions.QueueNamingConvention(typeof(TRequest)),
+				RoutingKey = _conventions.QueueNamingConvention(typeof(TRequest)),
 				ReplyQueueRoutingKey = replyQueueConfig.QueueName
 			};
 

--- a/src/RawRabbit/Common/NamingConventions.cs
+++ b/src/RawRabbit/Common/NamingConventions.cs
@@ -6,7 +6,7 @@ using System.Text;
 
 namespace RawRabbit.Common
 {
-	public interface INamingConvetions
+	public interface INamingConventions
 	{
 		Func<Type, string> ExchangeNamingConvention { get; set; }
 		Func<Type, string> QueueNamingConvention { get; set; }
@@ -18,7 +18,7 @@ namespace RawRabbit.Common
 		Func<Type, string> SubscriberQueueSuffix { get; set; }
 	}
 
-	public class NamingConvetions : INamingConvetions
+	public class NamingConventions : INamingConventions
 	{
 		private readonly IEnumerable<string> _disallowedDirectoryNames = new[] {"bin", "debug", "release"};
 		private readonly Dictionary<Type, int> _subscriberCounter;
@@ -32,7 +32,7 @@ namespace RawRabbit.Common
 		public virtual Func<string> RetryQueueNamingConvention { get; set; }
 		public virtual Func<Type, string> SubscriberQueueSuffix { get; set; }
 
-		public NamingConvetions()
+		public NamingConventions()
 		{
 			_subscriberCounter = new Dictionary<Type,int>();
 			

--- a/src/RawRabbit/Context/Enhancer/ContextEnhancer.cs
+++ b/src/RawRabbit/Context/Enhancer/ContextEnhancer.cs
@@ -11,12 +11,12 @@ namespace RawRabbit.Context.Enhancer
 	public class ContextEnhancer : IContextEnhancer
 	{
 		private readonly IChannelFactory _channelFactory;
-		private readonly INamingConvetions _convetions;
+		private readonly INamingConventions _conventions;
 
-		public ContextEnhancer(IChannelFactory channelFactory, INamingConvetions convetions)
+		public ContextEnhancer(IChannelFactory channelFactory, INamingConventions conventions)
 		{
 			_channelFactory = channelFactory;
-			_convetions = convetions;
+			_conventions = conventions;
 		}
 
 		public void WireUpContextFeatures<TMessageContext>(TMessageContext context, IRawConsumer consumer, BasicDeliverEventArgs args) where TMessageContext : IMessageContext
@@ -40,8 +40,8 @@ namespace RawRabbit.Context.Enhancer
 
 			advancedCtx.RetryLater = timespan =>
 			{
-				var dlxName = _convetions.DeadLetterExchangeNamingConvention();
-				var dlQueueName = _convetions.RetryQueueNamingConvention();
+				var dlxName = _conventions.DeadLetterExchangeNamingConvention();
+				var dlQueueName = _conventions.RetryQueueNamingConvention();
 				var channel = _channelFactory.CreateChannel();
 				channel.ExchangeDeclare(dlxName, ExchangeType.Direct);
 				channel.QueueDeclare(dlQueueName, false, false, true, new Dictionary<string, object>


### PR DESCRIPTION
Renamed NamingConvetions to NamingConventions and associated files such
as INamingConvetions.