### PR TITLE
Added default broker connection values for RawRabbitConfig class

### DIFF
--- a/src/RawRabbit/Configuration/RawRabbitConfiguration.cs
+++ b/src/RawRabbit/Configuration/RawRabbitConfiguration.cs
@@ -104,6 +104,10 @@ namespace RawRabbit.Configuration
 				Durable = true
 			};
 		    VirtualHost = "/";
+		    Username = "guest";
+		    Password = "guest";
+		    Port = 5672;
+		    Hostnames = new List<string> {"localhost"};
 		}
 
 		public static RawRabbitConfiguration Local => new RawRabbitConfiguration

--- a/src/RawRabbit/Configuration/RawRabbitConfiguration.cs
+++ b/src/RawRabbit/Configuration/RawRabbitConfiguration.cs
@@ -71,7 +71,7 @@ namespace RawRabbit.Configuration
 		/// </summary>
 		public SslOption Ssl { get; set; }
 
-		public string VirtualHost { get; set; }
+	    public string VirtualHost { get; set; }
 		public string Username { get; set; }
 		public string Password { get; set; }
 		public int Port { get; set; }
@@ -103,6 +103,7 @@ namespace RawRabbit.Configuration
 				AutoDelete = false,
 				Durable = true
 			};
+		    VirtualHost = "/";
 		}
 
 		public static RawRabbitConfiguration Local => new RawRabbitConfiguration


### PR DESCRIPTION
### Description

Usually people new to RabbitMQ or who has the native client background will expect the default host be set to the default most of the time. This prevents getting #158 so inexperienced won't  run away. :smile: 

This is was the error that made me thought there was a bug with the package and removed it first time I used RR. :smile: 

So I think it is good idea to set default broker connection values right away rather then getting strange errors. The user can override them as wished. 

### Check List

- [x] All test passed.
- [x] Added documentation _(if applicable)_.
- [x] Tests added to ensure functionality.
- [x] Pull Request to `stable` branch.
