### PR TITLE
(feature) RawRabbit.DependencyInjection.Ninject extension

### DIFF
--- a/RawRabbit.sln
+++ b/RawRabbit.sln
@@ -25,6 +25,8 @@ Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "RawRabbit.IntegrationTests"
 EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "RawRabbit.DependencyInjection.Autofac", "src\RawRabbit.DependencyInjection.Autofac\RawRabbit.DependencyInjection.Autofac.xproj", "{CB108BB0-9CA3-44DD-9D58-5A42AA8750B1}"
 EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "RawRabbit.DependencyInjection.Ninject", "src\RawRabbit.DependencyInjection.Ninject\RawRabbit.DependencyInjection.Ninject.xproj", "{F756087B-0F11-4524-B6D7-342B632F0255}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -55,6 +57,10 @@ Global
 		{CB108BB0-9CA3-44DD-9D58-5A42AA8750B1}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{CB108BB0-9CA3-44DD-9D58-5A42AA8750B1}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{CB108BB0-9CA3-44DD-9D58-5A42AA8750B1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F756087B-0F11-4524-B6D7-342B632F0255}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F756087B-0F11-4524-B6D7-342B632F0255}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F756087B-0F11-4524-B6D7-342B632F0255}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F756087B-0F11-4524-B6D7-342B632F0255}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -66,5 +72,6 @@ Global
 		{2318827A-0FE9-49D0-916E-3E0955AF6544} = {2F91E22A-AEBA-4BEF-9A03-C8232830F697}
 		{A3181958-F6A1-489A-AFCB-388AF4BAAB4A} = {2F91E22A-AEBA-4BEF-9A03-C8232830F697}
 		{CB108BB0-9CA3-44DD-9D58-5A42AA8750B1} = {7FCF8D3B-BA55-4C47-AC60-5CEF75418BEB}
+		{F756087B-0F11-4524-B6D7-342B632F0255} = {7FCF8D3B-BA55-4C47-AC60-5CEF75418BEB}
 	EndGlobalSection
 EndGlobal

