### PR TITLE
(#129) Expose Mandatory Option For Publish

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ docs/*build*/
 #VS Code
 .vscode/**
 
+#Rider
+.idea/**
+
 # User-specific files (MonoDevelop/Xamarin Studio)
 *.userprefs
 **ncrunch**

--- a/sample/RawRabbit.Messages.Sample/project.json
+++ b/sample/RawRabbit.Messages.Sample/project.json
@@ -7,6 +7,6 @@
 
 	"frameworks": {
 		"netstandard1.5": {},
-		"net451": {},
+		"net451": {}
 	}
 }

--- a/src/RawRabbit/Configuration/Publish/IPublishConfigurationBuilder.cs
+++ b/src/RawRabbit/Configuration/Publish/IPublishConfigurationBuilder.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using RabbitMQ.Client;
+using RabbitMQ.Client.Events;
 using RawRabbit.Configuration.Exchange;
 
 namespace RawRabbit.Configuration.Publish
@@ -9,5 +10,6 @@ namespace RawRabbit.Configuration.Publish
 		IPublishConfigurationBuilder WithExchange(Action<IExchangeConfigurationBuilder> exchange);
 		IPublishConfigurationBuilder WithRoutingKey(string routingKey);
 		IPublishConfigurationBuilder WithProperties(Action<IBasicProperties> properties);
+		IPublishConfigurationBuilder WithMandatoryDelivery(EventHandler<BasicReturnEventArgs> basicReturn);
 	}
 }

--- a/src/RawRabbit/Configuration/Publish/PublishConfiguration.cs
+++ b/src/RawRabbit/Configuration/Publish/PublishConfiguration.cs
@@ -10,7 +10,6 @@ namespace RawRabbit.Configuration.Publish
 		public ExchangeConfiguration Exchange { get; set; }
 		public string RoutingKey { get; set; }
 		public Action<IBasicProperties> PropertyModifier { get; set; }
-		public bool Mandatory { get; set; }
 		public EventHandler<BasicReturnEventArgs> BasicReturn { get; set; }
 	}
 }

--- a/src/RawRabbit/Configuration/Publish/PublishConfiguration.cs
+++ b/src/RawRabbit/Configuration/Publish/PublishConfiguration.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using RabbitMQ.Client;
+using RabbitMQ.Client.Events;
 using RawRabbit.Configuration.Exchange;
 
 namespace RawRabbit.Configuration.Publish
@@ -9,5 +10,7 @@ namespace RawRabbit.Configuration.Publish
 		public ExchangeConfiguration Exchange { get; set; }
 		public string RoutingKey { get; set; }
 		public Action<IBasicProperties> PropertyModifier { get; set; }
+		public bool Mandatory { get; set; }
+		public EventHandler<BasicReturnEventArgs> BasicReturn { get; set; }
 	}
 }

--- a/src/RawRabbit/Configuration/Publish/PublishConfigurationBuilder.cs
+++ b/src/RawRabbit/Configuration/Publish/PublishConfigurationBuilder.cs
@@ -1,5 +1,6 @@
 using System;
 using RabbitMQ.Client;
+using RabbitMQ.Client.Events;
 using RawRabbit.Configuration.Exchange;
 using RawRabbit.Configuration.Request;
 
@@ -11,12 +12,16 @@ namespace RawRabbit.Configuration.Publish
 		private string _routingKey;
 		private Action<IBasicProperties> _properties;
 		private const string _oneOrMoreWords = "#";
+		private bool _mandatory;
+		private EventHandler<BasicReturnEventArgs> _basicReturn;
 
 		public PublishConfiguration Configuration => new PublishConfiguration
 		{
 			Exchange = _exchange.Configuration,
 			RoutingKey = _routingKey,
-			PropertyModifier = _properties ?? (b => {})
+			PropertyModifier = _properties ?? (b => {}),
+			Mandatory = _mandatory,
+			BasicReturn = _basicReturn
 		};
 
 		public PublishConfigurationBuilder(ExchangeConfiguration defaultExchange = null, string routingKey =null)
@@ -46,6 +51,13 @@ namespace RawRabbit.Configuration.Publish
 		public IPublishConfigurationBuilder WithProperties(Action<IBasicProperties> properties)
 		{
 			_properties = properties;
+			return this;
+		}
+
+		public IPublishConfigurationBuilder WithMandatoryDelivery(EventHandler<BasicReturnEventArgs> basicReturn)
+		{
+			_mandatory = true;
+			_basicReturn = basicReturn;
 			return this;
 		}
 	}

--- a/src/RawRabbit/Configuration/Publish/PublishConfigurationBuilder.cs
+++ b/src/RawRabbit/Configuration/Publish/PublishConfigurationBuilder.cs
@@ -12,7 +12,6 @@ namespace RawRabbit.Configuration.Publish
 		private string _routingKey;
 		private Action<IBasicProperties> _properties;
 		private const string _oneOrMoreWords = "#";
-		private bool _mandatory;
 		private EventHandler<BasicReturnEventArgs> _basicReturn;
 
 		public PublishConfiguration Configuration => new PublishConfiguration
@@ -20,7 +19,6 @@ namespace RawRabbit.Configuration.Publish
 			Exchange = _exchange.Configuration,
 			RoutingKey = _routingKey,
 			PropertyModifier = _properties ?? (b => {}),
-			Mandatory = _mandatory,
 			BasicReturn = _basicReturn
 		};
 
@@ -56,7 +54,6 @@ namespace RawRabbit.Configuration.Publish
 
 		public IPublishConfigurationBuilder WithMandatoryDelivery(EventHandler<BasicReturnEventArgs> basicReturn)
 		{
-			_mandatory = true;
 			_basicReturn = basicReturn;
 			return this;
 		}

--- a/src/RawRabbit/Operations/Publisher.cs
+++ b/src/RawRabbit/Operations/Publisher.cs
@@ -67,9 +67,12 @@ namespace RawRabbit.Operations
 							routingKey: _config.RouteWithGlobalId ? $"{config.RoutingKey}.{globalMessageId}" : config.RoutingKey,
 							basicProperties: props,
 							body: _serializer.Serialize(message),
-							mandatory: config.Mandatory
+							mandatory: (config.BasicReturn != null)
 						);
-						return ackTask;
+						return ackTask
+						.ContinueWith(a => {
+							channelTask.Result.BasicReturn -= config.BasicReturn;
+						});
 					}
 				})
 				.Unwrap();

--- a/src/RawRabbit/Operations/Publisher.cs
+++ b/src/RawRabbit/Operations/Publisher.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Threading.Tasks;
-using RabbitMQ.Client;
 using RawRabbit.Channel.Abstraction;
 using RawRabbit.Common;
 using RawRabbit.Configuration;
@@ -57,6 +56,9 @@ namespace RawRabbit.Operations
 					{
 						throw t.Exception;
 					}
+
+					channelTask.Result.BasicReturn += config.BasicReturn;
+
 					lock (_publishLock)
 					{
 						var ackTask = _acknowledger.GetAckTask(channelTask.Result);
@@ -64,8 +66,9 @@ namespace RawRabbit.Operations
 							exchange: config.Exchange.ExchangeName,
 							routingKey: _config.RouteWithGlobalId ? $"{config.RoutingKey}.{globalMessageId}" : config.RoutingKey,
 							basicProperties: props,
-							body: _serializer.Serialize(message)
-							);
+							body: _serializer.Serialize(message),
+							mandatory: config.Mandatory
+						);
 						return ackTask;
 					}
 				})

--- a/test/RawRabbit.IntegrationTests/SimpleUse/PublishAndSubscribeTests.cs
+++ b/test/RawRabbit.IntegrationTests/SimpleUse/PublishAndSubscribeTests.cs
@@ -10,7 +10,6 @@ using RawRabbit.Common;
 using RawRabbit.Configuration;
 using RawRabbit.Exceptions;
 using RawRabbit.IntegrationTests.TestMessages;
-using RawRabbit.vNext;
 using Xunit;
 using ExchangeType = RawRabbit.Configuration.Exchange.ExchangeType;
 
@@ -387,6 +386,26 @@ namespace RawRabbit.IntegrationTests.SimpleUse
 				await tcs.Task;
 				/* Assert */
 				Assert.True(true);
+			}
+		}
+
+		[Fact]
+		public async Task Should_Run_Basic_Return_When_The_Manatory_Set_After_Failed_Publish()
+		{
+			/* Setup */
+			using (var client = TestClientFactory.CreateNormal())
+			{
+				var tcs = new TaskCompletionSource<bool>();
+				/* Test */
+				await client.PublishAsync(new SimpleMessage(),
+					configuration: cfg => cfg
+						.WithMandatoryDelivery((obj, evt) =>
+						{
+							tcs.SetResult(true);
+						}));
+
+				/* Assert */
+				Assert.True(tcs.Task.Result);
 			}
 		}
 	}


### PR DESCRIPTION
### Description

The mandatory option has been exposed to RawRabbit by adding a new property to the PublishConfiguration and a new method, WithMandatoryDelivery, on PublishConfigurationBuilder. This method also allows the user to pass a function to the BasicReturn event handler.
Publisher has been updated to use the mandatory flag in the BasicPublish method and the BasicReturn event.
The Rider IDE user files have also been ignored.
Solves #129. 

### Check List

- [ ] All test passed.
- [ ] Added documentation _(if applicable)_.
- [x] Tests added to ensure functionality.
- [x] Pull Request to `stable` branch.
