### PR TITLE
Introduce non-generic interface IBusClient

### DIFF
--- a/src/RawRabbit.vNext/BusClientFactory.cs
+++ b/src/RawRabbit.vNext/BusClientFactory.cs
@@ -10,39 +10,39 @@ namespace RawRabbit.vNext
 {
 	public class BusClientFactory
 	{
-		public static BusClient CreateDefault(TimeSpan requestTimeout)
+		public static IBusClient CreateDefault(TimeSpan requestTimeout)
 		{
 			var cfg = RawRabbitConfiguration.Local;
 			cfg.RequestTimeout = requestTimeout;
 			return CreateDefault(cfg);
 		}
 
-		public static BusClient CreateDefault(RawRabbitConfiguration config)
+		public static IBusClient CreateDefault(RawRabbitConfiguration config)
 		{
 			var addCfg = new Action<IServiceCollection>(s => s.AddSingleton(p => config));
 			var services = new ServiceCollection().AddRawRabbit(null, addCfg);
 			return CreateDefault(services);
 		}
 
-		public static BusClient CreateDefault(Action<IServiceCollection> custom = null)
+		public static IBusClient CreateDefault(Action<IServiceCollection> custom = null)
 		{
 			var services = new ServiceCollection().AddRawRabbit(null, custom);
 			return CreateDefault(services);
 		}
 
-		public static BusClient CreateDefault(Action<IConfigurationBuilder> config, Action<IServiceCollection> custom)
+		public static IBusClient CreateDefault(Action<IConfigurationBuilder> config, Action<IServiceCollection> custom)
 		{
 			var services = new ServiceCollection().AddRawRabbit(config, custom);
 			return CreateDefault(services);
 		}
 
-		public static BusClient CreateDefault(IServiceCollection services)
+		public static IBusClient CreateDefault(IServiceCollection services)
 		{
 			var serviceProvider = services.BuildServiceProvider();
 
 			LogManager.CurrentFactory = serviceProvider.GetService<ILoggerFactory>();
 
-			return serviceProvider.GetService<BusClient>();
+			return serviceProvider.GetService<IBusClient>();
 		}
 
 		public static IBusClient<TMessageContext> CreateDefault<TMessageContext>(Action<IConfigurationBuilder> config = null, Action<IServiceCollection> custom = null) where TMessageContext : IMessageContext

--- a/src/RawRabbit.vNext/IServiceCollectionExtensions.cs
+++ b/src/RawRabbit.vNext/IServiceCollectionExtensions.cs
@@ -24,7 +24,7 @@ namespace RawRabbit.vNext
 		public static IServiceCollection AddRawRabbit(this IServiceCollection collection, Action<IConfigurationBuilder> config = null, Action<IServiceCollection> custom = null)
 		{
 			return collection
-				.AddTransient<BusClient>()
+				.AddTransient<IBusClient,BusClient>()
 				.AddRawRabbit<MessageContext>(config, custom);
 		}
 

--- a/src/RawRabbit/BusClient.cs
+++ b/src/RawRabbit/BusClient.cs
@@ -4,7 +4,9 @@ using RawRabbit.Operations.Abstraction;
 
 namespace RawRabbit
 {
-	public class BusClient : BaseBusClient<MessageContext>
+	public interface IBusClient : IBusClient<MessageContext> { }
+
+	public class BusClient : BaseBusClient<MessageContext>, IBusClient
 	{
 		public BusClient(IConfigurationEvaluator configEval, ISubscriber<MessageContext> subscriber, IPublisher publisher, IResponder<MessageContext> responder, IRequester requester)
 			: base(configEval, subscriber, publisher, responder, requester)


### PR DESCRIPTION
This makes sense, since there is a non-generic class BusClient that inherits
from the generic BusClientBase. It makes sence that the BusClientFactory
return an interface.