--- a/docs/Getting-started.md
+++ b/docs/Getting-started.md
@@ -42,6 +42,15 @@ builder.RegisterRawRabbit("guest:guest@localhost:5672/");
 var container = builder.Build();
 ``` 
 
+### Ninject
+
+The package [`RawRabbit.DependencyInjection.Ninject`](https://www.nuget.org/packages/RawRabbit.DependencyInjection.Ninject) contains modules and extension methods for registering `RawRabbit`.
+
+```csharp
+var kernel = new StandardKernel();
+kernel.RegisterRawRabbit("guest:guest@localhost:5672/");
+``` 
+
 ## Broker connection
 As soon as the client is instansiated, it will try to connect to the broker.  By default `RawRabbit` will try to connect to `localhost`. Configuration can be provided in different ways.
 

--- a/src/RawRabbit.DependencyInjection.Ninject/KernelExtension.cs
+++ b/src/RawRabbit.DependencyInjection.Ninject/KernelExtension.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Ninject;
+using RawRabbit.Common;
+using RawRabbit.Configuration;
+using RawRabbit.Context;
+
+namespace RawRabbit.DependencyInjection.Ninject
+{
+    public static class KernelExtension
+    {
+        public static IKernel RegisterRawRabbit<TMessageContext>(this IKernel kernel)
+            where TMessageContext : IMessageContext
+        {
+            kernel.Load(new RawRabbitModule<TMessageContext>());
+            return kernel;
+        }
+
+        public static IKernel RegisterRawRabbit(this IKernel kernel)
+        {
+            kernel.Load(new RawRabbitModule());
+            return kernel;
+        }
+
+        public static IKernel RegisterRawRabbit<TMessageContext>(this IKernel kernel, RawRabbitConfiguration configuration)
+            where TMessageContext : IMessageContext
+        {
+            kernel
+                .Bind<RawRabbitConfiguration>()
+                .ToConstant(configuration)
+                .InSingletonScope();
+
+            kernel.Load(new RawRabbitModule<TMessageContext>());
+            return kernel;
+        }
+
+        public static IKernel RegisterRawRabbit(this IKernel kernel, RawRabbitConfiguration configuration)
+        {
+            return RegisterRawRabbit<MessageContext>(kernel, configuration);
+        }
+
+        public static IKernel RegisterRawRabbit<TMessageContext>(this IKernel kernel, string connectionString)
+            where TMessageContext : IMessageContext
+        {
+            var config = ConnectionStringParser.Parse(connectionString);
+            return RegisterRawRabbit<TMessageContext>(kernel, config);
+        }
+
+        public static IKernel RegisterRawRabbit(this IKernel kernel, string connectionString)
+        {
+            return RegisterRawRabbit<MessageContext>(kernel, connectionString);
+        }
+
+    }
+}

--- a/src/RawRabbit.DependencyInjection.Ninject/Properties/AssemblyInfo.cs
+++ b/src/RawRabbit.DependencyInjection.Ninject/Properties/AssemblyInfo.cs
@@ -1,0 +1,23 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("RawRabbit.DependencyInjection.Ninject")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("RawRabbit.DependencyInjection.Ninject")]
+[assembly: AssemblyCopyright("Copyright ©  2016")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("f756087b-0f11-4524-b6d7-342b632f0255")]

--- a/src/RawRabbit.DependencyInjection.Ninject/RawRabbit.DependencyInjection.Ninject.xproj
+++ b/src/RawRabbit.DependencyInjection.Ninject/RawRabbit.DependencyInjection.Ninject.xproj
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>f756087b-0f11-4524-b6d7-342b632f0255</ProjectGuid>
+    <RootNamespace>RawRabbit.DependencyInjection.Ninject</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+  </PropertyGroup>
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <ProduceOutputsOnBuild>True</ProduceOutputsOnBuild>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/src/RawRabbit.DependencyInjection.Ninject/RawRabbitModule.cs
+++ b/src/RawRabbit.DependencyInjection.Ninject/RawRabbitModule.cs
@@ -1,0 +1,163 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using Ninject;
+using Ninject.Modules;
+using RabbitMQ.Client;
+using RawRabbit.Channel;
+using RawRabbit.Channel.Abstraction;
+using RawRabbit.Common;
+using RawRabbit.Configuration;
+using RawRabbit.Consumer.Abstraction;
+using RawRabbit.Consumer.Eventing;
+using RawRabbit.Context;
+using RawRabbit.Context.Enhancer;
+using RawRabbit.Context.Provider;
+using RawRabbit.ErrorHandling;
+using RawRabbit.Logging;
+using RawRabbit.Operations;
+using RawRabbit.Operations.Abstraction;
+using RawRabbit.Serialization;
+
+namespace RawRabbit.DependencyInjection.Ninject
+{
+    public class RawRabbitModule : RawRabbitModule<MessageContext> { }
+
+    public class RawRabbitModule<TMessageContext> : NinjectModule where TMessageContext : IMessageContext
+    {
+        public override void Load()
+        {
+            Kernel
+                .Bind<ISubscriber<TMessageContext>>()
+                .To<Subscriber<TMessageContext>>()
+                .InSingletonScope();
+
+            Kernel
+                .Bind<IPublisher>()
+                .To<Publisher<TMessageContext>>()
+                .InSingletonScope();
+
+            Kernel
+                .Bind<IResponder<TMessageContext>>()
+                .To<Responder<TMessageContext>>()
+                .InSingletonScope();
+
+            Kernel
+                .Bind<IRequester>()
+                .To<Requester<TMessageContext>>()
+                .InSingletonScope()
+                .WithConstructorArgument("requestTimeout", (context) =>
+                    context.Kernel.Get<RawRabbitConfiguration>().RequestTimeout);
+
+            Kernel
+                .Bind<IMessageContextProvider<TMessageContext>>()
+                .To<MessageContextProvider<TMessageContext>>()
+                .InSingletonScope()
+                .WithConstructorArgument("createContextAsync", (Func<Task<TMessageContext>>) null);
+
+            Kernel
+                .Bind<IContextEnhancer>()
+                .To<ContextEnhancer>()
+                .InSingletonScope();
+
+            Kernel
+                .Bind<ITopologyProvider>()
+                .To<TopologyProvider>()
+                .InSingletonScope();
+
+            Kernel
+                .Bind<IConnectionFactory>()
+                .ToMethod(context =>
+                {
+                    var cfg = context.Kernel.Get<RawRabbitConfiguration>();
+                    return new ConnectionFactory
+                    {
+                        VirtualHost = cfg.VirtualHost,
+                        UserName = cfg.Username,
+                        Password = cfg.Password,
+                        Port = cfg.Port,
+                        HostName = cfg.Hostnames.FirstOrDefault() ?? string.Empty,
+                        AutomaticRecoveryEnabled = cfg.AutomaticRecovery,
+                        TopologyRecoveryEnabled = cfg.TopologyRecovery,
+                        NetworkRecoveryInterval = cfg.RecoveryInterval,
+                        ClientProperties = context.Kernel.Get<IClientPropertyProvider>().GetClientProperties(cfg),
+                        Ssl = cfg.Ssl
+                    };
+                })
+                .InSingletonScope();
+
+            Kernel
+                .Bind<IClientPropertyProvider>()
+                .To<ClientPropertyProvider>()
+                .InSingletonScope();
+
+            Kernel
+                .Bind<ILoggerFactory>()
+                .To<LoggerFactory>()
+                .InSingletonScope();
+
+            Kernel
+                .Bind<IMessageSerializer>()
+                .To<JsonMessageSerializer>()
+                .InSingletonScope()
+                .WithConstructorArgument("config", (Action<JsonSerializer>) null);
+
+            Kernel
+                .Bind<IConsumerFactory>()
+                .To<EventingBasicConsumerFactory>()
+                .InSingletonScope();
+
+            Kernel
+                .Bind<IErrorHandlingStrategy>()
+                .To<DefaultStrategy>()
+                .InSingletonScope();
+
+            Kernel
+                .Bind<IBasicPropertiesProvider>()
+                .To<BasicPropertiesProvider>()
+                .InSingletonScope();
+
+            Kernel
+                .Bind<IChannelFactory>()
+                .To<ChannelFactory>()
+                .InSingletonScope();
+
+            Kernel
+                .Bind<ChannelFactoryConfiguration>()
+                .ToConstant(ChannelFactoryConfiguration.Default)
+                .InSingletonScope();
+
+            Kernel
+                .Bind<IConfigurationEvaluator>()
+                .To<ConfigurationEvaluator>()
+                .InSingletonScope();
+
+            Kernel
+                .Bind<IPublishAcknowledger>()
+                .To<PublishAcknowledger>()
+                .InSingletonScope()
+                .WithConstructorArgument("publishTimeout", 
+                    context => context.Kernel.Get<RawRabbitConfiguration>().PublishConfirmTimeout);
+
+            Kernel
+                .Bind<INamingConventions>()
+                .To<NamingConventions>()
+                .InSingletonScope();
+
+            Kernel
+                .Bind<IBusClient<TMessageContext>>()
+                .To<BaseBusClient<TMessageContext>>()
+                .InSingletonScope();
+
+            if (typeof (TMessageContext) == typeof (MessageContext))
+            {
+                Kernel
+                    .Bind<IBusClient>()
+                    .To<BusClient>()
+                    .InSingletonScope();
+            }
+        }
+    }
+}

--- a/src/RawRabbit.DependencyInjection.Ninject/project.json
+++ b/src/RawRabbit.DependencyInjection.Ninject/project.json
@@ -1,0 +1,23 @@
+﻿{
+	"authors": [ "par.dahlman", "Joshua Barron" ],
+	"dependencies": {
+		"RawRabbit": "",
+		"Ninject": "3.2.2"
+	},
+	"description": "Wire up RawRabbit with Ninject!",
+	"frameworks": {
+		"dnx45": { },
+		"dnx451": { },
+		"dnx50": { },
+		"net45": { },
+		"net451": { },
+		"net452": { },
+		"net46": { },
+		"net50": { }
+	},
+	"iconUrl": "http://pardahlman.se/raw/icon.png",
+	"projectUrl": "https://github.com/pardahlman/RawRabbit",
+	"tags": [ "rabbitmq", "raw", "rawrabbit", "autfac" ],
+	"title": "RawRabbit.DependencyInjection.Autofac",
+	"version": "1.8.12-*"
+}

--- a/test/RawRabbit.Tests/DependencyInjection/NinjectTests.cs
+++ b/test/RawRabbit.Tests/DependencyInjection/NinjectTests.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Ninject;
+using RawRabbit.Context;
+using Xunit;
+using RawRabbit.DependencyInjection.Ninject;
+
+namespace RawRabbit.Tests.DependencyInjection
+{
+    public class NinjectTests
+    {
+        [Fact]
+        public void Should_Be_Able_To_Resolve_IBusClient()
+        {
+            /* Setup */
+            var kernel = new StandardKernel();
+            kernel.RegisterRawRabbit("guest:guest@localhost:5672/");
+            
+            /* Test */
+            var client = kernel.Get<IBusClient>();
+
+            /* Assert */
+            Assert.True(true, "Could resolve");
+        }
+
+        [Fact]
+        public void Should_Be_Able_To_Resolve_BusClient_With_Advanced_Context()
+        {
+            /* Setup */
+            var kernel = new StandardKernel();
+            kernel.RegisterRawRabbit<AdvancedMessageContext>("guest:guest@localhost:5672/");
+
+            /* Test */
+            var client = kernel.Get<IBusClient<AdvancedMessageContext>>();
+
+            /* Assert */
+            Assert.True(true, "Could resolve");
+        }
+    }
+}

--- a/test/RawRabbit.Tests/project.json
+++ b/test/RawRabbit.Tests/project.json
@@ -6,7 +6,8 @@
 		"Microsoft.Extensions.Configuration": "1.0.0-rc1-final",
 		"Moq" : "4.2.1510.2205",
 		"RawRabbit": "",
-		"RawRabbit.DependencyInjection.Autofac": "",
+    "RawRabbit.DependencyInjection.Autofac": "",
+    "RawRabbit.DependencyInjection.Ninject": "",
 		"RawRabbit.vNext": "",
 		"xunit": "2.1.0",
 		"xunit.runner.dnx": "2.1.0-rc1-build204"


### PR DESCRIPTION
This pull request adds a new package for using RawRabbit with Ninject.  I have based it on the Autofac package - all dependencies are registered as singletons and parameter injection works the same way.  I also used the Autofac tests as a basis for Ninject tests, which are passing in this pull request.  

Thanks for developing RawRabbit - I hope this PR is useful.