### PR TITLE
Converted tabs to 4 spaces

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,4 +1,4 @@
 ﻿{
-	"projects": [ "src", "test", "sample" ],
-	"sdk": { "version": "1.0.0-preview2-003121" }
+    "projects": [ "src", "test", "sample" ],
+    "sdk": { "version": "1.0.0-preview2-003121" }
 }

--- a/sample/RawRabbit.AspNet.Sample/Controllers/ValuesController.cs
+++ b/sample/RawRabbit.AspNet.Sample/Controllers/ValuesController.cs
@@ -10,59 +10,59 @@ using ILogger = Microsoft.Extensions.Logging.ILogger;
 
 namespace RawRabbit.AspNet.Sample.Controllers
 {
-	using IBusClient = Extensions.Client.IBusClient;
+    using IBusClient = Extensions.Client.IBusClient;
 
-	public class ValuesController : Controller
-	{
-		private readonly IBusClient _busClient;
-		private readonly Random _random;
-		private readonly ILogger<ValuesController> _logger;
+    public class ValuesController : Controller
+    {
+        private readonly IBusClient _busClient;
+        private readonly Random _random;
+        private readonly ILogger<ValuesController> _logger;
 
-		public ValuesController(IBusClient busClient, ILoggerFactory loggerFactory)
-		{
-			_busClient = busClient;
-			_logger = loggerFactory.CreateLogger<ValuesController>();
-			_random = new Random();
-		}
+        public ValuesController(IBusClient busClient, ILoggerFactory loggerFactory)
+        {
+            _busClient = busClient;
+            _logger = loggerFactory.CreateLogger<ValuesController>();
+            _random = new Random();
+        }
 
-		[HttpGet]
-		[Route("api/values")]
-		public Task<List<string>> GetAsync()
-		{
-			_logger.LogDebug("Recieved Value Request.");
-			var valueSequence = _busClient.ExecuteSequence(s => s
-				.PublishAsync(new ValuesRequested
-					{
-						NumberOfValues = _random.Next(1,10)
-					})
-				.When<ValueCreationFailed>(
-					(failed, context) =>
-					{
-						_logger.LogWarning("Unable to create Values. Exception: {0}", failed.Exception);
-						return Task.FromResult(true);
-					}, it => it.AbortsExecution())
-				.Complete<ValuesCalculated>()
-			);
+        [HttpGet]
+        [Route("api/values")]
+        public Task<List<string>> GetAsync()
+        {
+            _logger.LogDebug("Recieved Value Request.");
+            var valueSequence = _busClient.ExecuteSequence(s => s
+                .PublishAsync(new ValuesRequested
+                    {
+                        NumberOfValues = _random.Next(1,10)
+                    })
+                .When<ValueCreationFailed>(
+                    (failed, context) =>
+                    {
+                        _logger.LogWarning("Unable to create Values. Exception: {0}", failed.Exception);
+                        return Task.FromResult(true);
+                    }, it => it.AbortsExecution())
+                .Complete<ValuesCalculated>()
+            );
 
-			return valueSequence.Task.ContinueWith(tResponse =>
-			{
-				if (tResponse.IsFaulted)
-					throw new Exception("No response recieved. Is the Console App started?");
-				
-				_logger.LogInformation("Successfully created {valueCount} values", tResponse.Result.Values.Count);
-				return valueSequence.Aborted
-					? new List<string>()
-					: tResponse.Result.Values;
-			});
-		}
+            return valueSequence.Task.ContinueWith(tResponse =>
+            {
+                if (tResponse.IsFaulted)
+                    throw new Exception("No response recieved. Is the Console App started?");
+                
+                _logger.LogInformation("Successfully created {valueCount} values", tResponse.Result.Values.Count);
+                return valueSequence.Aborted
+                    ? new List<string>()
+                    : tResponse.Result.Values;
+            });
+        }
 
-		[HttpGet("{id}")]
-		public Task<string> GetAsync(int id)
-		{
-			_logger.LogInformation("Requesting Value with id {valueId}", id);
-			return _busClient
-				.RequestAsync<ValueRequest, ValueResponse>(new ValueRequest {Value = id})
-				.ContinueWith(tResponse => tResponse.Result.Value);
-		}
-	}
+        [HttpGet("{id}")]
+        public Task<string> GetAsync(int id)
+        {
+            _logger.LogInformation("Requesting Value with id {valueId}", id);
+            return _busClient
+                .RequestAsync<ValueRequest, ValueResponse>(new ValueRequest {Value = id})
+                .ContinueWith(tResponse => tResponse.Result.Value);
+        }
+    }
 }

--- a/sample/RawRabbit.AspNet.Sample/Program.cs
+++ b/sample/RawRabbit.AspNet.Sample/Program.cs
@@ -3,18 +3,18 @@ using Microsoft.AspNetCore.Hosting;
 
 namespace RawRabbit.AspNet.Sample
 {
-	public class Program
-	{
-		public static void Main(string[] args)
-		{
-			var host = new WebHostBuilder()
-				.UseKestrel()
-				.UseContentRoot(Directory.GetCurrentDirectory())
-				.UseIISIntegration()
-				.UseStartup<Startup>()
-				.Build();
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            var host = new WebHostBuilder()
+                .UseKestrel()
+                .UseContentRoot(Directory.GetCurrentDirectory())
+                .UseIISIntegration()
+                .UseStartup<Startup>()
+                .Build();
 
-			host.Run();
-		}
-	}
+            host.Run();
+        }
+    }
 }

--- a/sample/RawRabbit.AspNet.Sample/Startup.cs
+++ b/sample/RawRabbit.AspNet.Sample/Startup.cs
@@ -13,47 +13,47 @@ using ILogger = Serilog.ILogger;
 
 namespace RawRabbit.AspNet.Sample
 {
-	public class Startup
-	{
-		private readonly string _rootPath;
+    public class Startup
+    {
+        private readonly string _rootPath;
 
-		public Startup(IHostingEnvironment env)
-		{
-			_rootPath = env.ContentRootPath;
-			var builder = new ConfigurationBuilder()
-				.SetBasePath(_rootPath)
-				.AddJsonFile("appsettings.json")
-				.AddEnvironmentVariables();
-			Configuration = builder.Build();
-		}
+        public Startup(IHostingEnvironment env)
+        {
+            _rootPath = env.ContentRootPath;
+            var builder = new ConfigurationBuilder()
+                .SetBasePath(_rootPath)
+                .AddJsonFile("appsettings.json")
+                .AddEnvironmentVariables();
+            Configuration = builder.Build();
+        }
 
-		public IConfigurationRoot Configuration { get; }
+        public IConfigurationRoot Configuration { get; }
 
-		public void ConfigureServices(IServiceCollection services)
-		{
-			services
-				.AddRawRabbit(
-					Configuration.GetSection("RawRabbit"),
-					ioc => ioc
-						.AddSingleton(LoggingFactory.ApplicationLogger))
-						.AddSingleton<IConfigurationEvaluator, AttributeConfigEvaluator>()
-				.AddMvc();
-		}
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services
+                .AddRawRabbit(
+                    Configuration.GetSection("RawRabbit"),
+                    ioc => ioc
+                        .AddSingleton(LoggingFactory.ApplicationLogger))
+                        .AddSingleton<IConfigurationEvaluator, AttributeConfigEvaluator>()
+                .AddMvc();
+        }
 
-		public void Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerFactory loggerFactory)
-		{
-			loggerFactory
-				.AddSerilog(GetConfiguredSerilogger())
-				.AddConsole(Configuration.GetSection("Logging"));
+        public void Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerFactory loggerFactory)
+        {
+            loggerFactory
+                .AddSerilog(GetConfiguredSerilogger())
+                .AddConsole(Configuration.GetSection("Logging"));
 
-			app.UseMvc();
-		}
+            app.UseMvc();
+        }
 
-		private ILogger GetConfiguredSerilogger()
-		{
-			return new LoggerConfiguration()
-				.WriteTo.File($"{_rootPath}/Logs/serilog.log", LogEventLevel.Debug)
-				.CreateLogger();
-		}
-	}
+        private ILogger GetConfiguredSerilogger()
+        {
+            return new LoggerConfiguration()
+                .WriteTo.File($"{_rootPath}/Logs/serilog.log", LogEventLevel.Debug)
+                .CreateLogger();
+        }
+    }
 }

--- a/sample/RawRabbit.AspNet.Sample/appsettings.json
+++ b/sample/RawRabbit.AspNet.Sample/appsettings.json
@@ -1,34 +1,34 @@
 ﻿{
-	"Logging": {
-		"IncludeScopes": false,
-		"LogLevel": {
-			"Default": "Debug",
-			"System": "Information",
-			"Microsoft": "Information"
-		}
-	},
-	"RawRabbit": {
-		"Username": "guest",
-		"Password": "guest",
-		"VirtualHost": "/",
-		"Port": 5672,
-		"Hostnames": [ "localhost" ],
-		"RequestTimeout": "00:00:10",
-		"PublishConfirmTimeout": "00:00:01",
-		"RecoveryInterval": "00:00:10",
-		"PersistentDeliveryMode": true,
-		"AutoCloseConnection": true,
-		"AutomaticRecovery": true,
-		"TopologyRecovery": true,
-		"Exchange": {
-			"Durable": true,
-			"AutoDelete": true,
-			"Type": "Topic"
-		},
-		"Queue": {
-			"AutoDelete": true,
-			"Durable": true,
-			"Exclusive": true
-		}
-	}
+    "Logging": {
+        "IncludeScopes": false,
+        "LogLevel": {
+            "Default": "Debug",
+            "System": "Information",
+            "Microsoft": "Information"
+        }
+    },
+    "RawRabbit": {
+        "Username": "guest",
+        "Password": "guest",
+        "VirtualHost": "/",
+        "Port": 5672,
+        "Hostnames": [ "localhost" ],
+        "RequestTimeout": "00:00:10",
+        "PublishConfirmTimeout": "00:00:01",
+        "RecoveryInterval": "00:00:10",
+        "PersistentDeliveryMode": true,
+        "AutoCloseConnection": true,
+        "AutomaticRecovery": true,
+        "TopologyRecovery": true,
+        "Exchange": {
+            "Durable": true,
+            "AutoDelete": true,
+            "Type": "Topic"
+        },
+        "Queue": {
+            "AutoDelete": true,
+            "Durable": true,
+            "Exclusive": true
+        }
+    }
 }

--- a/sample/RawRabbit.AspNet.Sample/project.json
+++ b/sample/RawRabbit.AspNet.Sample/project.json
@@ -1,60 +1,60 @@
 {
-	"dependencies": {
-		"Microsoft.AspNetCore.Mvc": "1.0.0",
-		"Microsoft.AspNetCore.Server.IISIntegration": "1.0.0",
-		"Microsoft.AspNetCore.Server.Kestrel": "1.0.0",
-		"Microsoft.Extensions.Configuration.EnvironmentVariables": "1.0.0",
-		"Microsoft.Extensions.Configuration.FileExtensions": "1.0.0",
-		"Microsoft.Extensions.Configuration.Json": "1.0.0",
-		"Microsoft.Extensions.Logging": "1.0.0",
-		"Microsoft.Extensions.Logging.Console": "1.0.0",
-		"RawRabbit": { "target": "project" },
-		"RawRabbit.Extensions": { "target": "project" },
-		"RawRabbit.vNext": { "target": "project" },
-		"RawRabbit.Messages.Sample": { "target": "project" },
-		"Serilog.Extensions.Logging": "1.0.0",
-		"Serilog.Sinks.File": "2.2.0"
-	},
+    "dependencies": {
+        "Microsoft.AspNetCore.Mvc": "1.0.0",
+        "Microsoft.AspNetCore.Server.IISIntegration": "1.0.0",
+        "Microsoft.AspNetCore.Server.Kestrel": "1.0.0",
+        "Microsoft.Extensions.Configuration.EnvironmentVariables": "1.0.0",
+        "Microsoft.Extensions.Configuration.FileExtensions": "1.0.0",
+        "Microsoft.Extensions.Configuration.Json": "1.0.0",
+        "Microsoft.Extensions.Logging": "1.0.0",
+        "Microsoft.Extensions.Logging.Console": "1.0.0",
+        "RawRabbit": { "target": "project" },
+        "RawRabbit.Extensions": { "target": "project" },
+        "RawRabbit.vNext": { "target": "project" },
+        "RawRabbit.Messages.Sample": { "target": "project" },
+        "Serilog.Extensions.Logging": "1.0.0",
+        "Serilog.Sinks.File": "2.2.0"
+    },
 
-	"tools": {
-		"Microsoft.AspNetCore.Server.IISIntegration.Tools": {
-			"version": "1.0.0-preview1-final",
-			"imports": "portable-net45+win8+dnxcore50"
-		}
-	},
+    "tools": {
+        "Microsoft.AspNetCore.Server.IISIntegration.Tools": {
+            "version": "1.0.0-preview1-final",
+            "imports": "portable-net45+win8+dnxcore50"
+        }
+    },
 
-	"frameworks": {
-		"netcoreapp1.0": {
-			"dependencies": {
-				"Microsoft.NETCore.App": {
-					"type": "platform",
-					"version": "1.0.0"
-				}
-			},
-			"imports": "dnxcore50"
-		}
-	},
+    "frameworks": {
+        "netcoreapp1.0": {
+            "dependencies": {
+                "Microsoft.NETCore.App": {
+                    "type": "platform",
+                    "version": "1.0.0"
+                }
+            },
+            "imports": "dnxcore50"
+        }
+    },
 
-	"buildOptions": {
-		"emitEntryPoint": true,
-		"preserveCompilationContext": true
-	},
+    "buildOptions": {
+        "emitEntryPoint": true,
+        "preserveCompilationContext": true
+    },
 
-	"runtimeOptions": {
-		"gcServer": true
-	},
+    "runtimeOptions": {
+        "gcServer": true
+    },
 
-	"publishOptions": {
-		"include": [
-			"wwwroot",
-			"Views",
-			"rawrabbit.json",
-			"appsettings.json",
-			"web.config"
-		]
-	},
+    "publishOptions": {
+        "include": [
+            "wwwroot",
+            "Views",
+            "rawrabbit.json",
+            "appsettings.json",
+            "web.config"
+        ]
+    },
 
-	"scripts": {
-		"postpublish": [ "dotnet publish-iis --publish-folder %publish:OutputPath% --framework %publish:FullTargetFramework%" ]
-	}
+    "scripts": {
+        "postpublish": [ "dotnet publish-iis --publish-folder %publish:OutputPath% --framework %publish:FullTargetFramework%" ]
+    }
 }

--- a/sample/RawRabbit.AspNet.Sample/web.config
+++ b/sample/RawRabbit.AspNet.Sample/web.config
@@ -1,14 +1,14 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
 
-	<!--
+    <!--
     Configure your application settings in appsettings.json. Learn more at http://go.microsoft.com/fwlink/?LinkId=786380
   -->
 
-	<system.webServer>
-		<handlers>
-			<add name="aspNetCore" path="*" verb="*" modules="AspNetCoreModule" resourceType="Unspecified"/>
-		</handlers>
-		<aspNetCore processPath="%LAUNCHER_PATH%" arguments="%LAUNCHER_ARGS%" stdoutLogEnabled="false" stdoutLogFile=".\logs\stdout" forwardWindowsAuthToken="false"/>
-	</system.webServer>
+    <system.webServer>
+        <handlers>
+            <add name="aspNetCore" path="*" verb="*" modules="AspNetCoreModule" resourceType="Unspecified"/>
+        </handlers>
+        <aspNetCore processPath="%LAUNCHER_PATH%" arguments="%LAUNCHER_ARGS%" stdoutLogEnabled="false" stdoutLogFile=".\logs\stdout" forwardWindowsAuthToken="false"/>
+    </system.webServer>
 </configuration>

--- a/sample/RawRabbit.ConsoleApp.Sample/Program.cs
+++ b/sample/RawRabbit.ConsoleApp.Sample/Program.cs
@@ -13,40 +13,40 @@ using RawRabbit.vNext;
 
 namespace RawRabbit.ConsoleApp.Sample
 {
-	public class Program
-	{
-		private static IBusClient _client;
+    public class Program
+    {
+        private static IBusClient _client;
 
-		public static void Main(string[] args)
-		{
-			_client = BusClientFactory.CreateDefault(
-				cfg => cfg
-					.SetBasePath(Directory.GetCurrentDirectory())
-					.AddJsonFile("rawrabbit.json"),
-				ioc => ioc
-					.AddSingleton<IConfigurationEvaluator, AttributeConfigEvaluator>()
-				);
+        public static void Main(string[] args)
+        {
+            _client = BusClientFactory.CreateDefault(
+                cfg => cfg
+                    .SetBasePath(Directory.GetCurrentDirectory())
+                    .AddJsonFile("rawrabbit.json"),
+                ioc => ioc
+                    .AddSingleton<IConfigurationEvaluator, AttributeConfigEvaluator>()
+                );
 
-			_client.SubscribeAsync<ValuesRequested>(ServeValuesAsync);
-			_client.RespondAsync<ValueRequest, ValueResponse>(SendValuesThoughRpcAsync);
-		}
+            _client.SubscribeAsync<ValuesRequested>(ServeValuesAsync);
+            _client.RespondAsync<ValueRequest, ValueResponse>(SendValuesThoughRpcAsync);
+        }
 
-		private static Task<ValueResponse> SendValuesThoughRpcAsync(ValueRequest request, MessageContext context)
-		{
-			return Task.FromResult(new ValueResponse
-			{
-				Value = $"value{request.Value}"
-			});
-		}
+        private static Task<ValueResponse> SendValuesThoughRpcAsync(ValueRequest request, MessageContext context)
+        {
+            return Task.FromResult(new ValueResponse
+            {
+                Value = $"value{request.Value}"
+            });
+        }
 
-		private static Task ServeValuesAsync(ValuesRequested message, MessageContext context)
-		{
-			var values = new List<string>();
-			for (var i = 0; i < message.NumberOfValues; i++)
-			{
-				values.Add($"value{i}");
-			}
-			return _client.PublishAsync(new ValuesCalculated {Values = values});
-		}
-	}
+        private static Task ServeValuesAsync(ValuesRequested message, MessageContext context)
+        {
+            var values = new List<string>();
+            for (var i = 0; i < message.NumberOfValues; i++)
+            {
+                values.Add($"value{i}");
+            }
+            return _client.PublishAsync(new ValuesCalculated {Values = values});
+        }
+    }
 }

--- a/sample/RawRabbit.ConsoleApp.Sample/project.json
+++ b/sample/RawRabbit.ConsoleApp.Sample/project.json
@@ -1,32 +1,32 @@
 ﻿{
-	"version": "1.0.0-*",
-	"buildOptions": {
-		"emitEntryPoint": true
-	},
+    "version": "1.0.0-*",
+    "buildOptions": {
+        "emitEntryPoint": true
+    },
 
-	"dependencies": {
-		"RawRabbit": { "target": "project" },
-		"RawRabbit.Extensions": { "target": "project" },
-		"RawRabbit.vNext": { "target": "project" },
-		"RawRabbit.Messages.Sample": { "target": "project" },
-		"Microsoft.Extensions.Configuration.Json": "1.0.0"
-	},
+    "dependencies": {
+        "RawRabbit": { "target": "project" },
+        "RawRabbit.Extensions": { "target": "project" },
+        "RawRabbit.vNext": { "target": "project" },
+        "RawRabbit.Messages.Sample": { "target": "project" },
+        "Microsoft.Extensions.Configuration.Json": "1.0.0"
+    },
 
-	"frameworks": {
-		"netcoreapp1.0": {
-			"dependencies": {
-				"Microsoft.NETCore.App": {
-					"type": "platform",
-					"version": "1.0.0"
-				}
-			},
-			"imports": "dnxcore50"
-		}
-	},
+    "frameworks": {
+        "netcoreapp1.0": {
+            "dependencies": {
+                "Microsoft.NETCore.App": {
+                    "type": "platform",
+                    "version": "1.0.0"
+                }
+            },
+            "imports": "dnxcore50"
+        }
+    },
 
-	"publishOptions": {
-		"include": [
-			"rawrabbit.json"
-		]
-	}
+    "publishOptions": {
+        "include": [
+            "rawrabbit.json"
+        ]
+    }
 }

--- a/sample/RawRabbit.ConsoleApp.Sample/rawrabbit.json
+++ b/sample/RawRabbit.ConsoleApp.Sample/rawrabbit.json
@@ -1,24 +1,24 @@
 ﻿{
-	"Username": "guest",
-	"Password": "guest",
-	"VirtualHost": "/",
-	"Port": 5672,
-	"Hostnames": [ "localhost" ],
-	"RequestTimeout": "00:00:10",
-	"PublishConfirmTimeout": "00:00:01",
-	"RecoveryInterval": "00:00:10",
-	"PersistentDeliveryMode": true,
-	"AutoCloseConnection": true,
-	"AutomaticRecovery": true,
-	"TopologyRecovery": true,
-	"Exchange": {
-		"Durable": true,
-		"AutoDelete": true,
-		"Type": "Topic"
-	},
-	"Queue": {
-		"AutoDelete": true,
-		"Durable": true,
-		"Exclusive": true
-	}
+    "Username": "guest",
+    "Password": "guest",
+    "VirtualHost": "/",
+    "Port": 5672,
+    "Hostnames": [ "localhost" ],
+    "RequestTimeout": "00:00:10",
+    "PublishConfirmTimeout": "00:00:01",
+    "RecoveryInterval": "00:00:10",
+    "PersistentDeliveryMode": true,
+    "AutoCloseConnection": true,
+    "AutomaticRecovery": true,
+    "TopologyRecovery": true,
+    "Exchange": {
+        "Durable": true,
+        "AutoDelete": true,
+        "Type": "Topic"
+    },
+    "Queue": {
+        "AutoDelete": true,
+        "Durable": true,
+        "Exclusive": true
+    }
 }

--- a/sample/RawRabbit.Messages.Sample/AnotherMessage.cs
+++ b/sample/RawRabbit.Messages.Sample/AnotherMessage.cs
@@ -1,6 +1,6 @@
 ﻿namespace RawRabbit.Messages.Sample
 {
-	public class AnotherMessage
-	{
-	}
+    public class AnotherMessage
+    {
+    }
 }

--- a/sample/RawRabbit.Messages.Sample/ValueCreationFailed.cs
+++ b/sample/RawRabbit.Messages.Sample/ValueCreationFailed.cs
@@ -2,8 +2,8 @@
 
 namespace RawRabbit.Messages.Sample
 {
-	public class ValueCreationFailed
-	{
-		public Exception Exception { get; set; }
-	}
+    public class ValueCreationFailed
+    {
+        public Exception Exception { get; set; }
+    }
 }

--- a/sample/RawRabbit.Messages.Sample/ValueRequest.cs
+++ b/sample/RawRabbit.Messages.Sample/ValueRequest.cs
@@ -3,11 +3,11 @@ using RawRabbit.Configuration.Exchange;
 
 namespace RawRabbit.Messages.Sample
 {
-	[Exchange(Type = ExchangeType.Topic, Name = "custom.rpc.exchange")]
-	[Queue(Name = "custom.request.queue", Durable = false)]
-	[Routing(RoutingKey = "custom.routing.key")]
-	public class ValueRequest
-	{
-		public int Value { get; set; }
-	}
+    [Exchange(Type = ExchangeType.Topic, Name = "custom.rpc.exchange")]
+    [Queue(Name = "custom.request.queue", Durable = false)]
+    [Routing(RoutingKey = "custom.routing.key")]
+    public class ValueRequest
+    {
+        public int Value { get; set; }
+    }
 }

--- a/sample/RawRabbit.Messages.Sample/ValueResponse.cs
+++ b/sample/RawRabbit.Messages.Sample/ValueResponse.cs
@@ -1,7 +1,7 @@
 ﻿namespace RawRabbit.Messages.Sample
 {
-	public class ValueResponse
-	{
-		public string Value { get; set; }
-	}
+    public class ValueResponse
+    {
+        public string Value { get; set; }
+    }
 }

--- a/sample/RawRabbit.Messages.Sample/ValuesCalculated.cs
+++ b/sample/RawRabbit.Messages.Sample/ValuesCalculated.cs
@@ -2,8 +2,8 @@
 
 namespace RawRabbit.Messages.Sample
 {
-	public class ValuesCalculated
-	{
-		public List<string> Values { get; set; }
-	}
+    public class ValuesCalculated
+    {
+        public List<string> Values { get; set; }
+    }
 }

--- a/sample/RawRabbit.Messages.Sample/ValuesRequested.cs
+++ b/sample/RawRabbit.Messages.Sample/ValuesRequested.cs
@@ -1,7 +1,7 @@
 ﻿namespace RawRabbit.Messages.Sample
 {
-	public class ValuesRequested
-	{
-		public int NumberOfValues { get; set; }
-	}
+    public class ValuesRequested
+    {
+        public int NumberOfValues { get; set; }
+    }
 }

--- a/sample/RawRabbit.Messages.Sample/project.json
+++ b/sample/RawRabbit.Messages.Sample/project.json
@@ -1,12 +1,12 @@
 ﻿{
-	"version": "1.0.0-*",
+    "version": "1.0.0-*",
 
-	"dependencies": {
-		"RawRabbit.Attributes": { "target": "project" }
-	},
+    "dependencies": {
+        "RawRabbit.Attributes": { "target": "project" }
+    },
 
-	"frameworks": {
-		"netstandard1.5": {},
-		"net451": {}
-	}
+    "frameworks": {
+        "netstandard1.5": {},
+        "net451": {}
+    }
 }

--- a/src/RawRabbit.Attributes/AttributeConfigEvaluator.cs
+++ b/src/RawRabbit.Attributes/AttributeConfigEvaluator.cs
@@ -11,210 +11,210 @@ using RawRabbit.Configuration.Subscribe;
 
 namespace RawRabbit.Attributes
 {
-	public class AttributeConfigEvaluator : IConfigurationEvaluator
-	{
-		private readonly ConfigurationEvaluator _fallback;
+    public class AttributeConfigEvaluator : IConfigurationEvaluator
+    {
+        private readonly ConfigurationEvaluator _fallback;
 
-		public AttributeConfigEvaluator(RawRabbitConfiguration config, INamingConventions conventions)
-		{
-			_fallback = new ConfigurationEvaluator(config, conventions);
-		}
-		public SubscriptionConfiguration GetConfiguration<TMessage>(Action<ISubscriptionConfigurationBuilder> configuration = null)
-		{
-			return GetConfiguration(typeof(TMessage), configuration);
-		}
+        public AttributeConfigEvaluator(RawRabbitConfiguration config, INamingConventions conventions)
+        {
+            _fallback = new ConfigurationEvaluator(config, conventions);
+        }
+        public SubscriptionConfiguration GetConfiguration<TMessage>(Action<ISubscriptionConfigurationBuilder> configuration = null)
+        {
+            return GetConfiguration(typeof(TMessage), configuration);
+        }
 
-		public PublishConfiguration GetConfiguration<TMessage>(Action<IPublishConfigurationBuilder> configuration)
-		{
-			return GetConfiguration(typeof(TMessage), configuration);
-		}
+        public PublishConfiguration GetConfiguration<TMessage>(Action<IPublishConfigurationBuilder> configuration)
+        {
+            return GetConfiguration(typeof(TMessage), configuration);
+        }
 
-		public ResponderConfiguration GetConfiguration<TRequest, TResponse>(Action<IResponderConfigurationBuilder> configuration)
-		{
-			return GetConfiguration(typeof(TRequest), typeof(TResponse), configuration);
-		}
+        public ResponderConfiguration GetConfiguration<TRequest, TResponse>(Action<IResponderConfigurationBuilder> configuration)
+        {
+            return GetConfiguration(typeof(TRequest), typeof(TResponse), configuration);
+        }
 
-		public RequestConfiguration GetConfiguration<TRequest, TResponse>(Action<IRequestConfigurationBuilder> configuration)
-		{
-			return GetConfiguration(typeof(TRequest), typeof(TResponse), configuration);
-		}
+        public RequestConfiguration GetConfiguration<TRequest, TResponse>(Action<IRequestConfigurationBuilder> configuration)
+        {
+            return GetConfiguration(typeof(TRequest), typeof(TResponse), configuration);
+        }
 
-		public SubscriptionConfiguration GetConfiguration(Type messageType, Action<ISubscriptionConfigurationBuilder> configuration = null)
-		{
-			configuration = configuration ?? (builder => { });
-			configuration = (builder =>
-			{
-				builder
-					.WithExchange(ExchangeAction(messageType))
-					.WithQueue(QueueAction(messageType));
+        public SubscriptionConfiguration GetConfiguration(Type messageType, Action<ISubscriptionConfigurationBuilder> configuration = null)
+        {
+            configuration = configuration ?? (builder => { });
+            configuration = (builder =>
+            {
+                builder
+                    .WithExchange(ExchangeAction(messageType))
+                    .WithQueue(QueueAction(messageType));
 
-				var routingAttr = GetAttribute<RoutingAttribute>(messageType);
-				if (routingAttr != null)
-				{
-					if (routingAttr.NullableNoAck.HasValue)
-					{
-						builder.WithNoAck(routingAttr.NullableNoAck.Value);
-					}
-					if (routingAttr.PrefetchCount > 0)
-					{
-						builder.WithPrefetchCount(routingAttr.PrefetchCount);
-					}
-					if (routingAttr.RoutingKey != null)
-					{
-						builder.WithRoutingKey(routingAttr.RoutingKey);
-					}
-				}
-			}) + configuration;
-			var cfg = _fallback.GetConfiguration(messageType, configuration);
-			return cfg;
-		}
+                var routingAttr = GetAttribute<RoutingAttribute>(messageType);
+                if (routingAttr != null)
+                {
+                    if (routingAttr.NullableNoAck.HasValue)
+                    {
+                        builder.WithNoAck(routingAttr.NullableNoAck.Value);
+                    }
+                    if (routingAttr.PrefetchCount > 0)
+                    {
+                        builder.WithPrefetchCount(routingAttr.PrefetchCount);
+                    }
+                    if (routingAttr.RoutingKey != null)
+                    {
+                        builder.WithRoutingKey(routingAttr.RoutingKey);
+                    }
+                }
+            }) + configuration;
+            var cfg = _fallback.GetConfiguration(messageType, configuration);
+            return cfg;
+        }
 
-		public PublishConfiguration GetConfiguration(Type messageType, Action<IPublishConfigurationBuilder> configuration)
-		{
-			configuration = configuration ?? (builder => { });
-			configuration = (builder =>
-			{
-				builder.WithExchange(ExchangeAction(messageType));
-				var routingAttr = GetAttribute<RoutingAttribute>(messageType);
-				if (routingAttr?.RoutingKey != null)
-				{
-					builder.WithRoutingKey(routingAttr.RoutingKey);
-				}
-			}) + configuration;
-			var cfg = _fallback.GetConfiguration(messageType, configuration);
-			return cfg;
-		}
+        public PublishConfiguration GetConfiguration(Type messageType, Action<IPublishConfigurationBuilder> configuration)
+        {
+            configuration = configuration ?? (builder => { });
+            configuration = (builder =>
+            {
+                builder.WithExchange(ExchangeAction(messageType));
+                var routingAttr = GetAttribute<RoutingAttribute>(messageType);
+                if (routingAttr?.RoutingKey != null)
+                {
+                    builder.WithRoutingKey(routingAttr.RoutingKey);
+                }
+            }) + configuration;
+            var cfg = _fallback.GetConfiguration(messageType, configuration);
+            return cfg;
+        }
 
-		public ResponderConfiguration GetConfiguration(Type requestType, Type responseType, Action<IResponderConfigurationBuilder> configuration)
-		{
-			configuration = configuration ?? (builder => { });
-			configuration = (builder =>
-			{
-				builder
-					.WithExchange(ExchangeAction(requestType))
-					.WithQueue(QueueAction(requestType));
+        public ResponderConfiguration GetConfiguration(Type requestType, Type responseType, Action<IResponderConfigurationBuilder> configuration)
+        {
+            configuration = configuration ?? (builder => { });
+            configuration = (builder =>
+            {
+                builder
+                    .WithExchange(ExchangeAction(requestType))
+                    .WithQueue(QueueAction(requestType));
 
-				var routingAttr = GetAttribute<RoutingAttribute>(requestType);
-				if (routingAttr != null)
-				{
-					if (routingAttr.NullableNoAck.HasValue)
-					{
-						builder.WithNoAck(routingAttr.NullableNoAck.Value);
-					}
-					if (routingAttr.PrefetchCount > 0)
-					{
-						builder.WithPrefetchCount(routingAttr.PrefetchCount);
-					}
-					if (routingAttr.RoutingKey != null)
-					{
-						builder.WithRoutingKey(routingAttr.RoutingKey);
-					}
-				}
-			}) + configuration;
-			var cfg = _fallback.GetConfiguration(requestType, responseType, configuration);
-			return cfg;
-		}
+                var routingAttr = GetAttribute<RoutingAttribute>(requestType);
+                if (routingAttr != null)
+                {
+                    if (routingAttr.NullableNoAck.HasValue)
+                    {
+                        builder.WithNoAck(routingAttr.NullableNoAck.Value);
+                    }
+                    if (routingAttr.PrefetchCount > 0)
+                    {
+                        builder.WithPrefetchCount(routingAttr.PrefetchCount);
+                    }
+                    if (routingAttr.RoutingKey != null)
+                    {
+                        builder.WithRoutingKey(routingAttr.RoutingKey);
+                    }
+                }
+            }) + configuration;
+            var cfg = _fallback.GetConfiguration(requestType, responseType, configuration);
+            return cfg;
+        }
 
-		public RequestConfiguration GetConfiguration(Type requestType, Type responseType, Action<IRequestConfigurationBuilder> configuration)
-		{
-			configuration = configuration ?? (builder => { });
-			configuration = (builder =>
-			{
-				builder.WithExchange(ExchangeAction(requestType));
+        public RequestConfiguration GetConfiguration(Type requestType, Type responseType, Action<IRequestConfigurationBuilder> configuration)
+        {
+            configuration = configuration ?? (builder => { });
+            configuration = (builder =>
+            {
+                builder.WithExchange(ExchangeAction(requestType));
 
-				var routingAttr = GetAttribute<RoutingAttribute>(requestType);
-				if (routingAttr != null)
-				{
-					if (routingAttr.NullableNoAck.HasValue)
-					{
-						builder.WithNoAck(routingAttr.NullableNoAck.Value);
-					}
-					if (routingAttr.RoutingKey != null)
-					{
-						builder.WithRoutingKey(routingAttr.RoutingKey);
-					}
-				}
-			}) + configuration;
-			var cfg = _fallback.GetConfiguration(requestType, responseType, configuration);
-			return cfg;
-		}
+                var routingAttr = GetAttribute<RoutingAttribute>(requestType);
+                if (routingAttr != null)
+                {
+                    if (routingAttr.NullableNoAck.HasValue)
+                    {
+                        builder.WithNoAck(routingAttr.NullableNoAck.Value);
+                    }
+                    if (routingAttr.RoutingKey != null)
+                    {
+                        builder.WithRoutingKey(routingAttr.RoutingKey);
+                    }
+                }
+            }) + configuration;
+            var cfg = _fallback.GetConfiguration(requestType, responseType, configuration);
+            return cfg;
+        }
 
-		private static Action<IExchangeConfigurationBuilder> ExchangeAction(Type messageType)
-		{
-			var exchangeAttr = GetAttribute<ExchangeAttribute>(messageType);
-			if (exchangeAttr == null)
-			{
-				return builder => { };
-			}
-			return builder =>
-			{
-				if (!string.IsNullOrWhiteSpace(exchangeAttr.Name))
-				{
-					builder.WithName(exchangeAttr.Name);
-				}
-				if (exchangeAttr.NullableDurability.HasValue)
-				{
-					builder.WithDurability(exchangeAttr.NullableDurability.Value);
-				}
-				if (exchangeAttr.NullableAutoDelete.HasValue)
-				{
-					builder.WithDurability(exchangeAttr.NullableAutoDelete.Value);
-				}
-				if (exchangeAttr.Type != ExchangeType.Unknown)
-				{
-					builder.WithType(exchangeAttr.Type);
-				}
-			};
-		}
+        private static Action<IExchangeConfigurationBuilder> ExchangeAction(Type messageType)
+        {
+            var exchangeAttr = GetAttribute<ExchangeAttribute>(messageType);
+            if (exchangeAttr == null)
+            {
+                return builder => { };
+            }
+            return builder =>
+            {
+                if (!string.IsNullOrWhiteSpace(exchangeAttr.Name))
+                {
+                    builder.WithName(exchangeAttr.Name);
+                }
+                if (exchangeAttr.NullableDurability.HasValue)
+                {
+                    builder.WithDurability(exchangeAttr.NullableDurability.Value);
+                }
+                if (exchangeAttr.NullableAutoDelete.HasValue)
+                {
+                    builder.WithDurability(exchangeAttr.NullableAutoDelete.Value);
+                }
+                if (exchangeAttr.Type != ExchangeType.Unknown)
+                {
+                    builder.WithType(exchangeAttr.Type);
+                }
+            };
+        }
 
-		private static Action<IQueueConfigurationBuilder> QueueAction(Type messageType)
-		{
-			var queueAttr = GetAttribute<QueueAttribute>(messageType);
-			if (queueAttr == null)
-			{
-				return builder => { };
-			}
-			return builder =>
-			{
-				if (!string.IsNullOrWhiteSpace(queueAttr.Name))
-				{
-					builder.WithName(queueAttr.Name);
-				}
-				if (queueAttr.NullableDurability.HasValue)
-				{
-					builder.WithDurability(queueAttr.NullableDurability.Value);
-				}
-				if (queueAttr.NullableExclusitivy.HasValue)
-				{
-					builder.WithDurability(queueAttr.NullableExclusitivy.Value);
-				}
-				if (queueAttr.NullableAutoDelete.HasValue)
-				{
-					builder.WithDurability(queueAttr.NullableAutoDelete.Value);
-				}
-				if (queueAttr.MessageTtl > 0)
-				{
-					builder.WithArgument(QueueArgument.MessageTtl, queueAttr.MessageTtl);
-				}
-				if (queueAttr.MaxPriority > 0)
-				{
-					builder.WithArgument(QueueArgument.MaxPriority, queueAttr.MaxPriority);
-				}
-				if (!string.IsNullOrWhiteSpace(queueAttr.DeadLeterExchange))
-				{
-					builder.WithArgument(QueueArgument.DeadLetterExchange, queueAttr.DeadLeterExchange);
-				}
-				if (!string.IsNullOrWhiteSpace(queueAttr.Mode))
-				{
-					builder.WithArgument(QueueArgument.QueueMode, queueAttr.Mode);
-				}
-			};
-		}
+        private static Action<IQueueConfigurationBuilder> QueueAction(Type messageType)
+        {
+            var queueAttr = GetAttribute<QueueAttribute>(messageType);
+            if (queueAttr == null)
+            {
+                return builder => { };
+            }
+            return builder =>
+            {
+                if (!string.IsNullOrWhiteSpace(queueAttr.Name))
+                {
+                    builder.WithName(queueAttr.Name);
+                }
+                if (queueAttr.NullableDurability.HasValue)
+                {
+                    builder.WithDurability(queueAttr.NullableDurability.Value);
+                }
+                if (queueAttr.NullableExclusitivy.HasValue)
+                {
+                    builder.WithDurability(queueAttr.NullableExclusitivy.Value);
+                }
+                if (queueAttr.NullableAutoDelete.HasValue)
+                {
+                    builder.WithDurability(queueAttr.NullableAutoDelete.Value);
+                }
+                if (queueAttr.MessageTtl > 0)
+                {
+                    builder.WithArgument(QueueArgument.MessageTtl, queueAttr.MessageTtl);
+                }
+                if (queueAttr.MaxPriority > 0)
+                {
+                    builder.WithArgument(QueueArgument.MaxPriority, queueAttr.MaxPriority);
+                }
+                if (!string.IsNullOrWhiteSpace(queueAttr.DeadLeterExchange))
+                {
+                    builder.WithArgument(QueueArgument.DeadLetterExchange, queueAttr.DeadLeterExchange);
+                }
+                if (!string.IsNullOrWhiteSpace(queueAttr.Mode))
+                {
+                    builder.WithArgument(QueueArgument.QueueMode, queueAttr.Mode);
+                }
+            };
+        }
 
-		private static TAttribute GetAttribute<TAttribute>(Type type) where TAttribute : Attribute
-		{
-			var attr = type.GetTypeInfo().GetCustomAttribute<TAttribute>();
-			return attr;
-		}
-	}
+        private static TAttribute GetAttribute<TAttribute>(Type type) where TAttribute : Attribute
+        {
+            var attr = type.GetTypeInfo().GetCustomAttribute<TAttribute>();
+            return attr;
+        }
+    }
 }

--- a/src/RawRabbit.Attributes/ExchangeAttribute.cs
+++ b/src/RawRabbit.Attributes/ExchangeAttribute.cs
@@ -3,15 +3,15 @@ using RawRabbit.Configuration.Exchange;
 
 namespace RawRabbit.Attributes
 {
-	[AttributeUsage(AttributeTargets.Class)]
-	public class ExchangeAttribute : Attribute
-	{
-		internal bool? NullableDurability;
-		internal bool? NullableAutoDelete;
+    [AttributeUsage(AttributeTargets.Class)]
+    public class ExchangeAttribute : Attribute
+    {
+        internal bool? NullableDurability;
+        internal bool? NullableAutoDelete;
 
-		public string Name { get; set; }
-		public ExchangeType Type { get; set; }
-		public bool Durable { set { NullableDurability = value; } }
-		public bool AutoDelete { set { NullableAutoDelete = value; } }
-	}
+        public string Name { get; set; }
+        public ExchangeType Type { get; set; }
+        public bool Durable { set { NullableDurability = value; } }
+        public bool AutoDelete { set { NullableAutoDelete = value; } }
+    }
 }

--- a/src/RawRabbit.Attributes/QueueAttribute.cs
+++ b/src/RawRabbit.Attributes/QueueAttribute.cs
@@ -2,35 +2,35 @@
 
 namespace RawRabbit.Attributes
 {
-	[AttributeUsage(AttributeTargets.Class)]
-	public class QueueAttribute : Attribute
-	{
-		internal bool? NullableDurability;
-		internal bool? NullableExclusitivy;
-		internal bool? NullableAutoDelete;
+    [AttributeUsage(AttributeTargets.Class)]
+    public class QueueAttribute : Attribute
+    {
+        internal bool? NullableDurability;
+        internal bool? NullableExclusitivy;
+        internal bool? NullableAutoDelete;
 
-		public string Name { get; set; }
+        public string Name { get; set; }
 
-		public bool Durable
-		{
-			get { return NullableDurability.GetValueOrDefault(); }
-			set { NullableDurability = value; }
-		}
+        public bool Durable
+        {
+            get { return NullableDurability.GetValueOrDefault(); }
+            set { NullableDurability = value; }
+        }
 
-		public bool Exclusive
-		{
-			get { return NullableExclusitivy.GetValueOrDefault(); }
-			set { NullableExclusitivy = value; }
-		}
+        public bool Exclusive
+        {
+            get { return NullableExclusitivy.GetValueOrDefault(); }
+            set { NullableExclusitivy = value; }
+        }
 
-		public bool AutoDelete
-		{
-			get { return NullableAutoDelete.GetValueOrDefault(); }
-			set { NullableAutoDelete = value; }
-		}
-		public int MessageTtl { get; set; }
-		public byte MaxPriority { get; set; }
-		public string DeadLeterExchange { get; set; }
-		public string Mode { get; set; }
-	}
+        public bool AutoDelete
+        {
+            get { return NullableAutoDelete.GetValueOrDefault(); }
+            set { NullableAutoDelete = value; }
+        }
+        public int MessageTtl { get; set; }
+        public byte MaxPriority { get; set; }
+        public string DeadLeterExchange { get; set; }
+        public string Mode { get; set; }
+    }
 }

--- a/src/RawRabbit.Attributes/RoutingAttribute.cs
+++ b/src/RawRabbit.Attributes/RoutingAttribute.cs
@@ -2,13 +2,13 @@
 
 namespace RawRabbit.Attributes
 {
-	[AttributeUsage(AttributeTargets.Class)]
-	public class RoutingAttribute : Attribute
-	{
-		internal bool? NullableNoAck;
+    [AttributeUsage(AttributeTargets.Class)]
+    public class RoutingAttribute : Attribute
+    {
+        internal bool? NullableNoAck;
 
-		public string RoutingKey { get; set; }
-		public ushort PrefetchCount { get; set; }
-		public bool NoAck { get { return NullableNoAck.GetValueOrDefault(); } set { NullableNoAck = value; } }
-	}
+        public string RoutingKey { get; set; }
+        public ushort PrefetchCount { get; set; }
+        public bool NoAck { get { return NullableNoAck.GetValueOrDefault(); } set { NullableNoAck = value; } }
+    }
 }

--- a/src/RawRabbit.Attributes/project.json
+++ b/src/RawRabbit.Attributes/project.json
@@ -1,21 +1,21 @@
 ﻿{
-	"title": "RawRabbit.Attributes",
-	"version": "1.10.2-*",
-	"authors": [ "pardahlman" ],
-	"description": "Configure messages and topology with attributes.",
-	"packOptions": {
-		"iconUrl": "http://pardahlman.se/raw/icon.png",
-		"projectUrl": "https://github.com/pardahlman/RawRabbit",
-		"tags": [ "rabbitmq", "raw", "rawrabbit", "attributes" ],
-		"publishExclude": [ "**.xproj", "**.user", "**.vspscc" ]
-	},
+    "title": "RawRabbit.Attributes",
+    "version": "1.10.2-*",
+    "authors": [ "pardahlman" ],
+    "description": "Configure messages and topology with attributes.",
+    "packOptions": {
+        "iconUrl": "http://pardahlman.se/raw/icon.png",
+        "projectUrl": "https://github.com/pardahlman/RawRabbit",
+        "tags": [ "rabbitmq", "raw", "rawrabbit", "attributes" ],
+        "publishExclude": [ "**.xproj", "**.user", "**.vspscc" ]
+    },
 
-	"dependencies": {
-		"RawRabbit": { "target": "project" }
-	},
+    "dependencies": {
+        "RawRabbit": { "target": "project" }
+    },
 
-	"frameworks": {
-		"netstandard1.5": {},
-		"net451": {}
-	}
+    "frameworks": {
+        "netstandard1.5": {},
+        "net451": {}
+    }
 }

--- a/src/RawRabbit.DependencyInjection.Autofac/ContainerBuilderExtension.cs
+++ b/src/RawRabbit.DependencyInjection.Autofac/ContainerBuilderExtension.cs
@@ -5,47 +5,47 @@ using RawRabbit.Context;
 
 namespace RawRabbit.DependencyInjection.Autofac
 {
-	public static class ContainerBuilderExtension
-	{
-		public static ContainerBuilder RegisterRawRabbit<TMessageContext>(this ContainerBuilder builder) where TMessageContext : IMessageContext
-		{
-			builder.RegisterModule<RawRabbitModule<TMessageContext>>();
-			return builder;
-		}
+    public static class ContainerBuilderExtension
+    {
+        public static ContainerBuilder RegisterRawRabbit<TMessageContext>(this ContainerBuilder builder) where TMessageContext : IMessageContext
+        {
+            builder.RegisterModule<RawRabbitModule<TMessageContext>>();
+            return builder;
+        }
 
-		public static ContainerBuilder RegisterRawRabbit(this ContainerBuilder builder)
-		{
-			builder.RegisterModule<RawRabbitModule>();
-			return builder;
-		}
+        public static ContainerBuilder RegisterRawRabbit(this ContainerBuilder builder)
+        {
+            builder.RegisterModule<RawRabbitModule>();
+            return builder;
+        }
 
-		public static ContainerBuilder RegisterRawRabbit(this ContainerBuilder builder, string connectionString)
-		{
-			return RegisterRawRabbit<MessageContext>(builder, connectionString);
-		}
+        public static ContainerBuilder RegisterRawRabbit(this ContainerBuilder builder, string connectionString)
+        {
+            return RegisterRawRabbit<MessageContext>(builder, connectionString);
+        }
 
-		public static ContainerBuilder RegisterRawRabbit<TMessageContext>(this ContainerBuilder builder, string connectionString)
-			where TMessageContext : IMessageContext
-		{
-			var config = ConnectionStringParser.Parse(connectionString);
-			return RegisterRawRabbit<TMessageContext>(builder, config);
-		}
+        public static ContainerBuilder RegisterRawRabbit<TMessageContext>(this ContainerBuilder builder, string connectionString)
+            where TMessageContext : IMessageContext
+        {
+            var config = ConnectionStringParser.Parse(connectionString);
+            return RegisterRawRabbit<TMessageContext>(builder, config);
+        }
 
-		public static ContainerBuilder RegisterRawRabbit(this ContainerBuilder builder, RawRabbitConfiguration configuration)
-		{
-			return RegisterRawRabbit<MessageContext>(builder, configuration);
-		}
+        public static ContainerBuilder RegisterRawRabbit(this ContainerBuilder builder, RawRabbitConfiguration configuration)
+        {
+            return RegisterRawRabbit<MessageContext>(builder, configuration);
+        }
 
-		public static ContainerBuilder RegisterRawRabbit<TMessageContext>(this ContainerBuilder builder, RawRabbitConfiguration configuration)
-			where TMessageContext : IMessageContext
-		{
-			builder
-				.Register(c => configuration)
-				.SingleInstance();
+        public static ContainerBuilder RegisterRawRabbit<TMessageContext>(this ContainerBuilder builder, RawRabbitConfiguration configuration)
+            where TMessageContext : IMessageContext
+        {
+            builder
+                .Register(c => configuration)
+                .SingleInstance();
 
-			builder.RegisterModule<RawRabbitModule<TMessageContext>>();
-			return builder;
-		}
-	}
+            builder.RegisterModule<RawRabbitModule<TMessageContext>>();
+            return builder;
+        }
+    }
 
 }

--- a/src/RawRabbit.DependencyInjection.Autofac/RawRabbitModule.cs
+++ b/src/RawRabbit.DependencyInjection.Autofac/RawRabbitModule.cs
@@ -22,163 +22,163 @@ using RawRabbit.Serialization;
 
 namespace RawRabbit.DependencyInjection.Autofac
 {
-	public class RawRabbitModule : RawRabbitModule<MessageContext> { }
+    public class RawRabbitModule : RawRabbitModule<MessageContext> { }
 
-	public class RawRabbitModule<TMessageContext> : Module where TMessageContext : IMessageContext
-	{
-		protected override void Load(ContainerBuilder builder)
-		{
-			builder
-				.RegisterType<Subscriber<TMessageContext>>()
-				.As<ISubscriber<TMessageContext>>()
-				.PreserveExistingDefaults();
+    public class RawRabbitModule<TMessageContext> : Module where TMessageContext : IMessageContext
+    {
+        protected override void Load(ContainerBuilder builder)
+        {
+            builder
+                .RegisterType<Subscriber<TMessageContext>>()
+                .As<ISubscriber<TMessageContext>>()
+                .PreserveExistingDefaults();
 
-			builder
-				.RegisterType<Publisher<TMessageContext>>()
-				.As<IPublisher>()
-				.PreserveExistingDefaults();
+            builder
+                .RegisterType<Publisher<TMessageContext>>()
+                .As<IPublisher>()
+                .PreserveExistingDefaults();
 
-			builder
-				.RegisterType<Responder<TMessageContext>>()
-				.As<IResponder<TMessageContext>>()
-				.PreserveExistingDefaults();
+            builder
+                .RegisterType<Responder<TMessageContext>>()
+                .As<IResponder<TMessageContext>>()
+                .PreserveExistingDefaults();
 
-			builder
-				.RegisterType<Requester<TMessageContext>>()
-				.As<IRequester>()
-				.PreserveExistingDefaults();
+            builder
+                .RegisterType<Requester<TMessageContext>>()
+                .As<IRequester>()
+                .PreserveExistingDefaults();
 
-			builder
-				.RegisterType<MessageContextProvider<TMessageContext>>()
-				.As<IMessageContextProvider<TMessageContext>>()
-				.PreserveExistingDefaults();
+            builder
+                .RegisterType<MessageContextProvider<TMessageContext>>()
+                .As<IMessageContextProvider<TMessageContext>>()
+                .PreserveExistingDefaults();
 
-			builder
-				.Register(c => new JsonSerializer
-				{
-					ContractResolver = new CamelCasePropertyNamesContractResolver(),
-					ObjectCreationHandling = ObjectCreationHandling.Auto,
-					TypeNameHandling = TypeNameHandling.Objects,
-					TypeNameAssemblyFormat = FormatterAssemblyStyle.Simple
-				})
-				.PreserveExistingDefaults();
+            builder
+                .Register(c => new JsonSerializer
+                {
+                    ContractResolver = new CamelCasePropertyNamesContractResolver(),
+                    ObjectCreationHandling = ObjectCreationHandling.Auto,
+                    TypeNameHandling = TypeNameHandling.Objects,
+                    TypeNameAssemblyFormat = FormatterAssemblyStyle.Simple
+                })
+                .PreserveExistingDefaults();
 
-			builder
-				.RegisterType<ContextEnhancer>()
-				.As<IContextEnhancer>()
-				.SingleInstance()
-				.PreserveExistingDefaults();
+            builder
+                .RegisterType<ContextEnhancer>()
+                .As<IContextEnhancer>()
+                .SingleInstance()
+                .PreserveExistingDefaults();
 
-			builder
-				.RegisterType<TopologyProvider>()
-				.As<ITopologyProvider>()
-				.SingleInstance()
-				.PreserveExistingDefaults();
+            builder
+                .RegisterType<TopologyProvider>()
+                .As<ITopologyProvider>()
+                .SingleInstance()
+                .PreserveExistingDefaults();
 
-			builder
-				.Register(context =>
-					{
-						var cfg = context.Resolve<RawRabbitConfiguration>();
-						return new ConnectionFactory
-						{
-							VirtualHost = cfg.VirtualHost,
-							UserName = cfg.Username,
-							Password = cfg.Password,
-							Port = cfg.Port,
-							HostName = cfg.Hostnames.FirstOrDefault() ?? string.Empty,
-							AutomaticRecoveryEnabled = cfg.AutomaticRecovery,
-							TopologyRecoveryEnabled = cfg.TopologyRecovery,
-							NetworkRecoveryInterval = cfg.RecoveryInterval,
-							ClientProperties = context.Resolve<IClientPropertyProvider>().GetClientProperties(cfg),
-							Ssl = cfg.Ssl
-						};
-					})
-				.As<IConnectionFactory>()
-				.SingleInstance()
-				.PreserveExistingDefaults();
+            builder
+                .Register(context =>
+                    {
+                        var cfg = context.Resolve<RawRabbitConfiguration>();
+                        return new ConnectionFactory
+                        {
+                            VirtualHost = cfg.VirtualHost,
+                            UserName = cfg.Username,
+                            Password = cfg.Password,
+                            Port = cfg.Port,
+                            HostName = cfg.Hostnames.FirstOrDefault() ?? string.Empty,
+                            AutomaticRecoveryEnabled = cfg.AutomaticRecovery,
+                            TopologyRecoveryEnabled = cfg.TopologyRecovery,
+                            NetworkRecoveryInterval = cfg.RecoveryInterval,
+                            ClientProperties = context.Resolve<IClientPropertyProvider>().GetClientProperties(cfg),
+                            Ssl = cfg.Ssl
+                        };
+                    })
+                .As<IConnectionFactory>()
+                .SingleInstance()
+                .PreserveExistingDefaults();
 
-			builder
-				.RegisterType<ClientPropertyProvider>()
-				.As<IClientPropertyProvider>()
-				.SingleInstance()
-				.PreserveExistingDefaults();
+            builder
+                .RegisterType<ClientPropertyProvider>()
+                .As<IClientPropertyProvider>()
+                .SingleInstance()
+                .PreserveExistingDefaults();
 
-			builder
-				.RegisterType<LoggerFactory>()
-				.As<ILoggerFactory>()
-				.SingleInstance()
-				.PreserveExistingDefaults();
+            builder
+                .RegisterType<LoggerFactory>()
+                .As<ILoggerFactory>()
+                .SingleInstance()
+                .PreserveExistingDefaults();
 
-			builder
-				.RegisterType<JsonMessageSerializer>()
-				.As<IMessageSerializer>()
-				.SingleInstance()
-				.PreserveExistingDefaults();
+            builder
+                .RegisterType<JsonMessageSerializer>()
+                .As<IMessageSerializer>()
+                .SingleInstance()
+                .PreserveExistingDefaults();
 
-			builder
-				.RegisterType<EventingBasicConsumerFactory>()
-				.As<IConsumerFactory>()
-				.SingleInstance()
-				.PreserveExistingDefaults();
+            builder
+                .RegisterType<EventingBasicConsumerFactory>()
+                .As<IConsumerFactory>()
+                .SingleInstance()
+                .PreserveExistingDefaults();
 
-			builder
-				.RegisterType<DefaultStrategy>()
-				.As<IErrorHandlingStrategy>()
-				.SingleInstance()
-				.PreserveExistingDefaults();
+            builder
+                .RegisterType<DefaultStrategy>()
+                .As<IErrorHandlingStrategy>()
+                .SingleInstance()
+                .PreserveExistingDefaults();
 
-			builder
-				.RegisterType<BasicPropertiesProvider>()
-				.As<IBasicPropertiesProvider>()
-				.SingleInstance()
-				.PreserveExistingDefaults();
+            builder
+                .RegisterType<BasicPropertiesProvider>()
+                .As<IBasicPropertiesProvider>()
+                .SingleInstance()
+                .PreserveExistingDefaults();
 
-			builder
-				.RegisterType<ChannelFactory>()
-				.As<IChannelFactory>()
-				.SingleInstance()
-				.PreserveExistingDefaults();
+            builder
+                .RegisterType<ChannelFactory>()
+                .As<IChannelFactory>()
+                .SingleInstance()
+                .PreserveExistingDefaults();
 
-			builder
-				.Register(c => ChannelFactoryConfiguration.Default)
-				.SingleInstance()
-				.PreserveExistingDefaults();
+            builder
+                .Register(c => ChannelFactoryConfiguration.Default)
+                .SingleInstance()
+                .PreserveExistingDefaults();
 
-			builder
-				.RegisterType<ConfigurationEvaluator>()
-				.As<IConfigurationEvaluator>()
-				.SingleInstance()
-				.PreserveExistingDefaults();
+            builder
+                .RegisterType<ConfigurationEvaluator>()
+                .As<IConfigurationEvaluator>()
+                .SingleInstance()
+                .PreserveExistingDefaults();
 
-			builder
-				.RegisterType<PublishAcknowledger>()
-				.WithParameter(new ResolvedParameter(
-					(info, context) => info.Name == "publishTimeout",
-					(info, context) => context.Resolve<RawRabbitConfiguration>().PublishConfirmTimeout))
-				.As<IPublishAcknowledger>()
-				.SingleInstance()
-				.PreserveExistingDefaults();
+            builder
+                .RegisterType<PublishAcknowledger>()
+                .WithParameter(new ResolvedParameter(
+                    (info, context) => info.Name == "publishTimeout",
+                    (info, context) => context.Resolve<RawRabbitConfiguration>().PublishConfirmTimeout))
+                .As<IPublishAcknowledger>()
+                .SingleInstance()
+                .PreserveExistingDefaults();
 
-			builder
-				.RegisterType<NamingConventions>()
-				.As<INamingConventions>()
-				.SingleInstance()
-				.PreserveExistingDefaults();
+            builder
+                .RegisterType<NamingConventions>()
+                .As<INamingConventions>()
+                .SingleInstance()
+                .PreserveExistingDefaults();
 
-			builder
-				.RegisterType<BaseBusClient<TMessageContext>>()
-				.As<IBusClient<TMessageContext>>()
-				.SingleInstance()
-				.PreserveExistingDefaults();
+            builder
+                .RegisterType<BaseBusClient<TMessageContext>>()
+                .As<IBusClient<TMessageContext>>()
+                .SingleInstance()
+                .PreserveExistingDefaults();
 
-			if (typeof (TMessageContext) == typeof (MessageContext))
-			{
-				builder
-					.RegisterType<BusClient>()
-					.As<IBusClient>()
-					.SingleInstance()
-					.PreserveExistingDefaults();
-			}
-		}
-	}
+            if (typeof (TMessageContext) == typeof (MessageContext))
+            {
+                builder
+                    .RegisterType<BusClient>()
+                    .As<IBusClient>()
+                    .SingleInstance()
+                    .PreserveExistingDefaults();
+            }
+        }
+    }
 }

--- a/src/RawRabbit.DependencyInjection.Autofac/project.json
+++ b/src/RawRabbit.DependencyInjection.Autofac/project.json
@@ -1,22 +1,22 @@
 ﻿{
-	"title": "RawRabbit.DependencyInjection.Autofac",
-	"version": "1.10.2-*",
-	"authors": [ "par.dahlman" ],
-	"description": "Wire up RawRabbit with Autfac!",
+    "title": "RawRabbit.DependencyInjection.Autofac",
+    "version": "1.10.2-*",
+    "authors": [ "par.dahlman" ],
+    "description": "Wire up RawRabbit with Autfac!",
 
-	"packOptions": {
-		"iconUrl": "http://pardahlman.se/raw/icon.png",
-		"projectUrl": "https://github.com/pardahlman/RawRabbit",
-		"tags": [ "rabbitmq", "raw", "rawrabbit", "autofac" ],
-		"publishExclude": [ "**.xproj", "**.user", "**.vspscc" ]
-	},
+    "packOptions": {
+        "iconUrl": "http://pardahlman.se/raw/icon.png",
+        "projectUrl": "https://github.com/pardahlman/RawRabbit",
+        "tags": [ "rabbitmq", "raw", "rawrabbit", "autofac" ],
+        "publishExclude": [ "**.xproj", "**.user", "**.vspscc" ]
+    },
 
-	"dependencies": {
-		"RawRabbit": { "target": "project" },
-		"Autofac": "4.1.0"
-	},
-	"frameworks": {
-		"netstandard1.5": {},
-		"net451": {}
-	}
+    "dependencies": {
+        "RawRabbit": { "target": "project" },
+        "Autofac": "4.1.0"
+    },
+    "frameworks": {
+        "netstandard1.5": {},
+        "net451": {}
+    }
 }

--- a/src/RawRabbit.DependencyInjection.Ninject/KernelExtension.cs
+++ b/src/RawRabbit.DependencyInjection.Ninject/KernelExtension.cs
@@ -5,48 +5,48 @@ using RawRabbit.Context;
 
 namespace RawRabbit.DependencyInjection.Ninject
 {
-	public static class KernelExtension
-	{
-		public static IKernel RegisterRawRabbit<TMessageContext>(this IKernel kernel)
-			where TMessageContext : IMessageContext
-		{
-			kernel.Load(new RawRabbitModule<TMessageContext>());
-			return kernel;
-		}
+    public static class KernelExtension
+    {
+        public static IKernel RegisterRawRabbit<TMessageContext>(this IKernel kernel)
+            where TMessageContext : IMessageContext
+        {
+            kernel.Load(new RawRabbitModule<TMessageContext>());
+            return kernel;
+        }
 
-		public static IKernel RegisterRawRabbit(this IKernel kernel)
-		{
-			kernel.Load(new RawRabbitModule());
-			return kernel;
-		}
+        public static IKernel RegisterRawRabbit(this IKernel kernel)
+        {
+            kernel.Load(new RawRabbitModule());
+            return kernel;
+        }
 
-		public static IKernel RegisterRawRabbit<TMessageContext>(this IKernel kernel, RawRabbitConfiguration configuration)
-			where TMessageContext : IMessageContext
-		{
-			kernel
-				.Bind<RawRabbitConfiguration>()
-				.ToConstant(configuration)
-				.InSingletonScope();
+        public static IKernel RegisterRawRabbit<TMessageContext>(this IKernel kernel, RawRabbitConfiguration configuration)
+            where TMessageContext : IMessageContext
+        {
+            kernel
+                .Bind<RawRabbitConfiguration>()
+                .ToConstant(configuration)
+                .InSingletonScope();
 
-			kernel.Load(new RawRabbitModule<TMessageContext>());
-			return kernel;
-		}
+            kernel.Load(new RawRabbitModule<TMessageContext>());
+            return kernel;
+        }
 
-		public static IKernel RegisterRawRabbit(this IKernel kernel, RawRabbitConfiguration configuration)
-		{
-			return RegisterRawRabbit<MessageContext>(kernel, configuration);
-		}
+        public static IKernel RegisterRawRabbit(this IKernel kernel, RawRabbitConfiguration configuration)
+        {
+            return RegisterRawRabbit<MessageContext>(kernel, configuration);
+        }
 
-		public static IKernel RegisterRawRabbit<TMessageContext>(this IKernel kernel, string connectionString)
-			where TMessageContext : IMessageContext
-		{
-			var config = ConnectionStringParser.Parse(connectionString);
-			return RegisterRawRabbit<TMessageContext>(kernel, config);
-		}
+        public static IKernel RegisterRawRabbit<TMessageContext>(this IKernel kernel, string connectionString)
+            where TMessageContext : IMessageContext
+        {
+            var config = ConnectionStringParser.Parse(connectionString);
+            return RegisterRawRabbit<TMessageContext>(kernel, config);
+        }
 
-		public static IKernel RegisterRawRabbit(this IKernel kernel, string connectionString)
-		{
-			return RegisterRawRabbit<MessageContext>(kernel, connectionString);
-		}
-	}
+        public static IKernel RegisterRawRabbit(this IKernel kernel, string connectionString)
+        {
+            return RegisterRawRabbit<MessageContext>(kernel, connectionString);
+        }
+    }
 }

--- a/src/RawRabbit.DependencyInjection.Ninject/RawRabbitModule.cs
+++ b/src/RawRabbit.DependencyInjection.Ninject/RawRabbitModule.cs
@@ -24,150 +24,150 @@ using RawRabbit.Serialization;
 
 namespace RawRabbit.DependencyInjection.Ninject
 {
-	public class RawRabbitModule : RawRabbitModule<MessageContext> { }
+    public class RawRabbitModule : RawRabbitModule<MessageContext> { }
 
-	public class RawRabbitModule<TMessageContext> : NinjectModule where TMessageContext : IMessageContext
-	{
-		public override void Load()
-		{
-			Kernel
-				.Bind<ISubscriber<TMessageContext>>()
-				.To<Subscriber<TMessageContext>>()
-				.InSingletonScope();
+    public class RawRabbitModule<TMessageContext> : NinjectModule where TMessageContext : IMessageContext
+    {
+        public override void Load()
+        {
+            Kernel
+                .Bind<ISubscriber<TMessageContext>>()
+                .To<Subscriber<TMessageContext>>()
+                .InSingletonScope();
 
-			Kernel
-				.Bind<IPublisher>()
-				.To<Publisher<TMessageContext>>()
-				.InSingletonScope();
+            Kernel
+                .Bind<IPublisher>()
+                .To<Publisher<TMessageContext>>()
+                .InSingletonScope();
 
-			Kernel
-				.Bind<IResponder<TMessageContext>>()
-				.To<Responder<TMessageContext>>()
-				.InSingletonScope();
+            Kernel
+                .Bind<IResponder<TMessageContext>>()
+                .To<Responder<TMessageContext>>()
+                .InSingletonScope();
 
-			Kernel
-				.Bind<IRequester>()
-				.To<Requester<TMessageContext>>()
-				.InSingletonScope();
+            Kernel
+                .Bind<IRequester>()
+                .To<Requester<TMessageContext>>()
+                .InSingletonScope();
 
-			Kernel
-				.Bind<IMessageContextProvider<TMessageContext>>()
-				.To<MessageContextProvider<TMessageContext>>()
-				.InSingletonScope()
-				.WithConstructorArgument("createContextAsync", (Func<Task<TMessageContext>>)null);
+            Kernel
+                .Bind<IMessageContextProvider<TMessageContext>>()
+                .To<MessageContextProvider<TMessageContext>>()
+                .InSingletonScope()
+                .WithConstructorArgument("createContextAsync", (Func<Task<TMessageContext>>)null);
 
-			Kernel
-				.Bind<JsonSerializer>()
-				.ToMethod(context => new JsonSerializer
-				{
-					ContractResolver = new CamelCasePropertyNamesContractResolver(),
-					ObjectCreationHandling = ObjectCreationHandling.Auto,
-					TypeNameHandling = TypeNameHandling.Objects,
-					TypeNameAssemblyFormat = FormatterAssemblyStyle.Simple
-				})
-				.InSingletonScope();
+            Kernel
+                .Bind<JsonSerializer>()
+                .ToMethod(context => new JsonSerializer
+                {
+                    ContractResolver = new CamelCasePropertyNamesContractResolver(),
+                    ObjectCreationHandling = ObjectCreationHandling.Auto,
+                    TypeNameHandling = TypeNameHandling.Objects,
+                    TypeNameAssemblyFormat = FormatterAssemblyStyle.Simple
+                })
+                .InSingletonScope();
 
-			Kernel
-				.Bind<IContextEnhancer>()
-				.To<ContextEnhancer>()
-				.InSingletonScope();
+            Kernel
+                .Bind<IContextEnhancer>()
+                .To<ContextEnhancer>()
+                .InSingletonScope();
 
-			Kernel
-				.Bind<ITopologyProvider>()
-				.To<TopologyProvider>()
-				.InSingletonScope();
+            Kernel
+                .Bind<ITopologyProvider>()
+                .To<TopologyProvider>()
+                .InSingletonScope();
 
-			Kernel
-				.Bind<IConnectionFactory>()
-				.ToMethod(context =>
-				{
-					var cfg = context.Kernel.Get<RawRabbitConfiguration>();
-					return new ConnectionFactory
-					{
-						VirtualHost = cfg.VirtualHost,
-						UserName = cfg.Username,
-						Password = cfg.Password,
-						Port = cfg.Port,
-						HostName = cfg.Hostnames.FirstOrDefault() ?? string.Empty,
-						AutomaticRecoveryEnabled = cfg.AutomaticRecovery,
-						TopologyRecoveryEnabled = cfg.TopologyRecovery,
-						NetworkRecoveryInterval = cfg.RecoveryInterval,
-						ClientProperties = context.Kernel.Get<IClientPropertyProvider>().GetClientProperties(cfg),
-						Ssl = cfg.Ssl
-					};
-				})
-				.InSingletonScope();
+            Kernel
+                .Bind<IConnectionFactory>()
+                .ToMethod(context =>
+                {
+                    var cfg = context.Kernel.Get<RawRabbitConfiguration>();
+                    return new ConnectionFactory
+                    {
+                        VirtualHost = cfg.VirtualHost,
+                        UserName = cfg.Username,
+                        Password = cfg.Password,
+                        Port = cfg.Port,
+                        HostName = cfg.Hostnames.FirstOrDefault() ?? string.Empty,
+                        AutomaticRecoveryEnabled = cfg.AutomaticRecovery,
+                        TopologyRecoveryEnabled = cfg.TopologyRecovery,
+                        NetworkRecoveryInterval = cfg.RecoveryInterval,
+                        ClientProperties = context.Kernel.Get<IClientPropertyProvider>().GetClientProperties(cfg),
+                        Ssl = cfg.Ssl
+                    };
+                })
+                .InSingletonScope();
 
-			Kernel
-				.Bind<IClientPropertyProvider>()
-				.To<ClientPropertyProvider>()
-				.InSingletonScope();
+            Kernel
+                .Bind<IClientPropertyProvider>()
+                .To<ClientPropertyProvider>()
+                .InSingletonScope();
 
-			Kernel
-				.Bind<ILoggerFactory>()
-				.To<LoggerFactory>()
-				.InSingletonScope();
+            Kernel
+                .Bind<ILoggerFactory>()
+                .To<LoggerFactory>()
+                .InSingletonScope();
 
-			Kernel
-				.Bind<IMessageSerializer>()
-				.To<JsonMessageSerializer>()
-				.InSingletonScope()
-				.WithConstructorArgument("config", (Action<JsonSerializer>)null);
+            Kernel
+                .Bind<IMessageSerializer>()
+                .To<JsonMessageSerializer>()
+                .InSingletonScope()
+                .WithConstructorArgument("config", (Action<JsonSerializer>)null);
 
-			Kernel
-				.Bind<IConsumerFactory>()
-				.To<EventingBasicConsumerFactory>()
-				.InSingletonScope();
+            Kernel
+                .Bind<IConsumerFactory>()
+                .To<EventingBasicConsumerFactory>()
+                .InSingletonScope();
 
-			Kernel
-				.Bind<IErrorHandlingStrategy>()
-				.To<DefaultStrategy>()
-				.InSingletonScope();
+            Kernel
+                .Bind<IErrorHandlingStrategy>()
+                .To<DefaultStrategy>()
+                .InSingletonScope();
 
-			Kernel
-				.Bind<IBasicPropertiesProvider>()
-				.To<BasicPropertiesProvider>()
-				.InSingletonScope();
+            Kernel
+                .Bind<IBasicPropertiesProvider>()
+                .To<BasicPropertiesProvider>()
+                .InSingletonScope();
 
-			Kernel
-				.Bind<IChannelFactory>()
-				.To<ChannelFactory>()
-				.InSingletonScope();
+            Kernel
+                .Bind<IChannelFactory>()
+                .To<ChannelFactory>()
+                .InSingletonScope();
 
-			Kernel
-				.Bind<ChannelFactoryConfiguration>()
-				.ToConstant(ChannelFactoryConfiguration.Default)
-				.InSingletonScope();
+            Kernel
+                .Bind<ChannelFactoryConfiguration>()
+                .ToConstant(ChannelFactoryConfiguration.Default)
+                .InSingletonScope();
 
-			Kernel
-				.Bind<IConfigurationEvaluator>()
-				.To<ConfigurationEvaluator>()
-				.InSingletonScope();
+            Kernel
+                .Bind<IConfigurationEvaluator>()
+                .To<ConfigurationEvaluator>()
+                .InSingletonScope();
 
-			Kernel
-				.Bind<IPublishAcknowledger>()
-				.To<PublishAcknowledger>()
-				.InSingletonScope()
-				.WithConstructorArgument("publishTimeout",
-					context => context.Kernel.Get<RawRabbitConfiguration>().PublishConfirmTimeout);
+            Kernel
+                .Bind<IPublishAcknowledger>()
+                .To<PublishAcknowledger>()
+                .InSingletonScope()
+                .WithConstructorArgument("publishTimeout",
+                    context => context.Kernel.Get<RawRabbitConfiguration>().PublishConfirmTimeout);
 
-			Kernel
-				.Bind<INamingConventions>()
-				.To<NamingConventions>()
-				.InSingletonScope();
+            Kernel
+                .Bind<INamingConventions>()
+                .To<NamingConventions>()
+                .InSingletonScope();
 
-			Kernel
-				.Bind<IBusClient<TMessageContext>>()
-				.To<BaseBusClient<TMessageContext>>()
-				.InSingletonScope();
+            Kernel
+                .Bind<IBusClient<TMessageContext>>()
+                .To<BaseBusClient<TMessageContext>>()
+                .InSingletonScope();
 
-			if (typeof(TMessageContext) == typeof(MessageContext))
-			{
-				Kernel
-					.Bind<IBusClient>()
-					.To<BusClient>()
-					.InSingletonScope();
-			}
-		}
-	}
+            if (typeof(TMessageContext) == typeof(MessageContext))
+            {
+                Kernel
+                    .Bind<IBusClient>()
+                    .To<BusClient>()
+                    .InSingletonScope();
+            }
+        }
+    }
 }

--- a/src/RawRabbit.DependencyInjection.Ninject/project.json
+++ b/src/RawRabbit.DependencyInjection.Ninject/project.json
@@ -1,29 +1,29 @@
 ﻿{
-	"title": "RawRabbit.DependencyInjection.Ninject",
-	"version": "1.10.2-*",
-	"authors": [ "par.dahlman", "Joshua Barron" ],
-	"description": "Wire up RawRabbit with Ninject!",
+    "title": "RawRabbit.DependencyInjection.Ninject",
+    "version": "1.10.2-*",
+    "authors": [ "par.dahlman", "Joshua Barron" ],
+    "description": "Wire up RawRabbit with Ninject!",
 
-	"packOptions": {
-		"iconUrl": "http://pardahlman.se/raw/icon.png",
-		"projectUrl": "https://github.com/pardahlman/RawRabbit",
-		"tags": [ "rabbitmq", "raw", "rawrabbit", "ninject" ],
-		"publishExclude": [ "**.xproj", "**.user", "**.vspscc" ]
-	},
+    "packOptions": {
+        "iconUrl": "http://pardahlman.se/raw/icon.png",
+        "projectUrl": "https://github.com/pardahlman/RawRabbit",
+        "tags": [ "rabbitmq", "raw", "rawrabbit", "ninject" ],
+        "publishExclude": [ "**.xproj", "**.user", "**.vspscc" ]
+    },
 
-	"dependencies": {
-		"RawRabbit": { "target": "project" }
-	},
-	"frameworks": {
-		"netstandard1.5": {
-			"dependencies": {
-				"Ninject": "4.0.0-beta-0134"
-			}
-		},
-		"net451": {
-			"dependencies": {
-				"Ninject": "3.2.2"
-			}
-		}
-	}
+    "dependencies": {
+        "RawRabbit": { "target": "project" }
+    },
+    "frameworks": {
+        "netstandard1.5": {
+            "dependencies": {
+                "Ninject": "4.0.0-beta-0134"
+            }
+        },
+        "net451": {
+            "dependencies": {
+                "Ninject": "3.2.2"
+            }
+        }
+    }
 }

--- a/src/RawRabbit.Extensions/BulkGet/BulkGetExtension.cs
+++ b/src/RawRabbit.Extensions/BulkGet/BulkGetExtension.cs
@@ -11,71 +11,71 @@ using RawRabbit.Serialization;
 
 namespace RawRabbit.Extensions.BulkGet
 {
-	public static class BulkGetExtension
-	{
-		public static BulkResult<TMessageContext> GetMessages<TMessageContext>(this IBusClient<TMessageContext> client, Action<IBulkGetConfigurationBuilder> cfg)
-			where TMessageContext : IMessageContext
-		{
-			var extended = (client as Client.IBusClient<TMessageContext>);
-			if (extended == null)
-			{
-				throw new InvalidOperationException("Bus client does not support extensions. Make sure that the client is of type ExtendableBusClient.");
-			}
-			var channel = extended.GetService<IChannelFactory>().CreateChannel();
-			var contextProvider = extended.GetService<IMessageContextProvider<TMessageContext>>();
-			var serializer = extended.GetService<IMessageSerializer>();
+    public static class BulkGetExtension
+    {
+        public static BulkResult<TMessageContext> GetMessages<TMessageContext>(this IBusClient<TMessageContext> client, Action<IBulkGetConfigurationBuilder> cfg)
+            where TMessageContext : IMessageContext
+        {
+            var extended = (client as Client.IBusClient<TMessageContext>);
+            if (extended == null)
+            {
+                throw new InvalidOperationException("Bus client does not support extensions. Make sure that the client is of type ExtendableBusClient.");
+            }
+            var channel = extended.GetService<IChannelFactory>().CreateChannel();
+            var contextProvider = extended.GetService<IMessageContextProvider<TMessageContext>>();
+            var serializer = extended.GetService<IMessageSerializer>();
 
-			var result = new Dictionary<Type, List<IBulkMessage>>();
-			var msgConfigs = GetMessageConfigurations(cfg);
-			
-			foreach (var msgConfig in msgConfigs)
-			{
-				var rawMsgs = new List<IBulkMessage>();
-				var batchSize = msgConfig.GetAll ? int.MaxValue : msgConfig.BatchSize;
+            var result = new Dictionary<Type, List<IBulkMessage>>();
+            var msgConfigs = GetMessageConfigurations(cfg);
+            
+            foreach (var msgConfig in msgConfigs)
+            {
+                var rawMsgs = new List<IBulkMessage>();
+                var batchSize = msgConfig.GetAll ? int.MaxValue : msgConfig.BatchSize;
 
-				foreach (var queueName in msgConfig.QueueNames)
-				{
-					while (rawMsgs.Count < batchSize)
-					{
-						var getResult = channel.BasicGet(queueName, msgConfig.NoAck);
-						if (getResult == null)
-						{
-							break;
-						}
+                foreach (var queueName in msgConfig.QueueNames)
+                {
+                    while (rawMsgs.Count < batchSize)
+                    {
+                        var getResult = channel.BasicGet(queueName, msgConfig.NoAck);
+                        if (getResult == null)
+                        {
+                            break;
+                        }
 
-						object message;
-						try
-						{
-							message = serializer.Deserialize(getResult.Body, msgConfig.MessageType);
-						}
-						catch (Exception)
-						{
-							// msg is not of right type.
-							continue;
-						}
-						var context = contextProvider.ExtractContext(getResult.BasicProperties.Headers[PropertyHeaders.Context]);
-						var bulkMessage = CreateBulkMessage(msgConfig.MessageType, message, context, channel, getResult.DeliveryTag);
-						rawMsgs.Add(bulkMessage);
-					}
-				}
-				result.Add(msgConfig.MessageType, rawMsgs);
-			}
+                        object message;
+                        try
+                        {
+                            message = serializer.Deserialize(getResult.Body, msgConfig.MessageType);
+                        }
+                        catch (Exception)
+                        {
+                            // msg is not of right type.
+                            continue;
+                        }
+                        var context = contextProvider.ExtractContext(getResult.BasicProperties.Headers[PropertyHeaders.Context]);
+                        var bulkMessage = CreateBulkMessage(msgConfig.MessageType, message, context, channel, getResult.DeliveryTag);
+                        rawMsgs.Add(bulkMessage);
+                    }
+                }
+                result.Add(msgConfig.MessageType, rawMsgs);
+            }
 
-			return new BulkResult<TMessageContext>(result);
-		}
+            return new BulkResult<TMessageContext>(result);
+        }
 
-		private static IEnumerable<MessageConfiguration> GetMessageConfigurations(Action<IBulkGetConfigurationBuilder> cfg)
-		{
-			var builder = new BulkGetConfigurationBuilder();
-			cfg(builder);
-			return builder.Configurations;
-		}
+        private static IEnumerable<MessageConfiguration> GetMessageConfigurations(Action<IBulkGetConfigurationBuilder> cfg)
+        {
+            var builder = new BulkGetConfigurationBuilder();
+            cfg(builder);
+            return builder.Configurations;
+        }
 
-		private static IBulkMessage CreateBulkMessage<TMessageContext>(Type messageType, object message, TMessageContext context, IModel channel, ulong deliveryTag)
-		{
-			var bulkMsgType = typeof(BulkMessage<,>).MakeGenericType(messageType, typeof(TMessageContext));
-			var msg = Activator.CreateInstance(bulkMsgType, channel, deliveryTag, context, message) as IBulkMessage;
-			return msg;
-		}
-	}
+        private static IBulkMessage CreateBulkMessage<TMessageContext>(Type messageType, object message, TMessageContext context, IModel channel, ulong deliveryTag)
+        {
+            var bulkMsgType = typeof(BulkMessage<,>).MakeGenericType(messageType, typeof(TMessageContext));
+            var msg = Activator.CreateInstance(bulkMsgType, channel, deliveryTag, context, message) as IBulkMessage;
+            return msg;
+        }
+    }
 }

--- a/src/RawRabbit.Extensions/BulkGet/Configuration/BulkGetConfigurationBuilder.cs
+++ b/src/RawRabbit.Extensions/BulkGet/Configuration/BulkGetConfigurationBuilder.cs
@@ -3,26 +3,26 @@ using System.Collections.Generic;
 
 namespace RawRabbit.Extensions.BulkGet.Configuration
 {
-	public interface IBulkGetConfigurationBuilder
-	{
-		IBulkGetConfigurationBuilder ForMessage<TMessage>(Action<IMessageConfigurationBuilder> msg) where TMessage : new();
-	}
+    public interface IBulkGetConfigurationBuilder
+    {
+        IBulkGetConfigurationBuilder ForMessage<TMessage>(Action<IMessageConfigurationBuilder> msg) where TMessage : new();
+    }
 
-	public class BulkGetConfigurationBuilder : IBulkGetConfigurationBuilder
-	{
-		public List<MessageConfiguration> Configurations { get; set; }
+    public class BulkGetConfigurationBuilder : IBulkGetConfigurationBuilder
+    {
+        public List<MessageConfiguration> Configurations { get; set; }
 
-		public BulkGetConfigurationBuilder()
-		{
-			Configurations = new List<MessageConfiguration>();
-		}
+        public BulkGetConfigurationBuilder()
+        {
+            Configurations = new List<MessageConfiguration>();
+        }
 
-		public IBulkGetConfigurationBuilder ForMessage<TMessage>(Action<IMessageConfigurationBuilder> msg) where TMessage : new()
-		{
-			var builder = new MessageConfigurationBuilder<TMessage>();
-			msg(builder);
-			Configurations.Add(builder.Configuration);
-			return this;
-		}
-	}
+        public IBulkGetConfigurationBuilder ForMessage<TMessage>(Action<IMessageConfigurationBuilder> msg) where TMessage : new()
+        {
+            var builder = new MessageConfigurationBuilder<TMessage>();
+            msg(builder);
+            Configurations.Add(builder.Configuration);
+            return this;
+        }
+    }
 }

--- a/src/RawRabbit.Extensions/BulkGet/Configuration/IMessageConfigurationBuilder.cs
+++ b/src/RawRabbit.Extensions/BulkGet/Configuration/IMessageConfigurationBuilder.cs
@@ -2,47 +2,47 @@
 
 namespace RawRabbit.Extensions.BulkGet.Configuration
 {
-	public interface IMessageConfigurationBuilder
-	{
-		IMessageConfigurationBuilder FromQueues(params string[] queueNames);
-		IMessageConfigurationBuilder GetAll();
-		IMessageConfigurationBuilder WithBatchSize(int batchSize);
-		IMessageConfigurationBuilder WithNoAck(bool noAck = true);
-	}
+    public interface IMessageConfigurationBuilder
+    {
+        IMessageConfigurationBuilder FromQueues(params string[] queueNames);
+        IMessageConfigurationBuilder GetAll();
+        IMessageConfigurationBuilder WithBatchSize(int batchSize);
+        IMessageConfigurationBuilder WithNoAck(bool noAck = true);
+    }
 
-	public class MessageConfigurationBuilder<TMessage> : IMessageConfigurationBuilder
-	{
-		public MessageConfiguration Configuration { get; }
+    public class MessageConfigurationBuilder<TMessage> : IMessageConfigurationBuilder
+    {
+        public MessageConfiguration Configuration { get; }
 
-		public MessageConfigurationBuilder()
-		{
-			Configuration = new MessageConfiguration
-			{
-				MessageType = typeof(TMessage)
-			};
-		}
-		public IMessageConfigurationBuilder FromQueues(params string[] queueNames)
-		{
-			Configuration.QueueNames = queueNames.ToList();
-			return this;
-		}
+        public MessageConfigurationBuilder()
+        {
+            Configuration = new MessageConfiguration
+            {
+                MessageType = typeof(TMessage)
+            };
+        }
+        public IMessageConfigurationBuilder FromQueues(params string[] queueNames)
+        {
+            Configuration.QueueNames = queueNames.ToList();
+            return this;
+        }
 
-		public IMessageConfigurationBuilder GetAll()
-		{
-			Configuration.GetAll = true;
-			return this;
-		}
+        public IMessageConfigurationBuilder GetAll()
+        {
+            Configuration.GetAll = true;
+            return this;
+        }
 
-		public IMessageConfigurationBuilder WithBatchSize(int batchSize)
-		{
-			Configuration.BatchSize = batchSize;
-			return this;
-		}
+        public IMessageConfigurationBuilder WithBatchSize(int batchSize)
+        {
+            Configuration.BatchSize = batchSize;
+            return this;
+        }
 
-		public IMessageConfigurationBuilder WithNoAck(bool noAck = true)
-		{
-			Configuration.NoAck = noAck;
-			return this;
-		}
-	}
+        public IMessageConfigurationBuilder WithNoAck(bool noAck = true)
+        {
+            Configuration.NoAck = noAck;
+            return this;
+        }
+    }
 }

--- a/src/RawRabbit.Extensions/BulkGet/Configuration/MessageConfiguration.cs
+++ b/src/RawRabbit.Extensions/BulkGet/Configuration/MessageConfiguration.cs
@@ -3,17 +3,17 @@ using System.Collections.Generic;
 
 namespace RawRabbit.Extensions.BulkGet.Configuration
 {
-	public class MessageConfiguration
-	{
-		public Type MessageType { get; set; }
-		public List<string> QueueNames { get; set; }
-		public bool GetAll { get; set; }
-		public int BatchSize { get; set; }
-		public bool NoAck { get; set; }
+    public class MessageConfiguration
+    {
+        public Type MessageType { get; set; }
+        public List<string> QueueNames { get; set; }
+        public bool GetAll { get; set; }
+        public int BatchSize { get; set; }
+        public bool NoAck { get; set; }
 
-		public MessageConfiguration()
-		{
-			QueueNames = new List<string>();
-		}
-	}
+        public MessageConfiguration()
+        {
+            QueueNames = new List<string>();
+        }
+    }
 }

--- a/src/RawRabbit.Extensions/BulkGet/Model/BulkMessage.cs
+++ b/src/RawRabbit.Extensions/BulkGet/Model/BulkMessage.cs
@@ -4,35 +4,35 @@ using RawRabbit.Context;
 
 namespace RawRabbit.Extensions.BulkGet.Model
 {
-	public class BulkMessage<TMessage, TMessageContext> : IDisposable, IBulkMessage where TMessageContext : IMessageContext
-	{
-		private readonly IModel _channel;
-		private readonly ulong _deliveryTag;
+    public class BulkMessage<TMessage, TMessageContext> : IDisposable, IBulkMessage where TMessageContext : IMessageContext
+    {
+        private readonly IModel _channel;
+        private readonly ulong _deliveryTag;
 
-		public BulkMessage(IModel channel, ulong deliveryTag, TMessageContext context, object message)
-		{
-			_channel = channel;
-			_deliveryTag = deliveryTag;
-			Context = context;
-			Message = (TMessage) message;
-		}
+        public BulkMessage(IModel channel, ulong deliveryTag, TMessageContext context, object message)
+        {
+            _channel = channel;
+            _deliveryTag = deliveryTag;
+            Context = context;
+            Message = (TMessage) message;
+        }
 
-		public TMessageContext Context { get; private set; }
-		public TMessage Message { get; private set; }
+        public TMessageContext Context { get; private set; }
+        public TMessage Message { get; private set; }
 
-		public void Ack()
-		{
-			_channel.BasicAck(_deliveryTag, false);
-		}
+        public void Ack()
+        {
+            _channel.BasicAck(_deliveryTag, false);
+        }
 
-		public void Nack(bool requeue = true)
-		{
-			_channel.BasicNack(_deliveryTag, false, requeue);
-		}
+        public void Nack(bool requeue = true)
+        {
+            _channel.BasicNack(_deliveryTag, false, requeue);
+        }
 
-		public void Dispose()
-		{
-			_channel?.Dispose();
-		}
-	}
+        public void Dispose()
+        {
+            _channel?.Dispose();
+        }
+    }
 }

--- a/src/RawRabbit.Extensions/BulkGet/Model/BulkResult.cs
+++ b/src/RawRabbit.Extensions/BulkGet/Model/BulkResult.cs
@@ -5,52 +5,52 @@ using RawRabbit.Context;
 
 namespace RawRabbit.Extensions.BulkGet.Model
 {
-	public class BulkResult<TMessageContext> : IDisposable where TMessageContext : IMessageContext
-	{
-		private readonly IDictionary<Type, List<IBulkMessage>> _messageTypeToMessages;
+    public class BulkResult<TMessageContext> : IDisposable where TMessageContext : IMessageContext
+    {
+        private readonly IDictionary<Type, List<IBulkMessage>> _messageTypeToMessages;
 
-		public BulkResult(IDictionary<Type, List<IBulkMessage>> messageTypeToMessages)
-		{
-			_messageTypeToMessages = messageTypeToMessages;
-		}
+        public BulkResult(IDictionary<Type, List<IBulkMessage>> messageTypeToMessages)
+        {
+            _messageTypeToMessages = messageTypeToMessages;
+        }
 
-		public void AckAll()
-		{
-			foreach (var bulkMessage in GetAllMessages())
-			{
-				bulkMessage.Ack();
-			}
-		}
+        public void AckAll()
+        {
+            foreach (var bulkMessage in GetAllMessages())
+            {
+                bulkMessage.Ack();
+            }
+        }
 
-		public void NackAll(bool requeue = true)
-		{
-			foreach (var bulkMessage in GetAllMessages())
-			{
-				bulkMessage.Nack(requeue);
-			}
-		}
+        public void NackAll(bool requeue = true)
+        {
+            foreach (var bulkMessage in GetAllMessages())
+            {
+                bulkMessage.Nack(requeue);
+            }
+        }
 
-		private IEnumerable<IBulkMessage> GetAllMessages()
-		{
-			return _messageTypeToMessages.Values
-				.Where(msgs => msgs != null)
-				.SelectMany(msgs => msgs);
-		}
+        private IEnumerable<IBulkMessage> GetAllMessages()
+        {
+            return _messageTypeToMessages.Values
+                .Where(msgs => msgs != null)
+                .SelectMany(msgs => msgs);
+        }
 
-		public IEnumerable<BulkMessage<TMessage, TMessageContext>> GetMessages<TMessage>()
-		{
-			List<IBulkMessage> messages;
-			return _messageTypeToMessages.TryGetValue(typeof (TMessage), out messages)
-				? messages.OfType<BulkMessage<TMessage, TMessageContext>>()
-				: Enumerable.Empty<BulkMessage<TMessage, TMessageContext>>();
-		}
+        public IEnumerable<BulkMessage<TMessage, TMessageContext>> GetMessages<TMessage>()
+        {
+            List<IBulkMessage> messages;
+            return _messageTypeToMessages.TryGetValue(typeof (TMessage), out messages)
+                ? messages.OfType<BulkMessage<TMessage, TMessageContext>>()
+                : Enumerable.Empty<BulkMessage<TMessage, TMessageContext>>();
+        }
 
-		public void Dispose()
-		{
-			foreach (var disposable in GetAllMessages().OfType<IDisposable>())
-			{
-				disposable?.Dispose();
-			}
-		}
-	}
+        public void Dispose()
+        {
+            foreach (var disposable in GetAllMessages().OfType<IDisposable>())
+            {
+                disposable?.Dispose();
+            }
+        }
+    }
 }

--- a/src/RawRabbit.Extensions/BulkGet/Model/IBulkMessage.cs
+++ b/src/RawRabbit.Extensions/BulkGet/Model/IBulkMessage.cs
@@ -1,8 +1,8 @@
 ﻿namespace RawRabbit.Extensions.BulkGet.Model
 {
-	public interface IBulkMessage
-	{
-		void Ack();
-		void Nack(bool requeue = true);
-	}
+    public interface IBulkMessage
+    {
+        void Ack();
+        void Nack(bool requeue = true);
+    }
 }

--- a/src/RawRabbit.Extensions/CleanEverything/CleanEverythingExtension.cs
+++ b/src/RawRabbit.Extensions/CleanEverything/CleanEverythingExtension.cs
@@ -11,74 +11,74 @@ using RawRabbit.Extensions.CleanEverything.Model;
 
 namespace RawRabbit.Extensions.CleanEverything
 {
-	public static class CleanEverythingExtension
-	{
-		public static Task CleanAsync<TMessageContext>(this IBusClient<TMessageContext> busClient, Action<ICleanConfigurationBuilder> cfg = null)
-			where TMessageContext : IMessageContext
-		{
-			var extended = (busClient as Client.IBusClient<TMessageContext>);
-			if (extended == null)
-			{
-				throw new InvalidOperationException("Bus client does not support extensions. Make sure that the client is of type ExtendableBusClient.");
-			}
-			var rawConfig = extended.GetService<RawRabbitConfiguration>();
-			var config = GetCleanConfiguration(cfg);
-			Task removeQueueTask = Task.FromResult(true);
-			Task removeExchangesTask = Task.FromResult(true);
-			Task closeConnectionsTask = Task.FromResult(true);
-			if (config.RemoveQueues)
-			{
-				removeQueueTask = RemoveEntities<Exchange>("queues", rawConfig);
-			}
-			if (config.RemoveExchanges)
-			{
-				removeExchangesTask = RemoveEntities<Exchange>("exchanges", rawConfig);
-			}
-			if (config.CloseConnections)
-			{
-				throw new NotImplementedException("Removal of connection is not implemented.");
-			}
-			return Task.WhenAll(removeQueueTask, removeExchangesTask, closeConnectionsTask);
-		}
+    public static class CleanEverythingExtension
+    {
+        public static Task CleanAsync<TMessageContext>(this IBusClient<TMessageContext> busClient, Action<ICleanConfigurationBuilder> cfg = null)
+            where TMessageContext : IMessageContext
+        {
+            var extended = (busClient as Client.IBusClient<TMessageContext>);
+            if (extended == null)
+            {
+                throw new InvalidOperationException("Bus client does not support extensions. Make sure that the client is of type ExtendableBusClient.");
+            }
+            var rawConfig = extended.GetService<RawRabbitConfiguration>();
+            var config = GetCleanConfiguration(cfg);
+            Task removeQueueTask = Task.FromResult(true);
+            Task removeExchangesTask = Task.FromResult(true);
+            Task closeConnectionsTask = Task.FromResult(true);
+            if (config.RemoveQueues)
+            {
+                removeQueueTask = RemoveEntities<Exchange>("queues", rawConfig);
+            }
+            if (config.RemoveExchanges)
+            {
+                removeExchangesTask = RemoveEntities<Exchange>("exchanges", rawConfig);
+            }
+            if (config.CloseConnections)
+            {
+                throw new NotImplementedException("Removal of connection is not implemented.");
+            }
+            return Task.WhenAll(removeQueueTask, removeExchangesTask, closeConnectionsTask);
+        }
 
-		private static async Task RemoveEntities<TEntity>(string entityName, RawRabbitConfiguration config) where TEntity : IRabbtMqEntity
-		{
-			var tasks = new List<Task>();
+        private static async Task RemoveEntities<TEntity>(string entityName, RawRabbitConfiguration config) where TEntity : IRabbtMqEntity
+        {
+            var tasks = new List<Task>();
 
-			using (var handler = new HttpClientHandler { Credentials = new NetworkCredential(config.Username, config.Password) })
-			using (var httpClient = new HttpClient(handler))
-			{
-				foreach (var hostname in config.Hostnames)
-				{
-					var response = await httpClient.GetAsync($"http://{hostname}:15672/api/{entityName}");
-					var entityStr = await response.Content.ReadAsStringAsync();
-					var entites = JsonConvert.DeserializeObject<List<TEntity>>(entityStr);
-					foreach (var entity in entites)
-					{
-						if (string.IsNullOrEmpty(entity.Name) || entity.Name.StartsWith("amq."))
-						{
-							continue;
-						}
-						var removeEntityTask = httpClient
-							.DeleteAsync(new Uri($"http://{hostname}:15672/api/{entityName}/{Uri.EscapeDataString(entity.Vhost)}/{Uri.EscapeUriString(entity.Name)}"));
+            using (var handler = new HttpClientHandler { Credentials = new NetworkCredential(config.Username, config.Password) })
+            using (var httpClient = new HttpClient(handler))
+            {
+                foreach (var hostname in config.Hostnames)
+                {
+                    var response = await httpClient.GetAsync($"http://{hostname}:15672/api/{entityName}");
+                    var entityStr = await response.Content.ReadAsStringAsync();
+                    var entites = JsonConvert.DeserializeObject<List<TEntity>>(entityStr);
+                    foreach (var entity in entites)
+                    {
+                        if (string.IsNullOrEmpty(entity.Name) || entity.Name.StartsWith("amq."))
+                        {
+                            continue;
+                        }
+                        var removeEntityTask = httpClient
+                            .DeleteAsync(new Uri($"http://{hostname}:15672/api/{entityName}/{Uri.EscapeDataString(entity.Vhost)}/{Uri.EscapeUriString(entity.Name)}"));
 
-						tasks.Add(removeEntityTask);
-					}
-				}
-			}
-			await Task.WhenAll(tasks);
-		}
+                        tasks.Add(removeEntityTask);
+                    }
+                }
+            }
+            await Task.WhenAll(tasks);
+        }
 
 
-		private static CleanConfiguration GetCleanConfiguration(Action<ICleanConfigurationBuilder> cfg)
-		{
-			if (cfg == null)
-			{
-				return CleanConfiguration.RemoveAll;
-			}
-			var builder = new CleanConfigurationBuilder();
-			cfg(builder);
-			return builder.Configuration;
-		}
-	}
+        private static CleanConfiguration GetCleanConfiguration(Action<ICleanConfigurationBuilder> cfg)
+        {
+            if (cfg == null)
+            {
+                return CleanConfiguration.RemoveAll;
+            }
+            var builder = new CleanConfigurationBuilder();
+            cfg(builder);
+            return builder.Configuration;
+        }
+    }
 }

--- a/src/RawRabbit.Extensions/CleanEverything/Configuration/CleanConfiguration.cs
+++ b/src/RawRabbit.Extensions/CleanEverything/Configuration/CleanConfiguration.cs
@@ -1,16 +1,16 @@
 ﻿namespace RawRabbit.Extensions.CleanEverything.Configuration
 {
-	public class CleanConfiguration
-	{
-		public bool RemoveQueues { get; set; }
-		public bool RemoveExchanges { get; set; }
-		public bool CloseConnections { get; set; }
+    public class CleanConfiguration
+    {
+        public bool RemoveQueues { get; set; }
+        public bool RemoveExchanges { get; set; }
+        public bool CloseConnections { get; set; }
 
-		public static CleanConfiguration RemoveAll => new CleanConfiguration
-		{
-			CloseConnections = true,
-			RemoveExchanges = true,
-			RemoveQueues = true
-		};
-	}
+        public static CleanConfiguration RemoveAll => new CleanConfiguration
+        {
+            CloseConnections = true,
+            RemoveExchanges = true,
+            RemoveQueues = true
+        };
+    }
 }

--- a/src/RawRabbit.Extensions/CleanEverything/Configuration/ICleanConfigurationBuilder.cs
+++ b/src/RawRabbit.Extensions/CleanEverything/Configuration/ICleanConfigurationBuilder.cs
@@ -1,37 +1,37 @@
 ﻿namespace RawRabbit.Extensions.CleanEverything.Configuration
 {
-	public interface ICleanConfigurationBuilder
-	{
-		ICleanConfigurationBuilder RemoveQueues();
-		ICleanConfigurationBuilder RemoveExchanges();
-		ICleanConfigurationBuilder CloseConnections();
-	}
+    public interface ICleanConfigurationBuilder
+    {
+        ICleanConfigurationBuilder RemoveQueues();
+        ICleanConfigurationBuilder RemoveExchanges();
+        ICleanConfigurationBuilder CloseConnections();
+    }
 
-	public class CleanConfigurationBuilder : ICleanConfigurationBuilder
-	{
-		public CleanConfiguration Configuration { get; }
+    public class CleanConfigurationBuilder : ICleanConfigurationBuilder
+    {
+        public CleanConfiguration Configuration { get; }
 
-		public CleanConfigurationBuilder()
-		{
-			Configuration = new CleanConfiguration();
-		}
+        public CleanConfigurationBuilder()
+        {
+            Configuration = new CleanConfiguration();
+        }
 
-		public ICleanConfigurationBuilder RemoveQueues()
-		{
-			Configuration.RemoveQueues = true;
-			return this;
-		}
+        public ICleanConfigurationBuilder RemoveQueues()
+        {
+            Configuration.RemoveQueues = true;
+            return this;
+        }
 
-		public ICleanConfigurationBuilder RemoveExchanges()
-		{
-			Configuration.RemoveExchanges = true;
-			return this;
-		}
+        public ICleanConfigurationBuilder RemoveExchanges()
+        {
+            Configuration.RemoveExchanges = true;
+            return this;
+        }
 
-		public ICleanConfigurationBuilder CloseConnections()
-		{
-			Configuration.CloseConnections = true;
-			return this;
-		}
-	}
+        public ICleanConfigurationBuilder CloseConnections()
+        {
+            Configuration.CloseConnections = true;
+            return this;
+        }
+    }
 }

--- a/src/RawRabbit.Extensions/CleanEverything/Model/Connection.cs
+++ b/src/RawRabbit.Extensions/CleanEverything/Model/Connection.cs
@@ -1,11 +1,11 @@
 ﻿namespace RawRabbit.Extensions.CleanEverything.Model
 {
-	public class Connection : IRabbtMqEntity
-	{
-		public string Address { get; set; }
-		public string Name { get; set; }
-		public int Port { get; set; }
-		public string User { get; set; }
-		public string Vhost { get; set; }
-	}
+    public class Connection : IRabbtMqEntity
+    {
+        public string Address { get; set; }
+        public string Name { get; set; }
+        public int Port { get; set; }
+        public string User { get; set; }
+        public string Vhost { get; set; }
+    }
 }

--- a/src/RawRabbit.Extensions/CleanEverything/Model/Exchange.cs
+++ b/src/RawRabbit.Extensions/CleanEverything/Model/Exchange.cs
@@ -1,12 +1,12 @@
 namespace RawRabbit.Extensions.CleanEverything.Model
 {
-	public class Exchange : IRabbtMqEntity
-	{
-		public string Name { get; set; }
-		public string Vhost { get; set; }
-		public string Type { get; set; }
-		public bool Durable { get; set; }
-		public bool AutoDelete { get; set; }
-		public bool Internal { get; set; }
-	}
+    public class Exchange : IRabbtMqEntity
+    {
+        public string Name { get; set; }
+        public string Vhost { get; set; }
+        public string Type { get; set; }
+        public bool Durable { get; set; }
+        public bool AutoDelete { get; set; }
+        public bool Internal { get; set; }
+    }
 }

--- a/src/RawRabbit.Extensions/CleanEverything/Model/IRabbtMqEntity.cs
+++ b/src/RawRabbit.Extensions/CleanEverything/Model/IRabbtMqEntity.cs
@@ -1,8 +1,8 @@
 namespace RawRabbit.Extensions.CleanEverything.Model
 {
-	public interface IRabbtMqEntity
-	{
-		string Name { get; }
-		string Vhost { get; }
-	}
+    public interface IRabbtMqEntity
+    {
+        string Name { get; }
+        string Vhost { get; }
+    }
 }

--- a/src/RawRabbit.Extensions/CleanEverything/Model/Queue.cs
+++ b/src/RawRabbit.Extensions/CleanEverything/Model/Queue.cs
@@ -1,13 +1,13 @@
 namespace RawRabbit.Extensions.CleanEverything.Model
 {
-	public class Queue : IRabbtMqEntity
-	{
-		public bool AutoDelete { get; set; }
-		public int Consumers { get; set; }
-		public bool Durable { get; set; }
-		public string Name { get; set; }
-		public string Node { get; set; }
-		public int Messages { get; set; }
-		public string Vhost { get; set; }
-	}
+    public class Queue : IRabbtMqEntity
+    {
+        public bool AutoDelete { get; set; }
+        public int Consumers { get; set; }
+        public bool Durable { get; set; }
+        public string Name { get; set; }
+        public string Node { get; set; }
+        public int Messages { get; set; }
+        public string Vhost { get; set; }
+    }
 }

--- a/src/RawRabbit.Extensions/Client/ExtendableBusClient.cs
+++ b/src/RawRabbit.Extensions/Client/ExtendableBusClient.cs
@@ -3,13 +3,13 @@ using RawRabbit.Context;
 
 namespace RawRabbit.Extensions.Client
 {
-	public interface IBusClient : IBusClient<MessageContext>
-	{
-	}
+    public interface IBusClient : IBusClient<MessageContext>
+    {
+    }
 
-	public class ExtendableBusClient : ExtendableBusClient<MessageContext>, IBusClient
-	{
-		public ExtendableBusClient(IServiceProvider serviceProvider) : base(serviceProvider)
-		{ }
-	}
+    public class ExtendableBusClient : ExtendableBusClient<MessageContext>, IBusClient
+    {
+        public ExtendableBusClient(IServiceProvider serviceProvider) : base(serviceProvider)
+        { }
+    }
 }

--- a/src/RawRabbit.Extensions/Client/ExtendableBusClientOfT.cs
+++ b/src/RawRabbit.Extensions/Client/ExtendableBusClientOfT.cs
@@ -6,30 +6,30 @@ using RawRabbit.Operations.Abstraction;
 
 namespace RawRabbit.Extensions.Client
 {
-	public interface IBusClient<out TMessageContext> : RawRabbit.IBusClient<TMessageContext> where TMessageContext : IMessageContext
-	{
-		TService GetService<TService>();
-	}
+    public interface IBusClient<out TMessageContext> : RawRabbit.IBusClient<TMessageContext> where TMessageContext : IMessageContext
+    {
+        TService GetService<TService>();
+    }
 
-	public class ExtendableBusClient<TMessageContext> : BaseBusClient<TMessageContext>, IBusClient<TMessageContext> where TMessageContext : IMessageContext
-	{
-		private readonly IServiceProvider _serviceProvider;
+    public class ExtendableBusClient<TMessageContext> : BaseBusClient<TMessageContext>, IBusClient<TMessageContext> where TMessageContext : IMessageContext
+    {
+        private readonly IServiceProvider _serviceProvider;
 
-		public ExtendableBusClient(IServiceProvider serviceProvider)
-			: base(
-				serviceProvider.GetService<IConfigurationEvaluator>(),
-				serviceProvider.GetService< ISubscriber<TMessageContext>>(),
-				serviceProvider.GetService<IPublisher>(),
-				serviceProvider.GetService<IResponder<TMessageContext>>(),
-				serviceProvider.GetService<IRequester>()
-			)
-		{
-			_serviceProvider = serviceProvider;
-		}
+        public ExtendableBusClient(IServiceProvider serviceProvider)
+            : base(
+                serviceProvider.GetService<IConfigurationEvaluator>(),
+                serviceProvider.GetService< ISubscriber<TMessageContext>>(),
+                serviceProvider.GetService<IPublisher>(),
+                serviceProvider.GetService<IResponder<TMessageContext>>(),
+                serviceProvider.GetService<IRequester>()
+            )
+        {
+            _serviceProvider = serviceProvider;
+        }
 
-		public TService GetService<TService>()
-		{
-			return _serviceProvider.GetService<TService>();
-		}
-	}
+        public TService GetService<TService>()
+        {
+            return _serviceProvider.GetService<TService>();
+        }
+    }
 }

--- a/src/RawRabbit.Extensions/Client/IServiceCollectionExtension.cs
+++ b/src/RawRabbit.Extensions/Client/IServiceCollectionExtension.cs
@@ -14,64 +14,64 @@ using RawRabbit.Logging;
 
 namespace RawRabbit.Extensions.Client
 {
-	public static class IServiceCollectionExtension
-	{
-		public static IServiceCollection AddRawRabbitExtensions<TMessageContext>(this IServiceCollection collection) where  TMessageContext : IMessageContext
-		{
-			collection
-				/* Message Sequence */
-				.AddSingleton<IMessageChainDispatcher, MessageChainDispatcher>()
-				.AddSingleton<IMessageSequenceRepository, MessageSequenceRepository>()
-				.AddSingleton<IMessageChainTopologyUtil, MessageChainTopologyUtil<TMessageContext>>()
-				.AddSingleton(c =>
-				{
-					var chainQueue = QueueConfiguration.Default;
-					chainQueue.QueueName = $"rawrabbit_chain_{Guid.NewGuid()}";
-					chainQueue.AutoDelete = true;
-					chainQueue.Exclusive = true;
-					return chainQueue;
-				})
-				/* Topology Updater */
-				.AddTransient<IBindingProvider, BindingProvider>()
-				.AddTransient<IExchangeUpdater, ExchangeUpdater>()
-				.AddSingleton<IBusClient<TMessageContext>>(c => new ExtendableBusClient<TMessageContext>(collection.BuildServiceProvider()));
-			return collection;
-		}
+    public static class IServiceCollectionExtension
+    {
+        public static IServiceCollection AddRawRabbitExtensions<TMessageContext>(this IServiceCollection collection) where  TMessageContext : IMessageContext
+        {
+            collection
+                /* Message Sequence */
+                .AddSingleton<IMessageChainDispatcher, MessageChainDispatcher>()
+                .AddSingleton<IMessageSequenceRepository, MessageSequenceRepository>()
+                .AddSingleton<IMessageChainTopologyUtil, MessageChainTopologyUtil<TMessageContext>>()
+                .AddSingleton(c =>
+                {
+                    var chainQueue = QueueConfiguration.Default;
+                    chainQueue.QueueName = $"rawrabbit_chain_{Guid.NewGuid()}";
+                    chainQueue.AutoDelete = true;
+                    chainQueue.Exclusive = true;
+                    return chainQueue;
+                })
+                /* Topology Updater */
+                .AddTransient<IBindingProvider, BindingProvider>()
+                .AddTransient<IExchangeUpdater, ExchangeUpdater>()
+                .AddSingleton<IBusClient<TMessageContext>>(c => new ExtendableBusClient<TMessageContext>(collection.BuildServiceProvider()));
+            return collection;
+        }
 
-		public static IServiceCollection AddRawRabbit<TMessageContext>(this IServiceCollection collection, Action<IConfigurationBuilder> config = null, Action<IServiceCollection> custom = null) where TMessageContext : IMessageContext
-		{
-			return vNext.IServiceCollectionExtensions
-				.AddRawRabbit(collection, config, custom)
-				.AddRawRabbitExtensions<TMessageContext>()
-				.AddSingleton<IBusClient>(c =>
-				{
-					LogManager.CurrentFactory = c.GetService<ILoggerFactory>();
-					return new ExtendableBusClient(collection.BuildServiceProvider());
-				});
-		}
+        public static IServiceCollection AddRawRabbit<TMessageContext>(this IServiceCollection collection, Action<IConfigurationBuilder> config = null, Action<IServiceCollection> custom = null) where TMessageContext : IMessageContext
+        {
+            return vNext.IServiceCollectionExtensions
+                .AddRawRabbit(collection, config, custom)
+                .AddRawRabbitExtensions<TMessageContext>()
+                .AddSingleton<IBusClient>(c =>
+                {
+                    LogManager.CurrentFactory = c.GetService<ILoggerFactory>();
+                    return new ExtendableBusClient(collection.BuildServiceProvider());
+                });
+        }
 
-		public static IServiceCollection AddRawRabbit(this IServiceCollection collection, Action<IConfigurationBuilder> config = null, Action<IServiceCollection> custom = null)
-		{
-			return AddRawRabbit<MessageContext>(collection, config, custom)
-				.AddSingleton<IBusClient>(provider =>
-				{
-					LogManager.CurrentFactory = provider.GetService<ILoggerFactory>();
-					return new ExtendableBusClient(collection.BuildServiceProvider());
-				});
-		}
+        public static IServiceCollection AddRawRabbit(this IServiceCollection collection, Action<IConfigurationBuilder> config = null, Action<IServiceCollection> custom = null)
+        {
+            return AddRawRabbit<MessageContext>(collection, config, custom)
+                .AddSingleton<IBusClient>(provider =>
+                {
+                    LogManager.CurrentFactory = provider.GetService<ILoggerFactory>();
+                    return new ExtendableBusClient(collection.BuildServiceProvider());
+                });
+        }
 
-		public static IServiceCollection AddRawRabbit(this IServiceCollection collection, IConfigurationSection section, Action<IServiceCollection> custom = null)
-		{
-			custom = custom ?? (serviceCollection => { });
-			custom += ioc => ioc.AddSingleton(c =>
-			{
-				var mainCfg = RawRabbitConfiguration.Local;
-				section.Bind(mainCfg);
-				mainCfg.Hostnames = mainCfg.Hostnames.Distinct(StringComparer.CurrentCultureIgnoreCase).ToList();
-				return mainCfg;
-			});
+        public static IServiceCollection AddRawRabbit(this IServiceCollection collection, IConfigurationSection section, Action<IServiceCollection> custom = null)
+        {
+            custom = custom ?? (serviceCollection => { });
+            custom += ioc => ioc.AddSingleton(c =>
+            {
+                var mainCfg = RawRabbitConfiguration.Local;
+                section.Bind(mainCfg);
+                mainCfg.Hostnames = mainCfg.Hostnames.Distinct(StringComparer.CurrentCultureIgnoreCase).ToList();
+                return mainCfg;
+            });
 
-			return AddRawRabbit(collection, config: null, custom: custom);
-		}
-	}
+            return AddRawRabbit(collection, config: null, custom: custom);
+        }
+    }
 }

--- a/src/RawRabbit.Extensions/Client/RawRabbitFactory.cs
+++ b/src/RawRabbit.Extensions/Client/RawRabbitFactory.cs
@@ -6,35 +6,35 @@ using RawRabbit.vNext;
 
 namespace RawRabbit.Extensions.Client
 {
-	public class RawRabbitFactory
-	{
-		[Obsolete("Use 'Create' methods instead.")]
-		public static IBusClient<MessageContext> GetExtendableClient(Action<IServiceCollection> custom = null)
-		{
-			var provider = new ServiceCollection()
-				.AddRawRabbit(config: null, custom: custom)
-				.AddRawRabbitExtensions<MessageContext>()
-				.BuildServiceProvider();
-			return new ExtendableBusClient(provider);
-		}
+    public class RawRabbitFactory
+    {
+        [Obsolete("Use 'Create' methods instead.")]
+        public static IBusClient<MessageContext> GetExtendableClient(Action<IServiceCollection> custom = null)
+        {
+            var provider = new ServiceCollection()
+                .AddRawRabbit(config: null, custom: custom)
+                .AddRawRabbitExtensions<MessageContext>()
+                .BuildServiceProvider();
+            return new ExtendableBusClient(provider);
+        }
 
-		public static Disposable.IBusClient<TMessageContext> Create<TMessageContext>(Action<IServiceCollection> custom = null)
-			where TMessageContext : IMessageContext
-		{
-			var provider = new ServiceCollection()
-				.AddRawRabbit(config: null, custom: custom)
-				.AddRawRabbitExtensions<MessageContext>()
-				.BuildServiceProvider();
-			return new BusClient<TMessageContext>(new ExtendableBusClient<TMessageContext>(provider));
-		}
+        public static Disposable.IBusClient<TMessageContext> Create<TMessageContext>(Action<IServiceCollection> custom = null)
+            where TMessageContext : IMessageContext
+        {
+            var provider = new ServiceCollection()
+                .AddRawRabbit(config: null, custom: custom)
+                .AddRawRabbitExtensions<MessageContext>()
+                .BuildServiceProvider();
+            return new BusClient<TMessageContext>(new ExtendableBusClient<TMessageContext>(provider));
+        }
 
-		public static Disposable.IBusClient Create(Action<IServiceCollection> custom = null)
-		{
-			var provider = new ServiceCollection()
-				.AddRawRabbit(config: null, custom: custom)
-				.AddRawRabbitExtensions<MessageContext>()
-				.BuildServiceProvider();
-			return new Disposable.BusClient(new ExtendableBusClient(provider));
-		}
-	}
+        public static Disposable.IBusClient Create(Action<IServiceCollection> custom = null)
+        {
+            var provider = new ServiceCollection()
+                .AddRawRabbit(config: null, custom: custom)
+                .AddRawRabbitExtensions<MessageContext>()
+                .BuildServiceProvider();
+            return new Disposable.BusClient(new ExtendableBusClient(provider));
+        }
+    }
 }

--- a/src/RawRabbit.Extensions/Disposable/BusClient.cs
+++ b/src/RawRabbit.Extensions/Disposable/BusClient.cs
@@ -9,55 +9,55 @@ using RawRabbit.Context;
 
 namespace RawRabbit.Extensions.Disposable
 {
-	public interface IBusClient : Client.IBusClient, IDisposable { }
+    public interface IBusClient : Client.IBusClient, IDisposable { }
 
-	public class BusClient : IBusClient
-	{
-		private readonly Client.IBusClient _client;
+    public class BusClient : IBusClient
+    {
+        private readonly Client.IBusClient _client;
 
-		public BusClient(Client.IBusClient client)
-		{
-			_client = client;
-		}
+        public BusClient(Client.IBusClient client)
+        {
+            _client = client;
+        }
 
-		public void Dispose()
-		{
-			var shutDownTask = ShutdownAsync(TimeSpan.Zero);
-			shutDownTask.GetAwaiter().GetResult();
-		}
+        public void Dispose()
+        {
+            var shutDownTask = ShutdownAsync(TimeSpan.Zero);
+            shutDownTask.GetAwaiter().GetResult();
+        }
 
-		#region Pass-through
+        #region Pass-through
 
-		public TService GetService<TService>()
-		{
-			return _client.GetService<TService>();
-		}
+        public TService GetService<TService>()
+        {
+            return _client.GetService<TService>();
+        }
 
-		public Task ShutdownAsync(TimeSpan? graceful = null)
-		{
-			return _client.ShutdownAsync(graceful);
-		}
+        public Task ShutdownAsync(TimeSpan? graceful = null)
+        {
+            return _client.ShutdownAsync(graceful);
+        }
 
-		public ISubscription SubscribeAsync<T>(Func<T, MessageContext, Task> subscribeMethod, Action<ISubscriptionConfigurationBuilder> configuration = null)
-		{
-			return _client.SubscribeAsync(subscribeMethod, configuration);
-		}
+        public ISubscription SubscribeAsync<T>(Func<T, MessageContext, Task> subscribeMethod, Action<ISubscriptionConfigurationBuilder> configuration = null)
+        {
+            return _client.SubscribeAsync(subscribeMethod, configuration);
+        }
 
-		public Task PublishAsync<T>(T message = default(T), Guid globalMessageId = new Guid(), Action<IPublishConfigurationBuilder> configuration = null)
-		{
-			return _client.PublishAsync(message, globalMessageId, configuration);
-		}
+        public Task PublishAsync<T>(T message = default(T), Guid globalMessageId = new Guid(), Action<IPublishConfigurationBuilder> configuration = null)
+        {
+            return _client.PublishAsync(message, globalMessageId, configuration);
+        }
 
-		public ISubscription RespondAsync<TRequest, TResponse>(Func<TRequest, MessageContext, Task<TResponse>> onMessage, Action<IResponderConfigurationBuilder> configuration = null)
-		{
-			return _client.RespondAsync(onMessage, configuration);
-		}
+        public ISubscription RespondAsync<TRequest, TResponse>(Func<TRequest, MessageContext, Task<TResponse>> onMessage, Action<IResponderConfigurationBuilder> configuration = null)
+        {
+            return _client.RespondAsync(onMessage, configuration);
+        }
 
-		public Task<TResponse> RequestAsync<TRequest, TResponse>(TRequest message = default(TRequest), Guid globalMessageId = new Guid(),
-			Action<IRequestConfigurationBuilder> configuration = null)
-		{
-			return _client.RequestAsync<TRequest, TResponse>(message, globalMessageId, configuration);
-		}
-		#endregion
-	}
+        public Task<TResponse> RequestAsync<TRequest, TResponse>(TRequest message = default(TRequest), Guid globalMessageId = new Guid(),
+            Action<IRequestConfigurationBuilder> configuration = null)
+        {
+            return _client.RequestAsync<TRequest, TResponse>(message, globalMessageId, configuration);
+        }
+        #endregion
+    }
 }

--- a/src/RawRabbit.Extensions/Disposable/BusClientOfT.cs
+++ b/src/RawRabbit.Extensions/Disposable/BusClientOfT.cs
@@ -9,50 +9,50 @@ using RawRabbit.Context;
 
 namespace RawRabbit.Extensions.Disposable
 {
-	public interface IBusClient<out TMessageContext> : RawRabbit.IBusClient<TMessageContext>, IDisposable where TMessageContext : IMessageContext
-	{ }
+    public interface IBusClient<out TMessageContext> : RawRabbit.IBusClient<TMessageContext>, IDisposable where TMessageContext : IMessageContext
+    { }
 
-	public class BusClient<TMessageContext> : IBusClient<TMessageContext> where TMessageContext : IMessageContext
-	{
-		private readonly Client.IBusClient<TMessageContext> _client;
+    public class BusClient<TMessageContext> : IBusClient<TMessageContext> where TMessageContext : IMessageContext
+    {
+        private readonly Client.IBusClient<TMessageContext> _client;
 
-		public BusClient(Client.IBusClient<TMessageContext> client)
-		{
-			_client = client;
-		}
+        public BusClient(Client.IBusClient<TMessageContext> client)
+        {
+            _client = client;
+        }
 
-		public void Dispose()
-		{
-			var shutDownTask = ShutdownAsync(TimeSpan.Zero);
-			shutDownTask.GetAwaiter().GetResult();
-		}
+        public void Dispose()
+        {
+            var shutDownTask = ShutdownAsync(TimeSpan.Zero);
+            shutDownTask.GetAwaiter().GetResult();
+        }
 
-		#region Pass-through
-		public Task ShutdownAsync(TimeSpan? graceful = null)
-		{
-			return _client.ShutdownAsync(graceful);
-		}
+        #region Pass-through
+        public Task ShutdownAsync(TimeSpan? graceful = null)
+        {
+            return _client.ShutdownAsync(graceful);
+        }
 
-		public ISubscription SubscribeAsync<T>(Func<T, TMessageContext, Task> subscribeMethod, Action<ISubscriptionConfigurationBuilder> configuration = null)
-		{
-			return _client.SubscribeAsync(subscribeMethod, configuration);
-		}
+        public ISubscription SubscribeAsync<T>(Func<T, TMessageContext, Task> subscribeMethod, Action<ISubscriptionConfigurationBuilder> configuration = null)
+        {
+            return _client.SubscribeAsync(subscribeMethod, configuration);
+        }
 
-		public Task PublishAsync<T>(T message = default(T), Guid globalMessageId = new Guid(), Action<IPublishConfigurationBuilder> configuration = null)
-		{
-			return _client.PublishAsync(message, globalMessageId, configuration);
-		}
+        public Task PublishAsync<T>(T message = default(T), Guid globalMessageId = new Guid(), Action<IPublishConfigurationBuilder> configuration = null)
+        {
+            return _client.PublishAsync(message, globalMessageId, configuration);
+        }
 
-		public ISubscription RespondAsync<TRequest, TResponse>(Func<TRequest, TMessageContext, Task<TResponse>> onMessage, Action<IResponderConfigurationBuilder> configuration = null)
-		{
-			return _client.RespondAsync(onMessage, configuration);
-		}
+        public ISubscription RespondAsync<TRequest, TResponse>(Func<TRequest, TMessageContext, Task<TResponse>> onMessage, Action<IResponderConfigurationBuilder> configuration = null)
+        {
+            return _client.RespondAsync(onMessage, configuration);
+        }
 
-		public Task<TResponse> RequestAsync<TRequest, TResponse>(TRequest message = default(TRequest), Guid globalMessageId = new Guid(),
-			Action<IRequestConfigurationBuilder> configuration = null)
-		{
-			return _client.RequestAsync<TRequest, TResponse>(message, globalMessageId, configuration);
-		}
-		#endregion
-	}
+        public Task<TResponse> RequestAsync<TRequest, TResponse>(TRequest message = default(TRequest), Guid globalMessageId = new Guid(),
+            Action<IRequestConfigurationBuilder> configuration = null)
+        {
+            return _client.RequestAsync<TRequest, TResponse>(message, globalMessageId, configuration);
+        }
+        #endregion
+    }
 }

--- a/src/RawRabbit.Extensions/MessageSequence/Configuration/Abstraction/IMessageChainPublisher.cs
+++ b/src/RawRabbit.Extensions/MessageSequence/Configuration/Abstraction/IMessageChainPublisher.cs
@@ -3,8 +3,8 @@ using RawRabbit.Context;
 
 namespace RawRabbit.Extensions.MessageSequence.Configuration.Abstraction
 {
-	public interface IMessageChainPublisher<TMessageContext> where TMessageContext : IMessageContext
-	{
-		IMessageSequenceBuilder<TMessageContext> PublishAsync<TMessage>(TMessage message = default(TMessage), Guid globalMessageId = new Guid()) where TMessage : new();
-	}
+    public interface IMessageChainPublisher<TMessageContext> where TMessageContext : IMessageContext
+    {
+        IMessageSequenceBuilder<TMessageContext> PublishAsync<TMessage>(TMessage message = default(TMessage), Guid globalMessageId = new Guid()) where TMessage : new();
+    }
 }

--- a/src/RawRabbit.Extensions/MessageSequence/Configuration/Abstraction/IMessageSequenceBuilder.cs
+++ b/src/RawRabbit.Extensions/MessageSequence/Configuration/Abstraction/IMessageSequenceBuilder.cs
@@ -5,9 +5,9 @@ using RawRabbit.Extensions.MessageSequence.Model;
 
 namespace RawRabbit.Extensions.MessageSequence.Configuration.Abstraction
 {
-	public interface IMessageSequenceBuilder<TMessageContext> where TMessageContext : IMessageContext
-	{
-		IMessageSequenceBuilder<TMessageContext> When<TMessage>(Func<TMessage, TMessageContext, Task> func, Action<IStepOptionBuilder> options = null);
-		MessageSequence<TMessage> Complete<TMessage>();
-	}
+    public interface IMessageSequenceBuilder<TMessageContext> where TMessageContext : IMessageContext
+    {
+        IMessageSequenceBuilder<TMessageContext> When<TMessage>(Func<TMessage, TMessageContext, Task> func, Action<IStepOptionBuilder> options = null);
+        MessageSequence<TMessage> Complete<TMessage>();
+    }
 }

--- a/src/RawRabbit.Extensions/MessageSequence/Configuration/Abstraction/IStepOptionBuilder.cs
+++ b/src/RawRabbit.Extensions/MessageSequence/Configuration/Abstraction/IStepOptionBuilder.cs
@@ -1,8 +1,8 @@
 namespace RawRabbit.Extensions.MessageSequence.Configuration.Abstraction
 {
-	public interface IStepOptionBuilder
-	{
-		IStepOptionBuilder AbortsExecution(bool aborts = true);
-		IStepOptionBuilder IsOptional(bool optional = true);
-	}
+    public interface IStepOptionBuilder
+    {
+        IStepOptionBuilder AbortsExecution(bool aborts = true);
+        IStepOptionBuilder IsOptional(bool optional = true);
+    }
 }

--- a/src/RawRabbit.Extensions/MessageSequence/Configuration/MessageSequenceBuilder.cs
+++ b/src/RawRabbit.Extensions/MessageSequence/Configuration/MessageSequenceBuilder.cs
@@ -12,122 +12,122 @@ using RawRabbit.Logging;
 
 namespace RawRabbit.Extensions.MessageSequence.Configuration
 {
-	public class MessageSequenceBuilder<TMessageContext>
-		: IMessageChainPublisher<TMessageContext>
-		, IMessageSequenceBuilder<TMessageContext> where TMessageContext : IMessageContext
-	{
-		private readonly ILogger _logger = LogManager.GetLogger<MessageSequenceBuilder<TMessageContext>>();
-		private readonly IBusClient<TMessageContext> _busClient;
-		private readonly IMessageChainTopologyUtil _chainTopology;
-		private readonly IMessageChainDispatcher _dispatcher;
-		private readonly IMessageSequenceRepository _repository;
-		private readonly RawRabbitConfiguration _mainCfg;
+    public class MessageSequenceBuilder<TMessageContext>
+        : IMessageChainPublisher<TMessageContext>
+        , IMessageSequenceBuilder<TMessageContext> where TMessageContext : IMessageContext
+    {
+        private readonly ILogger _logger = LogManager.GetLogger<MessageSequenceBuilder<TMessageContext>>();
+        private readonly IBusClient<TMessageContext> _busClient;
+        private readonly IMessageChainTopologyUtil _chainTopology;
+        private readonly IMessageChainDispatcher _dispatcher;
+        private readonly IMessageSequenceRepository _repository;
+        private readonly RawRabbitConfiguration _mainCfg;
 
-		private Func<Task> _publishAsync;
-		private Guid _globalMessageId ;
+        private Func<Task> _publishAsync;
+        private Guid _globalMessageId ;
 
-		public MessageSequenceBuilder(IBusClient<TMessageContext> busClient, IMessageChainTopologyUtil chainTopology, IMessageChainDispatcher dispatcher, IMessageSequenceRepository repository, RawRabbitConfiguration mainCfg)
-		{
-			_busClient = busClient;
-			_chainTopology = chainTopology;
-			_dispatcher = dispatcher;
-			_repository = repository;
-			_mainCfg = mainCfg;
-		}
+        public MessageSequenceBuilder(IBusClient<TMessageContext> busClient, IMessageChainTopologyUtil chainTopology, IMessageChainDispatcher dispatcher, IMessageSequenceRepository repository, RawRabbitConfiguration mainCfg)
+        {
+            _busClient = busClient;
+            _chainTopology = chainTopology;
+            _dispatcher = dispatcher;
+            _repository = repository;
+            _mainCfg = mainCfg;
+        }
 
-		public IMessageSequenceBuilder<TMessageContext> PublishAsync<TMessage>(TMessage message = default(TMessage), Guid globalMessageId = new Guid()) where TMessage : new()
-		{
-			_globalMessageId = globalMessageId == Guid.Empty
-				? Guid.NewGuid()
-				: globalMessageId;
-			_logger.LogDebug($"Preparing Message Sequence for '{_globalMessageId}' that starts with {typeof(TMessage).Name}.");
-			_publishAsync = () => _busClient.PublishAsync(message, _globalMessageId);
-			return this;
-		}
+        public IMessageSequenceBuilder<TMessageContext> PublishAsync<TMessage>(TMessage message = default(TMessage), Guid globalMessageId = new Guid()) where TMessage : new()
+        {
+            _globalMessageId = globalMessageId == Guid.Empty
+                ? Guid.NewGuid()
+                : globalMessageId;
+            _logger.LogDebug($"Preparing Message Sequence for '{_globalMessageId}' that starts with {typeof(TMessage).Name}.");
+            _publishAsync = () => _busClient.PublishAsync(message, _globalMessageId);
+            return this;
+        }
 
-		public IMessageSequenceBuilder<TMessageContext> When<TMessage>(Func<TMessage, TMessageContext, Task> func, Action<IStepOptionBuilder> options = null)
-		{
-			var optionBuilder = new StepOptionBuilder();
-			options?.Invoke(optionBuilder);
-			_logger.LogDebug($"Registering handler for '{_globalMessageId}' of type '{typeof(TMessage).Name}'. Optional: {optionBuilder.Configuration.Optional}, Aborts: {optionBuilder.Configuration.AbortsExecution}");
-			_dispatcher.AddMessageHandler(_globalMessageId, func, optionBuilder.Configuration);
-			var bindTask = _chainTopology.BindToExchange<TMessage>(_globalMessageId);
-			bindTask.ConfigureAwait(false);
-			Task.WaitAll(bindTask);
-			_logger.LogDebug($"Sucessfully bound Sequence Queue for GlobalMessageId '{_globalMessageId}' of type '{typeof(TMessage).Name}.");
-			return this;
-		}
+        public IMessageSequenceBuilder<TMessageContext> When<TMessage>(Func<TMessage, TMessageContext, Task> func, Action<IStepOptionBuilder> options = null)
+        {
+            var optionBuilder = new StepOptionBuilder();
+            options?.Invoke(optionBuilder);
+            _logger.LogDebug($"Registering handler for '{_globalMessageId}' of type '{typeof(TMessage).Name}'. Optional: {optionBuilder.Configuration.Optional}, Aborts: {optionBuilder.Configuration.AbortsExecution}");
+            _dispatcher.AddMessageHandler(_globalMessageId, func, optionBuilder.Configuration);
+            var bindTask = _chainTopology.BindToExchange<TMessage>(_globalMessageId);
+            bindTask.ConfigureAwait(false);
+            Task.WaitAll(bindTask);
+            _logger.LogDebug($"Sucessfully bound Sequence Queue for GlobalMessageId '{_globalMessageId}' of type '{typeof(TMessage).Name}.");
+            return this;
+        }
 
-		public MessageSequence<TMessage> Complete<TMessage>()
-		{
-			_logger.LogDebug($"Message Sequence for '{_globalMessageId}' completes with '{typeof(TMessage).Name}'.");
-			var sequenceDef = _repository.GetOrCreate(_globalMessageId);
-			
-			var messageTcs = new TaskCompletionSource<TMessage>();
-			var sequence = new MessageSequence<TMessage>
-			{
-				Task = messageTcs.Task
-			};
+        public MessageSequence<TMessage> Complete<TMessage>()
+        {
+            _logger.LogDebug($"Message Sequence for '{_globalMessageId}' completes with '{typeof(TMessage).Name}'.");
+            var sequenceDef = _repository.GetOrCreate(_globalMessageId);
+            
+            var messageTcs = new TaskCompletionSource<TMessage>();
+            var sequence = new MessageSequence<TMessage>
+            {
+                Task = messageTcs.Task
+            };
 
-			sequenceDef.TaskCompletionSource.Task.ContinueWith(tObj =>
-			{
-				UpdateSequenceFinalState(sequence);
-				messageTcs.TrySetResult((TMessage) tObj.Result);
-			});
+            sequenceDef.TaskCompletionSource.Task.ContinueWith(tObj =>
+            {
+                UpdateSequenceFinalState(sequence);
+                messageTcs.TrySetResult((TMessage) tObj.Result);
+            });
 
-			Func<TMessage, TMessageContext, Task> func = (message, context) =>
-			{
-				Task
-					.WhenAll(sequenceDef.State.HandlerTasks)
-					.ContinueWith(t => sequenceDef.TaskCompletionSource.TrySetResult(message));
-				return Task.FromResult(true);
-			};
+            Func<TMessage, TMessageContext, Task> func = (message, context) =>
+            {
+                Task
+                    .WhenAll(sequenceDef.State.HandlerTasks)
+                    .ContinueWith(t => sequenceDef.TaskCompletionSource.TrySetResult(message));
+                return Task.FromResult(true);
+            };
 
-			var bindTask = _chainTopology.BindToExchange<TMessage>(_globalMessageId);
-			_dispatcher.AddMessageHandler(_globalMessageId, func);
+            var bindTask = _chainTopology.BindToExchange<TMessage>(_globalMessageId);
+            _dispatcher.AddMessageHandler(_globalMessageId, func);
 
-			Task
-				.WhenAll(bindTask)
-				.ContinueWith(t => _publishAsync())
-				.Unwrap()
-				.Wait();
+            Task
+                .WhenAll(bindTask)
+                .ContinueWith(t => _publishAsync())
+                .Unwrap()
+                .Wait();
 
-			Timer timeoutTimer = null;
-			timeoutTimer = new Timer(state =>
-			{
-				timeoutTimer?.Dispose();
-				var seq = _repository.Get(_globalMessageId);
-				if (seq != null)
-				{
-					seq.State.Aborted = true;
-					_repository.Update(seq);
-					UpdateSequenceFinalState(sequence);
-				}
-				
-				messageTcs.TrySetException(
-					new TimeoutException(
-						$"Unable to complete sequence {_globalMessageId} in {_mainCfg.RequestTimeout.ToString("g")}. Operation Timed out."));
-			}, null, _mainCfg.RequestTimeout, new TimeSpan(-1));
+            Timer timeoutTimer = null;
+            timeoutTimer = new Timer(state =>
+            {
+                timeoutTimer?.Dispose();
+                var seq = _repository.Get(_globalMessageId);
+                if (seq != null)
+                {
+                    seq.State.Aborted = true;
+                    _repository.Update(seq);
+                    UpdateSequenceFinalState(sequence);
+                }
+                
+                messageTcs.TrySetException(
+                    new TimeoutException(
+                        $"Unable to complete sequence {_globalMessageId} in {_mainCfg.RequestTimeout.ToString("g")}. Operation Timed out."));
+            }, null, _mainCfg.RequestTimeout, new TimeSpan(-1));
 
-			return sequence;
-		}
+            return sequence;
+        }
 
-		private void UpdateSequenceFinalState<TMessage>(MessageSequence<TMessage> sequence)
-		{
-			var final = _repository.Get(_globalMessageId);
-			if (final == null)
-			{
-				return;
-			}
-			_logger.LogDebug($"Updating Sequence for '{_globalMessageId}'.");
-			sequence.Aborted = final.State.Aborted;
-			sequence.Completed = final.State.Completed;
-			sequence.Skipped = final.State.Skipped;
-			foreach (var step in final.StepDefinitions)
-			{
-				_chainTopology.UnbindFromExchange(step.Type, _globalMessageId);
-			}
-			_repository.Remove(_globalMessageId);
-		}
-	}
+        private void UpdateSequenceFinalState<TMessage>(MessageSequence<TMessage> sequence)
+        {
+            var final = _repository.Get(_globalMessageId);
+            if (final == null)
+            {
+                return;
+            }
+            _logger.LogDebug($"Updating Sequence for '{_globalMessageId}'.");
+            sequence.Aborted = final.State.Aborted;
+            sequence.Completed = final.State.Completed;
+            sequence.Skipped = final.State.Skipped;
+            foreach (var step in final.StepDefinitions)
+            {
+                _chainTopology.UnbindFromExchange(step.Type, _globalMessageId);
+            }
+            _repository.Remove(_globalMessageId);
+        }
+    }
 }

--- a/src/RawRabbit.Extensions/MessageSequence/Configuration/StepOptionBuilder.cs
+++ b/src/RawRabbit.Extensions/MessageSequence/Configuration/StepOptionBuilder.cs
@@ -3,26 +3,26 @@ using RawRabbit.Extensions.MessageSequence.Model;
 
 namespace RawRabbit.Extensions.MessageSequence.Configuration
 {
-	public class StepOptionBuilder : IStepOptionBuilder
-	{
-		public StepOption Configuration { get; set; }
+    public class StepOptionBuilder : IStepOptionBuilder
+    {
+        public StepOption Configuration { get; set; }
 
-		public StepOptionBuilder()
-		{
-			Configuration = new StepOption();
-		}
+        public StepOptionBuilder()
+        {
+            Configuration = new StepOption();
+        }
 
-		public IStepOptionBuilder AbortsExecution(bool aborts = true)
-		{
-			Configuration.Optional = true;
-			Configuration.AbortsExecution = aborts;
-			return this;
-		}
+        public IStepOptionBuilder AbortsExecution(bool aborts = true)
+        {
+            Configuration.Optional = true;
+            Configuration.AbortsExecution = aborts;
+            return this;
+        }
 
-		public IStepOptionBuilder IsOptional(bool optional = true)
-		{
-			Configuration.Optional = optional;
-			return this;
-		}
-	}
+        public IStepOptionBuilder IsOptional(bool optional = true)
+        {
+            Configuration.Optional = optional;
+            return this;
+        }
+    }
 }

--- a/src/RawRabbit.Extensions/MessageSequence/Core/Abstraction/IMessageChainDispatcher.cs
+++ b/src/RawRabbit.Extensions/MessageSequence/Core/Abstraction/IMessageChainDispatcher.cs
@@ -5,9 +5,9 @@ using RawRabbit.Extensions.MessageSequence.Model;
 
 namespace RawRabbit.Extensions.MessageSequence.Core.Abstraction
 {
-	public interface IMessageChainDispatcher
-	{
-		void AddMessageHandler<TMessage, TMessageContext>(Guid globalMessageId, Func<TMessage, TMessageContext, Task> func, StepOption configuration = null) where TMessageContext : IMessageContext;
-		void InvokeMessageHandler(Guid globalMessageId, object body, IMessageContext context);
-	}
+    public interface IMessageChainDispatcher
+    {
+        void AddMessageHandler<TMessage, TMessageContext>(Guid globalMessageId, Func<TMessage, TMessageContext, Task> func, StepOption configuration = null) where TMessageContext : IMessageContext;
+        void InvokeMessageHandler(Guid globalMessageId, object body, IMessageContext context);
+    }
 }

--- a/src/RawRabbit.Extensions/MessageSequence/Core/Abstraction/IMessageChainTopologyUtil.cs
+++ b/src/RawRabbit.Extensions/MessageSequence/Core/Abstraction/IMessageChainTopologyUtil.cs
@@ -3,11 +3,11 @@ using System.Threading.Tasks;
 
 namespace RawRabbit.Extensions.MessageSequence.Core.Abstraction
 {
-	public interface IMessageChainTopologyUtil
-	{
-		Task BindToExchange<T>(Guid globalMessaegId);
-		Task BindToExchange(Type messageType, Guid globalMessaegId);
-		Task UnbindFromExchange<T>(Guid globalMessaegId);
-		Task UnbindFromExchange(Type messageType, Guid globalMessaegId);
-	}
+    public interface IMessageChainTopologyUtil
+    {
+        Task BindToExchange<T>(Guid globalMessaegId);
+        Task BindToExchange(Type messageType, Guid globalMessaegId);
+        Task UnbindFromExchange<T>(Guid globalMessaegId);
+        Task UnbindFromExchange(Type messageType, Guid globalMessaegId);
+    }
 }

--- a/src/RawRabbit.Extensions/MessageSequence/Core/MessageChainDispatcher.cs
+++ b/src/RawRabbit.Extensions/MessageSequence/Core/MessageChainDispatcher.cs
@@ -9,94 +9,94 @@ using RawRabbit.Logging;
 
 namespace RawRabbit.Extensions.MessageSequence.Core
 {
-	public class MessageChainDispatcher : IMessageChainDispatcher
-	{
-		private readonly IMessageSequenceRepository _sequenceRepository;
-		private readonly ILogger _logger = LogManager.GetLogger<MessageChainDispatcher>();
+    public class MessageChainDispatcher : IMessageChainDispatcher
+    {
+        private readonly IMessageSequenceRepository _sequenceRepository;
+        private readonly ILogger _logger = LogManager.GetLogger<MessageChainDispatcher>();
 
-		public MessageChainDispatcher(IMessageSequenceRepository sequenceRepository)
-		{
-			_sequenceRepository = sequenceRepository;
-		}
+        public MessageChainDispatcher(IMessageSequenceRepository sequenceRepository)
+        {
+            _sequenceRepository = sequenceRepository;
+        }
 
-		public void AddMessageHandler<TMessage, TMessageContext>(Guid globalMessageId, Func<TMessage, TMessageContext, Task> func, StepOption configuration) where TMessageContext : IMessageContext
-		{
-			var sequence = _sequenceRepository.GetOrCreate(globalMessageId);
-			sequence.StepDefinitions.Add(new StepDefinition
-			{
-				Handler = (o, context) => func((TMessage) o, (TMessageContext) context),
-				Type = typeof(TMessage),
-				Optional = configuration?.Optional ?? false,
-				AbortsExecution = configuration?.AbortsExecution ?? false
-			});
-			_sequenceRepository.Update(sequence);
-		}
+        public void AddMessageHandler<TMessage, TMessageContext>(Guid globalMessageId, Func<TMessage, TMessageContext, Task> func, StepOption configuration) where TMessageContext : IMessageContext
+        {
+            var sequence = _sequenceRepository.GetOrCreate(globalMessageId);
+            sequence.StepDefinitions.Add(new StepDefinition
+            {
+                Handler = (o, context) => func((TMessage) o, (TMessageContext) context),
+                Type = typeof(TMessage),
+                Optional = configuration?.Optional ?? false,
+                AbortsExecution = configuration?.AbortsExecution ?? false
+            });
+            _sequenceRepository.Update(sequence);
+        }
 
-		public void InvokeMessageHandler(Guid globalMessageId, object body, IMessageContext context)
-		{
-			var sequence = _sequenceRepository.Get(globalMessageId);
-			if (sequence?.State.Aborted ?? true)
-			{
-				_logger.LogInformation($"Sequence for '{globalMessageId}' is either not found or aborted.");
-				return;
-			}
-			var bodyType = body.GetType();
-			var invokedIds = Enumerable
-				.Concat(sequence.State.Completed, sequence.State.Skipped)
-				.Select(s => s.StepId);
-			var last = sequence.StepDefinitions.LastOrDefault();
-			var notInvoked = sequence.StepDefinitions
-				.Where(s => !invokedIds.Contains(s.Id))
-				.Except(new [] {last})
-				.ToList();
-			if (notInvoked.All(s => s.Optional))
-			{
-				notInvoked.Add(last);
-			}
-			
-			var match = notInvoked.FirstOrDefault(p => p.Type == bodyType);
-			if (match == last)
-			{
-				var skipped = notInvoked
-					.TakeWhile(p => p != match)
-					.Select(s => new ExecutionResult
-						{
-							Time = DateTime.Now,
-							Type = s.Type,
-							StepId = s.Id
-						})
-					.ToList();
-				sequence.State.Skipped.AddRange(skipped);
-				_logger.LogDebug($"Skipping {skipped.Count} message handlers for {globalMessageId}");
-			}
-			try
-			{
-				if (match == null)
-				{
-					_logger.LogInformation($"Unable to find applicable message handler of type '{bodyType.Name}' for '{globalMessageId}'");
-					return;
-				}
-				_logger.LogInformation($"Invoking message handler of type '{bodyType.Name}' for '{globalMessageId}'");
-				sequence.State.Completed.Add(new ExecutionResult
-				{
-					Type = bodyType,
-					Time = DateTime.Now,
-					StepId = match.Id
-				});
-				sequence.State.HandlerTasks.Add(match.Handler(body, context));
-			}
-			catch (Exception e)
-			{
-				_logger.LogError($"Message handler of type '{bodyType.Name}' for '{globalMessageId}' threw an unhandles exception.", e);
-				sequence.State.Aborted = true;
-				sequence.TaskCompletionSource.TrySetException(e);
-			}
-			if (match.AbortsExecution)
-			{
-				_logger.LogInformation($"Message handler of type '{bodyType.Name}' for '{globalMessageId}' aborts execution.");
-				sequence.State.Aborted = true;
-				sequence.TaskCompletionSource.TrySetResult(null);
-			}
-		}
-	}
+        public void InvokeMessageHandler(Guid globalMessageId, object body, IMessageContext context)
+        {
+            var sequence = _sequenceRepository.Get(globalMessageId);
+            if (sequence?.State.Aborted ?? true)
+            {
+                _logger.LogInformation($"Sequence for '{globalMessageId}' is either not found or aborted.");
+                return;
+            }
+            var bodyType = body.GetType();
+            var invokedIds = Enumerable
+                .Concat(sequence.State.Completed, sequence.State.Skipped)
+                .Select(s => s.StepId);
+            var last = sequence.StepDefinitions.LastOrDefault();
+            var notInvoked = sequence.StepDefinitions
+                .Where(s => !invokedIds.Contains(s.Id))
+                .Except(new [] {last})
+                .ToList();
+            if (notInvoked.All(s => s.Optional))
+            {
+                notInvoked.Add(last);
+            }
+            
+            var match = notInvoked.FirstOrDefault(p => p.Type == bodyType);
+            if (match == last)
+            {
+                var skipped = notInvoked
+                    .TakeWhile(p => p != match)
+                    .Select(s => new ExecutionResult
+                        {
+                            Time = DateTime.Now,
+                            Type = s.Type,
+                            StepId = s.Id
+                        })
+                    .ToList();
+                sequence.State.Skipped.AddRange(skipped);
+                _logger.LogDebug($"Skipping {skipped.Count} message handlers for {globalMessageId}");
+            }
+            try
+            {
+                if (match == null)
+                {
+                    _logger.LogInformation($"Unable to find applicable message handler of type '{bodyType.Name}' for '{globalMessageId}'");
+                    return;
+                }
+                _logger.LogInformation($"Invoking message handler of type '{bodyType.Name}' for '{globalMessageId}'");
+                sequence.State.Completed.Add(new ExecutionResult
+                {
+                    Type = bodyType,
+                    Time = DateTime.Now,
+                    StepId = match.Id
+                });
+                sequence.State.HandlerTasks.Add(match.Handler(body, context));
+            }
+            catch (Exception e)
+            {
+                _logger.LogError($"Message handler of type '{bodyType.Name}' for '{globalMessageId}' threw an unhandles exception.", e);
+                sequence.State.Aborted = true;
+                sequence.TaskCompletionSource.TrySetException(e);
+            }
+            if (match.AbortsExecution)
+            {
+                _logger.LogInformation($"Message handler of type '{bodyType.Name}' for '{globalMessageId}' aborts execution.");
+                sequence.State.Aborted = true;
+                sequence.TaskCompletionSource.TrySetResult(null);
+            }
+        }
+    }
 }

--- a/src/RawRabbit.Extensions/MessageSequence/Core/MessageChainTopologyUtil.cs
+++ b/src/RawRabbit.Extensions/MessageSequence/Core/MessageChainTopologyUtil.cs
@@ -12,85 +12,85 @@ using RawRabbit.Serialization;
 
 namespace RawRabbit.Extensions.MessageSequence.Core
 {
-	public class MessageChainTopologyUtil<TMessageContext> : IMessageChainTopologyUtil where TMessageContext : IMessageContext
-	{
-		private readonly IChannelFactory _channelFactory;
-		private readonly ITopologyProvider _topologyProvider;
-		private readonly IConfigurationEvaluator _configEvaluator;
-		private readonly IMessageSerializer _serializer;
-		private readonly IMessageContextProvider<TMessageContext> _contextProvider;
-		private readonly IMessageChainDispatcher _messageDispatcher;
-		private readonly QueueConfiguration _queueConfig;
-		private EventingBasicConsumer _consumer;
+    public class MessageChainTopologyUtil<TMessageContext> : IMessageChainTopologyUtil where TMessageContext : IMessageContext
+    {
+        private readonly IChannelFactory _channelFactory;
+        private readonly ITopologyProvider _topologyProvider;
+        private readonly IConfigurationEvaluator _configEvaluator;
+        private readonly IMessageSerializer _serializer;
+        private readonly IMessageContextProvider<TMessageContext> _contextProvider;
+        private readonly IMessageChainDispatcher _messageDispatcher;
+        private readonly QueueConfiguration _queueConfig;
+        private EventingBasicConsumer _consumer;
 
-		public MessageChainTopologyUtil(
-			IChannelFactory channelFactory,
-			ITopologyProvider topologyProvider,
-			IConfigurationEvaluator configEvaluator,
-			IMessageSerializer serializer,
-			IMessageContextProvider<TMessageContext> contextProvider,
-			IMessageChainDispatcher messageDispatcher,
-			QueueConfiguration queueConfig)
-		{
-			_channelFactory = channelFactory;
-			_topologyProvider = topologyProvider;
-			_configEvaluator = configEvaluator;
-			_queueConfig = queueConfig;
-			_messageDispatcher = messageDispatcher;
-			_contextProvider = contextProvider;
-			_serializer = serializer;
-			InitializeConsumer();
-		}
+        public MessageChainTopologyUtil(
+            IChannelFactory channelFactory,
+            ITopologyProvider topologyProvider,
+            IConfigurationEvaluator configEvaluator,
+            IMessageSerializer serializer,
+            IMessageContextProvider<TMessageContext> contextProvider,
+            IMessageChainDispatcher messageDispatcher,
+            QueueConfiguration queueConfig)
+        {
+            _channelFactory = channelFactory;
+            _topologyProvider = topologyProvider;
+            _configEvaluator = configEvaluator;
+            _queueConfig = queueConfig;
+            _messageDispatcher = messageDispatcher;
+            _contextProvider = contextProvider;
+            _serializer = serializer;
+            InitializeConsumer();
+        }
 
-		public Task BindToExchange<TMessage>(Guid globalMessaegId)
-		{
-			return BindToExchange(typeof(TMessage), globalMessaegId);
-		}
+        public Task BindToExchange<TMessage>(Guid globalMessaegId)
+        {
+            return BindToExchange(typeof(TMessage), globalMessaegId);
+        }
 
-		public Task BindToExchange(Type messageType, Guid globalMessaegId)
-		{
-			var chainConfig = _configEvaluator.GetConfiguration(messageType);
-			return _topologyProvider.BindQueueAsync(
-				_queueConfig,
-				chainConfig.Exchange,
-				$"{chainConfig.RoutingKey}.{globalMessaegId}"
-			);
-		}
+        public Task BindToExchange(Type messageType, Guid globalMessaegId)
+        {
+            var chainConfig = _configEvaluator.GetConfiguration(messageType);
+            return _topologyProvider.BindQueueAsync(
+                _queueConfig,
+                chainConfig.Exchange,
+                $"{chainConfig.RoutingKey}.{globalMessaegId}"
+            );
+        }
 
-		public Task UnbindFromExchange<TMessage>(Guid globalMessaegId)
-		{
-			return UnbindFromExchange(typeof(TMessage), globalMessaegId);
-		}
+        public Task UnbindFromExchange<TMessage>(Guid globalMessaegId)
+        {
+            return UnbindFromExchange(typeof(TMessage), globalMessaegId);
+        }
 
-		public Task UnbindFromExchange(Type messageType, Guid globalMessaegId)
-		{
-			var chainConfig = _configEvaluator.GetConfiguration(messageType);
-			return _topologyProvider.UnbindQueueAsync(
-				_queueConfig,
-				chainConfig.Exchange,
-				$"{chainConfig.RoutingKey}.{globalMessaegId}"
-			);
-		}
+        public Task UnbindFromExchange(Type messageType, Guid globalMessaegId)
+        {
+            var chainConfig = _configEvaluator.GetConfiguration(messageType);
+            return _topologyProvider.UnbindQueueAsync(
+                _queueConfig,
+                chainConfig.Exchange,
+                $"{chainConfig.RoutingKey}.{globalMessaegId}"
+            );
+        }
 
-		private void InitializeConsumer()
-		{
-			var channelTask = _channelFactory.CreateChannelAsync();
-			var topologyTask = _topologyProvider.DeclareQueueAsync(_queueConfig);
+        private void InitializeConsumer()
+        {
+            var channelTask = _channelFactory.CreateChannelAsync();
+            var topologyTask = _topologyProvider.DeclareQueueAsync(_queueConfig);
 
-			Task.WhenAll(channelTask, topologyTask)
-				.ContinueWith(tChannel =>
-					{
-						_consumer = new EventingBasicConsumer(channelTask.Result);
-						_consumer.Received += (sender, args) =>
-						{
-							var context = _contextProvider.ExtractContext(args.BasicProperties.Headers[PropertyHeaders.Context]);
-							var body = _serializer.Deserialize(args);
-							_messageDispatcher.InvokeMessageHandler(context.GlobalRequestId, body, context);
-							_consumer.Model.BasicAck(args.DeliveryTag, false);
-						};
-						_consumer.Model.BasicConsume(_queueConfig.FullQueueName, false, _consumer);
-					})
-				.Wait();
-		}
-	}
+            Task.WhenAll(channelTask, topologyTask)
+                .ContinueWith(tChannel =>
+                    {
+                        _consumer = new EventingBasicConsumer(channelTask.Result);
+                        _consumer.Received += (sender, args) =>
+                        {
+                            var context = _contextProvider.ExtractContext(args.BasicProperties.Headers[PropertyHeaders.Context]);
+                            var body = _serializer.Deserialize(args);
+                            _messageDispatcher.InvokeMessageHandler(context.GlobalRequestId, body, context);
+                            _consumer.Model.BasicAck(args.DeliveryTag, false);
+                        };
+                        _consumer.Model.BasicConsume(_queueConfig.FullQueueName, false, _consumer);
+                    })
+                .Wait();
+        }
+    }
 }

--- a/src/RawRabbit.Extensions/MessageSequence/MessageSequenceExtension.cs
+++ b/src/RawRabbit.Extensions/MessageSequence/MessageSequenceExtension.cs
@@ -9,30 +9,30 @@ using RawRabbit.Extensions.MessageSequence.Repository;
 
 namespace RawRabbit.Extensions.MessageSequence
 {
-	public static class MessageSequenceExtension
-	{
-		public static MessageSequence<TCompleteType> ExecuteSequence<TMessageContext, TCompleteType>(
-			this IBusClient<TMessageContext> client,
-			Func<IMessageChainPublisher<TMessageContext>, MessageSequence<TCompleteType>> cfg
-			) where TMessageContext : IMessageContext
-		{
-			var extended = (client as Client.IBusClient<TMessageContext>);
-			if (extended == null)
-			{
-				throw new InvalidOperationException("Extensions is only available for ExtendableBusClient");
-			}
-			if (cfg == null)
-			{
-				throw new ArgumentNullException(nameof(cfg));
-			}
+    public static class MessageSequenceExtension
+    {
+        public static MessageSequence<TCompleteType> ExecuteSequence<TMessageContext, TCompleteType>(
+            this IBusClient<TMessageContext> client,
+            Func<IMessageChainPublisher<TMessageContext>, MessageSequence<TCompleteType>> cfg
+            ) where TMessageContext : IMessageContext
+        {
+            var extended = (client as Client.IBusClient<TMessageContext>);
+            if (extended == null)
+            {
+                throw new InvalidOperationException("Extensions is only available for ExtendableBusClient");
+            }
+            if (cfg == null)
+            {
+                throw new ArgumentNullException(nameof(cfg));
+            }
 
-			var chainTopology = extended.GetService<IMessageChainTopologyUtil>();
-			var messageDispather = extended.GetService<IMessageChainDispatcher>();
-			var repo = extended.GetService<IMessageSequenceRepository>();
-			var mainCfg = extended.GetService<RawRabbitConfiguration>();
-			
-			var configBuilder = new MessageSequenceBuilder<TMessageContext>(extended, chainTopology, messageDispather, repo, mainCfg);
-			return cfg(configBuilder);
-		}
-	}
+            var chainTopology = extended.GetService<IMessageChainTopologyUtil>();
+            var messageDispather = extended.GetService<IMessageChainDispatcher>();
+            var repo = extended.GetService<IMessageSequenceRepository>();
+            var mainCfg = extended.GetService<RawRabbitConfiguration>();
+            
+            var configBuilder = new MessageSequenceBuilder<TMessageContext>(extended, chainTopology, messageDispather, repo, mainCfg);
+            return cfg(configBuilder);
+        }
+    }
 }

--- a/src/RawRabbit.Extensions/MessageSequence/Model/ExecutionResult.cs
+++ b/src/RawRabbit.Extensions/MessageSequence/Model/ExecutionResult.cs
@@ -2,10 +2,10 @@ using System;
 
 namespace RawRabbit.Extensions.MessageSequence.Model
 {
-	public class ExecutionResult
-	{
-		public Guid StepId { get; set; }
-		public DateTime Time { get; set; }
-		public Type Type { get; set; }
-	}
+    public class ExecutionResult
+    {
+        public Guid StepId { get; set; }
+        public DateTime Time { get; set; }
+        public Type Type { get; set; }
+    }
 }

--- a/src/RawRabbit.Extensions/MessageSequence/Model/ExecutionState.cs
+++ b/src/RawRabbit.Extensions/MessageSequence/Model/ExecutionState.cs
@@ -4,19 +4,19 @@ using System.Threading.Tasks;
 
 namespace RawRabbit.Extensions.MessageSequence.Model
 {
-	public class ExecutionState
-	{
-		public List<ExecutionResult> Skipped { get; set; }
-		public List<ExecutionResult> Completed { get; set; }
-		public Guid GlobalRequestId { get; set; }
-		public bool Aborted { get; set; }
-		public List<Task> HandlerTasks { get; set; }
+    public class ExecutionState
+    {
+        public List<ExecutionResult> Skipped { get; set; }
+        public List<ExecutionResult> Completed { get; set; }
+        public Guid GlobalRequestId { get; set; }
+        public bool Aborted { get; set; }
+        public List<Task> HandlerTasks { get; set; }
 
-		public ExecutionState()
-		{
-			Skipped = new List<ExecutionResult>();
-			Completed = new List<ExecutionResult>();
-			HandlerTasks = new List<Task>();
-		}
-	}
+        public ExecutionState()
+        {
+            Skipped = new List<ExecutionResult>();
+            Completed = new List<ExecutionResult>();
+            HandlerTasks = new List<Task>();
+        }
+    }
 }

--- a/src/RawRabbit.Extensions/MessageSequence/Model/MessageSequence.cs
+++ b/src/RawRabbit.Extensions/MessageSequence/Model/MessageSequence.cs
@@ -3,11 +3,11 @@ using System.Threading.Tasks;
 
 namespace RawRabbit.Extensions.MessageSequence.Model
 {
-	public class MessageSequence<TMessageType>
-	{
-		public Task<TMessageType> Task { get; set; }
-		public bool Aborted { get; set; }
-		public List<ExecutionResult> Completed { get; set; }
-		public List<ExecutionResult> Skipped { get; set; }
-	}
+    public class MessageSequence<TMessageType>
+    {
+        public Task<TMessageType> Task { get; set; }
+        public bool Aborted { get; set; }
+        public List<ExecutionResult> Completed { get; set; }
+        public List<ExecutionResult> Skipped { get; set; }
+    }
 }

--- a/src/RawRabbit.Extensions/MessageSequence/Model/StepDefinition.cs
+++ b/src/RawRabbit.Extensions/MessageSequence/Model/StepDefinition.cs
@@ -4,17 +4,17 @@ using RawRabbit.Context;
 
 namespace RawRabbit.Extensions.MessageSequence.Model
 {
-	public class StepDefinition
-	{
-		public Guid Id { get; private set; }
-		public Func<object, IMessageContext, Task> Handler { get; set; }
-		public Type Type { get; set; }
-		public bool Optional { get; set; }
-		public bool AbortsExecution { get; set; }
+    public class StepDefinition
+    {
+        public Guid Id { get; private set; }
+        public Func<object, IMessageContext, Task> Handler { get; set; }
+        public Type Type { get; set; }
+        public bool Optional { get; set; }
+        public bool AbortsExecution { get; set; }
 
-		public StepDefinition()
-		{
-			Id = Guid.NewGuid();
-		}
-	}
+        public StepDefinition()
+        {
+            Id = Guid.NewGuid();
+        }
+    }
 }

--- a/src/RawRabbit.Extensions/MessageSequence/Model/StepOption.cs
+++ b/src/RawRabbit.Extensions/MessageSequence/Model/StepOption.cs
@@ -1,8 +1,8 @@
 namespace RawRabbit.Extensions.MessageSequence.Model
 {
-	public class StepOption
-	{
-		public bool AbortsExecution { get; set; }
-		public bool Optional { get; set; }
-	}
+    public class StepOption
+    {
+        public bool AbortsExecution { get; set; }
+        public bool Optional { get; set; }
+    }
 }

--- a/src/RawRabbit.Extensions/MessageSequence/Repository/IMessageSequenceRepository.cs
+++ b/src/RawRabbit.Extensions/MessageSequence/Repository/IMessageSequenceRepository.cs
@@ -3,11 +3,11 @@ using System.Threading.Tasks;
 
 namespace RawRabbit.Extensions.MessageSequence.Repository
 {
-	public interface IMessageSequenceRepository
-	{
-		SequenceDefinition Get(Guid globalMessageId);
-		SequenceDefinition GetOrCreate(Guid globalMessageId);
-		void Remove(Guid globalMessageId);
-		void Update(SequenceDefinition definition);
-	}
+    public interface IMessageSequenceRepository
+    {
+        SequenceDefinition Get(Guid globalMessageId);
+        SequenceDefinition GetOrCreate(Guid globalMessageId);
+        void Remove(Guid globalMessageId);
+        void Update(SequenceDefinition definition);
+    }
 }

--- a/src/RawRabbit.Extensions/MessageSequence/Repository/MessageSequenceRepository.cs
+++ b/src/RawRabbit.Extensions/MessageSequence/Repository/MessageSequenceRepository.cs
@@ -6,56 +6,56 @@ using RawRabbit.Extensions.MessageSequence.Model;
 
 namespace RawRabbit.Extensions.MessageSequence.Repository
 {
-	public class MessageSequenceRepository : IMessageSequenceRepository
-	{
-		private readonly ConcurrentDictionary<Guid, SequenceDefinition> _sequenceDictionary;
+    public class MessageSequenceRepository : IMessageSequenceRepository
+    {
+        private readonly ConcurrentDictionary<Guid, SequenceDefinition> _sequenceDictionary;
 
-		public MessageSequenceRepository()
-		{
-			_sequenceDictionary = new ConcurrentDictionary<Guid, SequenceDefinition>();
-		}
+        public MessageSequenceRepository()
+        {
+            _sequenceDictionary = new ConcurrentDictionary<Guid, SequenceDefinition>();
+        }
 
-		public SequenceDefinition Get(Guid globalMessageId)
-		{
-			SequenceDefinition sequence;
-			_sequenceDictionary.TryGetValue(globalMessageId, out sequence);
-			return sequence;
-		}
+        public SequenceDefinition Get(Guid globalMessageId)
+        {
+            SequenceDefinition sequence;
+            _sequenceDictionary.TryGetValue(globalMessageId, out sequence);
+            return sequence;
+        }
 
-		public SequenceDefinition GetOrCreate(Guid globalMessageId)
-		{
-			SequenceDefinition sequence;
-			if (_sequenceDictionary.TryGetValue(globalMessageId, out sequence))
-			{
-				return sequence;
-			}
-			return _sequenceDictionary.GetOrAdd(globalMessageId, new SequenceDefinition {GlobalMessageId = globalMessageId});
-		}
+        public SequenceDefinition GetOrCreate(Guid globalMessageId)
+        {
+            SequenceDefinition sequence;
+            if (_sequenceDictionary.TryGetValue(globalMessageId, out sequence))
+            {
+                return sequence;
+            }
+            return _sequenceDictionary.GetOrAdd(globalMessageId, new SequenceDefinition {GlobalMessageId = globalMessageId});
+        }
 
-		public void Remove(Guid globalMessageId)
-		{
-			SequenceDefinition removed;
-			_sequenceDictionary.TryRemove(globalMessageId, out removed);
-		}
+        public void Remove(Guid globalMessageId)
+        {
+            SequenceDefinition removed;
+            _sequenceDictionary.TryRemove(globalMessageId, out removed);
+        }
 
-		public void Update(SequenceDefinition definition)
-		{
-			/* Do noting in this in-memory implementation */
-		}
-	}
+        public void Update(SequenceDefinition definition)
+        {
+            /* Do noting in this in-memory implementation */
+        }
+    }
 
-	public class SequenceDefinition
-	{
-		public Guid GlobalMessageId { get; set; }
-		public List<StepDefinition> StepDefinitions { get; set; }
-		public ExecutionState State { get; set; }
-		public TaskCompletionSource<object> TaskCompletionSource { get; set; }
+    public class SequenceDefinition
+    {
+        public Guid GlobalMessageId { get; set; }
+        public List<StepDefinition> StepDefinitions { get; set; }
+        public ExecutionState State { get; set; }
+        public TaskCompletionSource<object> TaskCompletionSource { get; set; }
 
-		public SequenceDefinition()
-		{
-			StepDefinitions = new List<StepDefinition>();
-			State = new ExecutionState();
-			TaskCompletionSource = new TaskCompletionSource<object>();
-		}
-	}
+        public SequenceDefinition()
+        {
+            StepDefinitions = new List<StepDefinition>();
+            State = new ExecutionState();
+            TaskCompletionSource = new TaskCompletionSource<object>();
+        }
+    }
 }

--- a/src/RawRabbit.Extensions/TopologyUpdater/Configuration/Abstraction/IExchangeUpdateBuilder.cs
+++ b/src/RawRabbit.Extensions/TopologyUpdater/Configuration/Abstraction/IExchangeUpdateBuilder.cs
@@ -4,10 +4,10 @@ using RawRabbit.Extensions.TopologyUpdater.Model;
 
 namespace RawRabbit.Extensions.TopologyUpdater.Configuration.Abstraction
 {
-	public interface IExchangeUpdateBuilder
-	{
-		ITopologySelector UseConfiguration(Action<IExchangeConfigurationBuilder> cfgAction, Func<string, string> bindingKeyTransformer = null);
-		ITopologySelector UseConfiguration(ExchangeUpdateConfiguration configuration);
-		ITopologySelector UseConventions<TMessage>(Func<string, string> bindingKeyTransformer = null);
-	}
+    public interface IExchangeUpdateBuilder
+    {
+        ITopologySelector UseConfiguration(Action<IExchangeConfigurationBuilder> cfgAction, Func<string, string> bindingKeyTransformer = null);
+        ITopologySelector UseConfiguration(ExchangeUpdateConfiguration configuration);
+        ITopologySelector UseConventions<TMessage>(Func<string, string> bindingKeyTransformer = null);
+    }
 }

--- a/src/RawRabbit.Extensions/TopologyUpdater/Configuration/Abstraction/ITopologySelector.cs
+++ b/src/RawRabbit.Extensions/TopologyUpdater/Configuration/Abstraction/ITopologySelector.cs
@@ -2,11 +2,11 @@
 
 namespace RawRabbit.Extensions.TopologyUpdater.Configuration.Abstraction
 {
-	public interface ITopologySelector
-	{
-		IExchangeUpdateBuilder ForExchange(string name);
-		IExchangeUpdateBuilder ExchangeForMessage<TMessage>();
-		ITopologySelector UseConventionForExchange<TMessage>();
-		ITopologySelector UseConventionForExchange(params Type[] messageTypes);
-	}
+    public interface ITopologySelector
+    {
+        IExchangeUpdateBuilder ForExchange(string name);
+        IExchangeUpdateBuilder ExchangeForMessage<TMessage>();
+        ITopologySelector UseConventionForExchange<TMessage>();
+        ITopologySelector UseConventionForExchange(params Type[] messageTypes);
+    }
 }

--- a/src/RawRabbit.Extensions/TopologyUpdater/Configuration/TopologyUpdateBuilder.cs
+++ b/src/RawRabbit.Extensions/TopologyUpdater/Configuration/TopologyUpdateBuilder.cs
@@ -8,87 +8,87 @@ using RawRabbit.Extensions.TopologyUpdater.Model;
 
 namespace RawRabbit.Extensions.TopologyUpdater.Configuration
 {
-	public class TopologyUpdateBuilder : ITopologySelector, IExchangeUpdateBuilder
-	{
-		private readonly INamingConventions _conventions;
-		private readonly RawRabbitConfiguration _config;
-		public List<ExchangeUpdateConfiguration> Exchanges { get; set; }
-		private ExchangeUpdateConfiguration _current;
+    public class TopologyUpdateBuilder : ITopologySelector, IExchangeUpdateBuilder
+    {
+        private readonly INamingConventions _conventions;
+        private readonly RawRabbitConfiguration _config;
+        public List<ExchangeUpdateConfiguration> Exchanges { get; set; }
+        private ExchangeUpdateConfiguration _current;
 
-		public TopologyUpdateBuilder(INamingConventions conventions, RawRabbitConfiguration config)
-		{
-			_conventions = conventions;
-			_config = config;
-			Exchanges = new List<ExchangeUpdateConfiguration>();
-		}
+        public TopologyUpdateBuilder(INamingConventions conventions, RawRabbitConfiguration config)
+        {
+            _conventions = conventions;
+            _config = config;
+            Exchanges = new List<ExchangeUpdateConfiguration>();
+        }
 
-		#region ITopologySelector
-		public IExchangeUpdateBuilder ForExchange(string name)
-		{
-			_current = new ExchangeUpdateConfiguration { ExchangeName = name };
-			return this;
-		}
+        #region ITopologySelector
+        public IExchangeUpdateBuilder ForExchange(string name)
+        {
+            _current = new ExchangeUpdateConfiguration { ExchangeName = name };
+            return this;
+        }
 
-		public IExchangeUpdateBuilder ExchangeForMessage<TMessage>()
-		{
-			_current = new ExchangeUpdateConfiguration
-			{
-				ExchangeName = _conventions.ExchangeNamingConvention(typeof(TMessage))
-			};
-			return this;
-		}
+        public IExchangeUpdateBuilder ExchangeForMessage<TMessage>()
+        {
+            _current = new ExchangeUpdateConfiguration
+            {
+                ExchangeName = _conventions.ExchangeNamingConvention(typeof(TMessage))
+            };
+            return this;
+        }
 
-		public ITopologySelector UseConventionForExchange<TMessage>()
-		{
-			UseConventionForExchange(typeof(TMessage));
-			return this;
-		}
+        public ITopologySelector UseConventionForExchange<TMessage>()
+        {
+            UseConventionForExchange(typeof(TMessage));
+            return this;
+        }
 
-		public ITopologySelector UseConventionForExchange(params Type[] messageTypes)
-		{
-			foreach (var messageType in messageTypes)
-			{
-				Exchanges.Add(new ExchangeUpdateConfiguration(_config.Exchange)
-				{
-					ExchangeName = _conventions.ExchangeNamingConvention(messageType)
-				});
-			}
-			return this;
-		}
-		#endregion
+        public ITopologySelector UseConventionForExchange(params Type[] messageTypes)
+        {
+            foreach (var messageType in messageTypes)
+            {
+                Exchanges.Add(new ExchangeUpdateConfiguration(_config.Exchange)
+                {
+                    ExchangeName = _conventions.ExchangeNamingConvention(messageType)
+                });
+            }
+            return this;
+        }
+        #endregion
 
-		#region IExchangeUpdateBuilder
-		public ITopologySelector UseConfiguration(Action<IExchangeConfigurationBuilder> cfgAction, Func<string, string> bindingKeyTransformer = null)
-		{
-			var builder = new ExchangeConfigurationBuilder(new ExchangeUpdateConfiguration(_config.Exchange));
-			cfgAction(builder);
-			var cfg = builder.Configuration as ExchangeUpdateConfiguration;
-			cfg.ExchangeName = _current.ExchangeName;
-			if (bindingKeyTransformer != null)
-			{
-				cfg.BindingTransformer = bindingKeyTransformer;
-			}
-			Exchanges.Add(cfg);
-			return this;
-		}
+        #region IExchangeUpdateBuilder
+        public ITopologySelector UseConfiguration(Action<IExchangeConfigurationBuilder> cfgAction, Func<string, string> bindingKeyTransformer = null)
+        {
+            var builder = new ExchangeConfigurationBuilder(new ExchangeUpdateConfiguration(_config.Exchange));
+            cfgAction(builder);
+            var cfg = builder.Configuration as ExchangeUpdateConfiguration;
+            cfg.ExchangeName = _current.ExchangeName;
+            if (bindingKeyTransformer != null)
+            {
+                cfg.BindingTransformer = bindingKeyTransformer;
+            }
+            Exchanges.Add(cfg);
+            return this;
+        }
 
-		public ITopologySelector UseConfiguration(ExchangeUpdateConfiguration configuration)
-		{
-			configuration.ExchangeName = _current.ExchangeName;
-			Exchanges.Add(configuration);
-			return this;
-		}
+        public ITopologySelector UseConfiguration(ExchangeUpdateConfiguration configuration)
+        {
+            configuration.ExchangeName = _current.ExchangeName;
+            Exchanges.Add(configuration);
+            return this;
+        }
 
-		public ITopologySelector UseConventions<TMessage>(Func<string, string> bindingKeyTransformer = null)
-		{
-			_current.ExchangeName = _conventions.ExchangeNamingConvention(typeof(TMessage));
-			if (bindingKeyTransformer != null)
-			{
-				_current.BindingTransformer = bindingKeyTransformer;
-			}
-			Exchanges.Add(_current);
-			return this;
-		}
-		#endregion
-	}
+        public ITopologySelector UseConventions<TMessage>(Func<string, string> bindingKeyTransformer = null)
+        {
+            _current.ExchangeName = _conventions.ExchangeNamingConvention(typeof(TMessage));
+            if (bindingKeyTransformer != null)
+            {
+                _current.BindingTransformer = bindingKeyTransformer;
+            }
+            Exchanges.Add(_current);
+            return this;
+        }
+        #endregion
+    }
 }

--- a/src/RawRabbit.Extensions/TopologyUpdater/Core/Abstraction/IBindingProvider.cs
+++ b/src/RawRabbit.Extensions/TopologyUpdater/Core/Abstraction/IBindingProvider.cs
@@ -4,8 +4,8 @@ using RawRabbit.Extensions.TopologyUpdater.Model;
 
 namespace RawRabbit.Extensions.TopologyUpdater.Core.Abstraction
 {
-	public interface IBindingProvider
-	{
-		Task<List<Binding>> GetBindingsAsync(string exchangeName);
-	}
+    public interface IBindingProvider
+    {
+        Task<List<Binding>> GetBindingsAsync(string exchangeName);
+    }
 }

--- a/src/RawRabbit.Extensions/TopologyUpdater/Core/Abstraction/IExchangeUpdater.cs
+++ b/src/RawRabbit.Extensions/TopologyUpdater/Core/Abstraction/IExchangeUpdater.cs
@@ -5,9 +5,9 @@ using RawRabbit.Extensions.TopologyUpdater.Model;
 
 namespace RawRabbit.Extensions.TopologyUpdater.Core.Abstraction
 {
-	public interface IExchangeUpdater
-	{
-		Task<ExchangeUpdateResult> UpdateExchangeAsync(ExchangeUpdateConfiguration config);
-		Task<IEnumerable<ExchangeUpdateResult>> UpdateExchangesAsync(IEnumerable<ExchangeUpdateConfiguration> configs);
-	}
+    public interface IExchangeUpdater
+    {
+        Task<ExchangeUpdateResult> UpdateExchangeAsync(ExchangeUpdateConfiguration config);
+        Task<IEnumerable<ExchangeUpdateResult>> UpdateExchangesAsync(IEnumerable<ExchangeUpdateConfiguration> configs);
+    }
 }

--- a/src/RawRabbit.Extensions/TopologyUpdater/Core/BindingProvider.cs
+++ b/src/RawRabbit.Extensions/TopologyUpdater/Core/BindingProvider.cs
@@ -12,44 +12,44 @@ using RawRabbit.Extensions.TopologyUpdater.Model;
 
 namespace RawRabbit.Extensions.TopologyUpdater.Core
 {
-	public class BindingProvider : IBindingProvider
-	{
-		private readonly HttpClient _httpClient;
-		private const string UriEncodedDefaultVhost = "%2f";
-		private const string DefaultVhost = "/";
-		private const string BindingsPath = "bindings/source";
+    public class BindingProvider : IBindingProvider
+    {
+        private readonly HttpClient _httpClient;
+        private const string UriEncodedDefaultVhost = "%2f";
+        private const string DefaultVhost = "/";
+        private const string BindingsPath = "bindings/source";
 
-		public BindingProvider(RawRabbitConfiguration config)
-		{
-			var vHost = string.Equals(config.VirtualHost, DefaultVhost)
-					? UriEncodedDefaultVhost
-					: config.VirtualHost;
+        public BindingProvider(RawRabbitConfiguration config)
+        {
+            var vHost = string.Equals(config.VirtualHost, DefaultVhost)
+                    ? UriEncodedDefaultVhost
+                    : config.VirtualHost;
 
-			_httpClient = new HttpClient(new HttpClientHandler
-			{
-				Credentials = new NetworkCredential(config.Username, config.Password)
-			})
-			{
-				BaseAddress = new Uri($"http://{config.Hostnames.FirstOrDefault()}:15672/api/exchanges/{vHost}/")
-			};
-		}
+            _httpClient = new HttpClient(new HttpClientHandler
+            {
+                Credentials = new NetworkCredential(config.Username, config.Password)
+            })
+            {
+                BaseAddress = new Uri($"http://{config.Hostnames.FirstOrDefault()}:15672/api/exchanges/{vHost}/")
+            };
+        }
 
-		public Task<List<Binding>> GetBindingsAsync(string exchangeName)
-		{
-			return _httpClient
-				.GetAsync($"{exchangeName}/{BindingsPath}")
-				.ContinueWith(async tResponse =>
-				{
-					if (!tResponse.IsCompleted || !tResponse.Result.IsSuccessStatusCode)
-					{
-						return new List<Binding>();
-					}
+        public Task<List<Binding>> GetBindingsAsync(string exchangeName)
+        {
+            return _httpClient
+                .GetAsync($"{exchangeName}/{BindingsPath}")
+                .ContinueWith(async tResponse =>
+                {
+                    if (!tResponse.IsCompleted || !tResponse.Result.IsSuccessStatusCode)
+                    {
+                        return new List<Binding>();
+                    }
 
-					var responseStr = await tResponse.Result.Content.ReadAsStringAsync();
-					var bindings = JsonConvert.DeserializeObject<List<Binding>>(responseStr);
-					return bindings;
-				})
-				.Unwrap();
-		}
-	}
+                    var responseStr = await tResponse.Result.Content.ReadAsStringAsync();
+                    var bindings = JsonConvert.DeserializeObject<List<Binding>>(responseStr);
+                    return bindings;
+                })
+                .Unwrap();
+        }
+    }
 }

--- a/src/RawRabbit.Extensions/TopologyUpdater/Core/ExchangeUpdater.cs
+++ b/src/RawRabbit.Extensions/TopologyUpdater/Core/ExchangeUpdater.cs
@@ -10,58 +10,58 @@ using RawRabbit.Extensions.TopologyUpdater.Model;
 
 namespace RawRabbit.Extensions.TopologyUpdater.Core
 {
-	public class ExchangeUpdater : IExchangeUpdater
-	{
-		private readonly IBindingProvider _bindingProvider;
-		private readonly IChannelFactory _channelFactory;
-		private const string QueueDestination = "queue";
+    public class ExchangeUpdater : IExchangeUpdater
+    {
+        private readonly IBindingProvider _bindingProvider;
+        private readonly IChannelFactory _channelFactory;
+        private const string QueueDestination = "queue";
 
-		public ExchangeUpdater(IBindingProvider bindingProvider, IChannelFactory channelFactory)
-		{
-			_bindingProvider = bindingProvider;
-			_channelFactory = channelFactory;
-		}
+        public ExchangeUpdater(IBindingProvider bindingProvider, IChannelFactory channelFactory)
+        {
+            _bindingProvider = bindingProvider;
+            _channelFactory = channelFactory;
+        }
 
-		public Task<ExchangeUpdateResult> UpdateExchangeAsync(ExchangeUpdateConfiguration config)
-		{
-			var channelTask = _channelFactory.GetChannelAsync();
-			var bindingsTask = _bindingProvider.GetBindingsAsync(config.ExchangeName);
+        public Task<ExchangeUpdateResult> UpdateExchangeAsync(ExchangeUpdateConfiguration config)
+        {
+            var channelTask = _channelFactory.GetChannelAsync();
+            var bindingsTask = _bindingProvider.GetBindingsAsync(config.ExchangeName);
 
-			return Task
-				.WhenAll(channelTask, bindingsTask)
-				.ContinueWith(t =>
-				{
-					var channel = channelTask.Result;
-					var stopWatch = Stopwatch.StartNew();
-					channel.ExchangeDelete(config.ExchangeName);
-					channel.ExchangeDeclare(config.ExchangeName, config.ExchangeType.ToString(), config.Durable, config.AutoDelete, config.Arguments);
-					foreach (var binding in bindingsTask.Result ?? Enumerable.Empty<Binding>())
-					{
-						binding.RoutingKey = config.BindingTransformer(binding.RoutingKey);
-						if (string.Equals(binding.DestinationType, QueueDestination, StringComparison.CurrentCultureIgnoreCase))
-						{
-							channel.QueueBind(binding.Destination, config.ExchangeName, binding.RoutingKey);
-						}
-					}
-					stopWatch.Stop();
-					return new ExchangeUpdateResult
-					{
-						Exchange = config,
-						Bindings = bindingsTask.Result,
-						ExecutionTime = stopWatch.Elapsed
-					};
-				});
-		}
+            return Task
+                .WhenAll(channelTask, bindingsTask)
+                .ContinueWith(t =>
+                {
+                    var channel = channelTask.Result;
+                    var stopWatch = Stopwatch.StartNew();
+                    channel.ExchangeDelete(config.ExchangeName);
+                    channel.ExchangeDeclare(config.ExchangeName, config.ExchangeType.ToString(), config.Durable, config.AutoDelete, config.Arguments);
+                    foreach (var binding in bindingsTask.Result ?? Enumerable.Empty<Binding>())
+                    {
+                        binding.RoutingKey = config.BindingTransformer(binding.RoutingKey);
+                        if (string.Equals(binding.DestinationType, QueueDestination, StringComparison.CurrentCultureIgnoreCase))
+                        {
+                            channel.QueueBind(binding.Destination, config.ExchangeName, binding.RoutingKey);
+                        }
+                    }
+                    stopWatch.Stop();
+                    return new ExchangeUpdateResult
+                    {
+                        Exchange = config,
+                        Bindings = bindingsTask.Result,
+                        ExecutionTime = stopWatch.Elapsed
+                    };
+                });
+        }
 
-		public Task<IEnumerable<ExchangeUpdateResult>>  UpdateExchangesAsync(IEnumerable<ExchangeUpdateConfiguration> configs)
-		{
-			var updateTasks = configs
-				.Select(UpdateExchangeAsync)
-				.ToArray();
+        public Task<IEnumerable<ExchangeUpdateResult>>  UpdateExchangesAsync(IEnumerable<ExchangeUpdateConfiguration> configs)
+        {
+            var updateTasks = configs
+                .Select(UpdateExchangeAsync)
+                .ToArray();
 
-			return Task
-				.WhenAll(updateTasks)
-				.ContinueWith(t => updateTasks.Select(ut => ut.Result));
-		}
-	}
+            return Task
+                .WhenAll(updateTasks)
+                .ContinueWith(t => updateTasks.Select(ut => ut.Result));
+        }
+    }
 }

--- a/src/RawRabbit.Extensions/TopologyUpdater/Model/Binding.cs
+++ b/src/RawRabbit.Extensions/TopologyUpdater/Model/Binding.cs
@@ -2,17 +2,17 @@
 
 namespace RawRabbit.Extensions.TopologyUpdater.Model
 {
-	public class Binding
-	{
-		public string Source { get; set; }
-		public string Vhost { get; set; }
-		public string Destination { get; set; }
-		[JsonProperty("destination_type")]
-		public string DestinationType { get; set; }
-		[JsonProperty("routing_key")]
-		public string RoutingKey { get; set; }
-		public object Arguments { get; set; }
-		[JsonProperty("properties_key")]
-		public string PropertiesKey { get; set; }
-	}
+    public class Binding
+    {
+        public string Source { get; set; }
+        public string Vhost { get; set; }
+        public string Destination { get; set; }
+        [JsonProperty("destination_type")]
+        public string DestinationType { get; set; }
+        [JsonProperty("routing_key")]
+        public string RoutingKey { get; set; }
+        public object Arguments { get; set; }
+        [JsonProperty("properties_key")]
+        public string PropertiesKey { get; set; }
+    }
 }

--- a/src/RawRabbit.Extensions/TopologyUpdater/Model/ExchangeUpdateConfiguration.cs
+++ b/src/RawRabbit.Extensions/TopologyUpdater/Model/ExchangeUpdateConfiguration.cs
@@ -4,18 +4,18 @@ using RawRabbit.Configuration.Exchange;
 
 namespace RawRabbit.Extensions.TopologyUpdater.Model
 {
-	public class ExchangeUpdateConfiguration : ExchangeConfiguration
-	{
-		public Func<string, string> BindingTransformer { get; set; }
+    public class ExchangeUpdateConfiguration : ExchangeConfiguration
+    {
+        public Func<string, string> BindingTransformer { get; set; }
 
-		public ExchangeUpdateConfiguration(GeneralExchangeConfiguration exchange) : base(exchange)
-		{
-			BindingTransformer = s => s;
-		}
+        public ExchangeUpdateConfiguration(GeneralExchangeConfiguration exchange) : base(exchange)
+        {
+            BindingTransformer = s => s;
+        }
 
-		public ExchangeUpdateConfiguration()
-		{
-			BindingTransformer = s => s;
-		}
-	}
+        public ExchangeUpdateConfiguration()
+        {
+            BindingTransformer = s => s;
+        }
+    }
 }

--- a/src/RawRabbit.Extensions/TopologyUpdater/Model/ExchangeUpdateResult.cs
+++ b/src/RawRabbit.Extensions/TopologyUpdater/Model/ExchangeUpdateResult.cs
@@ -4,10 +4,10 @@ using RawRabbit.Configuration.Exchange;
 
 namespace RawRabbit.Extensions.TopologyUpdater.Model
 {
-	public class ExchangeUpdateResult
-	{
-		public ExchangeConfiguration Exchange { get; set; }
-		public List<Binding> Bindings { get; set; }
-		public TimeSpan ExecutionTime { get; set; }
-	}
+    public class ExchangeUpdateResult
+    {
+        public ExchangeConfiguration Exchange { get; set; }
+        public List<Binding> Bindings { get; set; }
+        public TimeSpan ExecutionTime { get; set; }
+    }
 }

--- a/src/RawRabbit.Extensions/TopologyUpdater/Model/TopologyUpdateResult.cs
+++ b/src/RawRabbit.Extensions/TopologyUpdater/Model/TopologyUpdateResult.cs
@@ -2,8 +2,8 @@
 
 namespace RawRabbit.Extensions.TopologyUpdater.Model
 {
-	public class TopologyUpdateResult
-	{
-		public List<ExchangeUpdateResult> Exchanges { get; set; }
-	}
+    public class TopologyUpdateResult
+    {
+        public List<ExchangeUpdateResult> Exchanges { get; set; }
+    }
 }

--- a/src/RawRabbit.Extensions/TopologyUpdater/TopologyUpdaterExtension.cs
+++ b/src/RawRabbit.Extensions/TopologyUpdater/TopologyUpdaterExtension.cs
@@ -11,34 +11,34 @@ using RawRabbit.Extensions.TopologyUpdater.Model;
 
 namespace RawRabbit.Extensions.TopologyUpdater
 {
-	public static class TopologyUpdaterExtension
-	{
-		public static Task<TopologyUpdateResult> UpdateTopologyAsync<TMessageContext>(this IBusClient<TMessageContext> client, Action<ITopologySelector> config) where TMessageContext : IMessageContext
-		{
-			var extended = (client as Client.IBusClient<TMessageContext>);
-			if (extended == null)
-			{
-				throw new InvalidOperationException("Extensions is only available for ExtendableBusClient");
-			}
+    public static class TopologyUpdaterExtension
+    {
+        public static Task<TopologyUpdateResult> UpdateTopologyAsync<TMessageContext>(this IBusClient<TMessageContext> client, Action<ITopologySelector> config) where TMessageContext : IMessageContext
+        {
+            var extended = (client as Client.IBusClient<TMessageContext>);
+            if (extended == null)
+            {
+                throw new InvalidOperationException("Extensions is only available for ExtendableBusClient");
+            }
 
-			var conventions = extended.GetService<INamingConventions>();
-			var clientConfig = extended.GetService<RawRabbitConfiguration>();
-			var exchangeUpdater = extended.GetService<IExchangeUpdater>();
+            var conventions = extended.GetService<INamingConventions>();
+            var clientConfig = extended.GetService<RawRabbitConfiguration>();
+            var exchangeUpdater = extended.GetService<IExchangeUpdater>();
 
-			var configBuilder = new TopologyUpdateBuilder(conventions, clientConfig);
-			config(configBuilder);
-			var exchangeConfig = configBuilder.Exchanges
-				.GroupBy(x => x.ExchangeName)
-				.Select(g => g.LastOrDefault());
+            var configBuilder = new TopologyUpdateBuilder(conventions, clientConfig);
+            config(configBuilder);
+            var exchangeConfig = configBuilder.Exchanges
+                .GroupBy(x => x.ExchangeName)
+                .Select(g => g.LastOrDefault());
 
-			var exchangesTask =  exchangeUpdater.UpdateExchangesAsync(exchangeConfig);
+            var exchangesTask =  exchangeUpdater.UpdateExchangesAsync(exchangeConfig);
 
-			return Task
-				.WhenAll(exchangesTask)
-				.ContinueWith(t => new TopologyUpdateResult
-				{
-					Exchanges = exchangesTask.Result.ToList()
-				});
-		}
-	}
+            return Task
+                .WhenAll(exchangesTask)
+                .ContinueWith(t => new TopologyUpdateResult
+                {
+                    Exchanges = exchangesTask.Result.ToList()
+                });
+        }
+    }
 }

--- a/src/RawRabbit.Extensions/project.json
+++ b/src/RawRabbit.Extensions/project.json
@@ -1,23 +1,23 @@
 ﻿{
-	"title": "RawRabbit.Extensions",
-	"version": "1.10.2-*",
-	"description": "Make the most of RawRabbit with these extensions",
-	"authors": [ "par.dahlman" ],
-	"packOptions": {
-		"iconUrl": "http://pardahlman.se/raw/icon.png",
-		"projectUrl": "https://github.com/pardahlman/RawRabbit",
-		"tags": [ "rabbitmq", "raw", "rawrabbit", "extensions" ],
-		"publishExclude": [ "**.xproj", "**.user", "**.vspscc" ]
-	},
+    "title": "RawRabbit.Extensions",
+    "version": "1.10.2-*",
+    "description": "Make the most of RawRabbit with these extensions",
+    "authors": [ "par.dahlman" ],
+    "packOptions": {
+        "iconUrl": "http://pardahlman.se/raw/icon.png",
+        "projectUrl": "https://github.com/pardahlman/RawRabbit",
+        "tags": [ "rabbitmq", "raw", "rawrabbit", "extensions" ],
+        "publishExclude": [ "**.xproj", "**.user", "**.vspscc" ]
+    },
 
-	"dependencies": {
-		"RawRabbit": { "target": "project" },
-		"RawRabbit.vNext": { "target": "project" },
-		"System.Net.Http": "4.1.0"
-	},
+    "dependencies": {
+        "RawRabbit": { "target": "project" },
+        "RawRabbit.vNext": { "target": "project" },
+        "System.Net.Http": "4.1.0"
+    },
 
-	"frameworks": {
-		"netstandard1.5": {},
-		"net451": {}
-	}
+    "frameworks": {
+        "netstandard1.5": {},
+        "net451": {}
+    }
 }

--- a/src/RawRabbit.Logging.Log4Net/Logger.cs
+++ b/src/RawRabbit.Logging.Log4Net/Logger.cs
@@ -3,33 +3,33 @@ using log4net;
 
 namespace RawRabbit.Logging.Log4Net
 {
-	public class Logger : ILogger
-	{
-		private readonly ILog _log4Net;
+    public class Logger : ILogger
+    {
+        private readonly ILog _log4Net;
 
-		public Logger(ILog log4Net)
-		{
-			_log4Net = log4Net;
-		}
+        public Logger(ILog log4Net)
+        {
+            _log4Net = log4Net;
+        }
 
-		public void LogDebug(string format, params object[] args)
-		{
-			_log4Net.DebugFormat(format, args);
-		}
+        public void LogDebug(string format, params object[] args)
+        {
+            _log4Net.DebugFormat(format, args);
+        }
 
-		public void LogInformation(string format, params object[] args)
-		{
-			_log4Net.InfoFormat(format, args);
-		}
+        public void LogInformation(string format, params object[] args)
+        {
+            _log4Net.InfoFormat(format, args);
+        }
 
-		public void LogWarning(string format, params object[] args)
-		{
-			_log4Net.WarnFormat(format,args);
-		}
+        public void LogWarning(string format, params object[] args)
+        {
+            _log4Net.WarnFormat(format,args);
+        }
 
-		public void LogError(string message, Exception exception)
-		{
-			_log4Net.Error(message, exception);
-		}
-	}
+        public void LogError(string message, Exception exception)
+        {
+            _log4Net.Error(message, exception);
+        }
+    }
 }

--- a/src/RawRabbit.Logging.Log4Net/LoggerFactory.cs
+++ b/src/RawRabbit.Logging.Log4Net/LoggerFactory.cs
@@ -1,15 +1,15 @@
 namespace RawRabbit.Logging.Log4Net
 {
-	public class LoggerFactory : ILoggerFactory {
+    public class LoggerFactory : ILoggerFactory {
 
-		public LogLevel MinimumLevel { get; set; }
+        public LogLevel MinimumLevel { get; set; }
 
-		public ILogger CreateLogger(string categoryName)
-		{
-			var log4net = global::log4net.LogManager.GetLogger(categoryName);
-			return new Logger(log4net);
-		}
+        public ILogger CreateLogger(string categoryName)
+        {
+            var log4net = global::log4net.LogManager.GetLogger(categoryName);
+            return new Logger(log4net);
+        }
 
-		public void Dispose() { }
-	}
+        public void Dispose() { }
+    }
 }

--- a/src/RawRabbit.Logging.Log4Net/project.json
+++ b/src/RawRabbit.Logging.Log4Net/project.json
@@ -1,22 +1,22 @@
 ﻿{
-	"title": "RawRabbit.Logging.Log4Net",
-	"version": "1.10.2-*",
-	"authors": [ "par.dahlman" ],
-	"description": "Write RawRabbit's logs with Log4Net",
+    "title": "RawRabbit.Logging.Log4Net",
+    "version": "1.10.2-*",
+    "authors": [ "par.dahlman" ],
+    "description": "Write RawRabbit's logs with Log4Net",
 
-	"packOptions": {
-		"iconUrl": "http://pardahlman.se/raw/icon.png",
-		"projectUrl": "https://github.com/pardahlman/RawRabbit",
-		"tags": [ "raw", "rabbit", "rawrabbit", "rabbitmq", "logger", "log4net" ],
-		"publishExclude": [ "**.xproj", "**.user", "**.vspscc" ]
-	},
+    "packOptions": {
+        "iconUrl": "http://pardahlman.se/raw/icon.png",
+        "projectUrl": "https://github.com/pardahlman/RawRabbit",
+        "tags": [ "raw", "rabbit", "rawrabbit", "rabbitmq", "logger", "log4net" ],
+        "publishExclude": [ "**.xproj", "**.user", "**.vspscc" ]
+    },
 
-	"dependencies": {
-		"RawRabbit": { "target": "project" },
-		"log4net": "2.0.5"
-	},
+    "dependencies": {
+        "RawRabbit": { "target": "project" },
+        "log4net": "2.0.5"
+    },
 
-	"frameworks": {
-		"net451": {}
-	}
+    "frameworks": {
+        "net451": {}
+    }
 }

--- a/src/RawRabbit.Logging.NLog/Logger.cs
+++ b/src/RawRabbit.Logging.NLog/Logger.cs
@@ -2,33 +2,33 @@
 
 namespace RawRabbit.Logging.NLog
 {
-	public class Logger : ILogger
-	{
-		private readonly global::NLog.ILogger _nlog;
+    public class Logger : ILogger
+    {
+        private readonly global::NLog.ILogger _nlog;
 
-		public Logger(global::NLog.ILogger nlog)
-		{
-			_nlog = nlog;
-		}
+        public Logger(global::NLog.ILogger nlog)
+        {
+            _nlog = nlog;
+        }
 
-		public void LogDebug(string format, params object[] args)
-		{
-			_nlog.Debug(format, args);
-		}
+        public void LogDebug(string format, params object[] args)
+        {
+            _nlog.Debug(format, args);
+        }
 
-		public void LogInformation(string format, params object[] args)
-		{
-			_nlog.Info(format, args);
-		}
+        public void LogInformation(string format, params object[] args)
+        {
+            _nlog.Info(format, args);
+        }
 
-		public void LogWarning(string format, params object[] args)
-		{
-			_nlog.Warn(format, args);
-		}
+        public void LogWarning(string format, params object[] args)
+        {
+            _nlog.Warn(format, args);
+        }
 
-		public void LogError(string message, Exception exception)
-		{
-			_nlog.Error(exception,message);
-		}
-	}
+        public void LogError(string message, Exception exception)
+        {
+            _nlog.Error(exception,message);
+        }
+    }
 }

--- a/src/RawRabbit.Logging.NLog/LoggerFactory.cs
+++ b/src/RawRabbit.Logging.NLog/LoggerFactory.cs
@@ -2,23 +2,23 @@
 
 namespace RawRabbit.Logging.NLog
 {
-	public class LoggerFactory : ILoggerFactory
-	{
-		public LogLevel MinimumLevel { get; set; }
+    public class LoggerFactory : ILoggerFactory
+    {
+        public LogLevel MinimumLevel { get; set; }
 
-		private readonly Func<string, global::NLog.Logger> _createFunc;
+        private readonly Func<string, global::NLog.Logger> _createFunc;
 
-		public LoggerFactory(Func<string, global::NLog.Logger> createFunc = null)
-		{
-			_createFunc = createFunc ?? (categoryName => global::NLog.LogManager.GetLogger(categoryName));
-		}
+        public LoggerFactory(Func<string, global::NLog.Logger> createFunc = null)
+        {
+            _createFunc = createFunc ?? (categoryName => global::NLog.LogManager.GetLogger(categoryName));
+        }
 
-		public ILogger CreateLogger(string categoryName)
-		{
-			var nlog = _createFunc(categoryName);
-			return new Logger(nlog);
-		}
+        public ILogger CreateLogger(string categoryName)
+        {
+            var nlog = _createFunc(categoryName);
+            return new Logger(nlog);
+        }
 
-		public void Dispose() { }
-	}
+        public void Dispose() { }
+    }
 }

--- a/src/RawRabbit.Logging.NLog/project.json
+++ b/src/RawRabbit.Logging.NLog/project.json
@@ -1,30 +1,30 @@
 ﻿{
-	"title": "RawRabbit.Logging.NLog",
-	"version": "1.10.2-*",
-	"authors": [ "par.dahlman" ],
-	"description": "Write RawRabbit's logs with NLog",
+    "title": "RawRabbit.Logging.NLog",
+    "version": "1.10.2-*",
+    "authors": [ "par.dahlman" ],
+    "description": "Write RawRabbit's logs with NLog",
 
-	"packOptions": {
-		"iconUrl": "http://pardahlman.se/raw/icon.png",
-		"projectUrl": "https://github.com/pardahlman/RawRabbit",
-		"tags": [ "raw", "rabbit", "rawrabbit", "rabbitmq", "logger", "nlog" ],
-		"publishExclude": [ "**.xproj", "**.user", "**.vspscc" ]
-	},
+    "packOptions": {
+        "iconUrl": "http://pardahlman.se/raw/icon.png",
+        "projectUrl": "https://github.com/pardahlman/RawRabbit",
+        "tags": [ "raw", "rabbit", "rawrabbit", "rabbitmq", "logger", "nlog" ],
+        "publishExclude": [ "**.xproj", "**.user", "**.vspscc" ]
+    },
 
-	"dependencies": {
-		"RawRabbit": { "target": "project" }
-	},
+    "dependencies": {
+        "RawRabbit": { "target": "project" }
+    },
 
-	"frameworks": {
-		"netstandard1.5": {
-			"dependencies": {
-				"NLog": "4.4.0-betaV15"
-			}
-		},
-		"net451": {
-			"dependencies": {
-				"NLog": "4.3.7"
-			}
-		}
-	}
+    "frameworks": {
+        "netstandard1.5": {
+            "dependencies": {
+                "NLog": "4.4.0-betaV15"
+            }
+        },
+        "net451": {
+            "dependencies": {
+                "NLog": "4.3.7"
+            }
+        }
+    }
 }

--- a/src/RawRabbit.Logging.Serilog/Logger.cs
+++ b/src/RawRabbit.Logging.Serilog/Logger.cs
@@ -2,33 +2,33 @@
 
 namespace RawRabbit.Logging.Serilog
 {
-	public class Logger : ILogger
-	{
-		private readonly global::Serilog.ILogger _serilog;
+    public class Logger : ILogger
+    {
+        private readonly global::Serilog.ILogger _serilog;
 
-		public Logger(global::Serilog.ILogger serilog)
-		{
-			_serilog = serilog;
-		}
+        public Logger(global::Serilog.ILogger serilog)
+        {
+            _serilog = serilog;
+        }
 
-		public void LogDebug(string format, params object[] args)
-		{
-			_serilog.Debug(format, args);
-		}
+        public void LogDebug(string format, params object[] args)
+        {
+            _serilog.Debug(format, args);
+        }
 
-		public void LogError(string message, Exception exception)
-		{
-			_serilog.Error(exception, message);
-		}
+        public void LogError(string message, Exception exception)
+        {
+            _serilog.Error(exception, message);
+        }
 
-		public void LogInformation(string format, params object[] args)
-		{
-			_serilog.Information(format, args);
-		}
+        public void LogInformation(string format, params object[] args)
+        {
+            _serilog.Information(format, args);
+        }
 
-		public void LogWarning(string format, params object[] args)
-		{
-			_serilog.Warning(format, args);
-		}
-	}
+        public void LogWarning(string format, params object[] args)
+        {
+            _serilog.Warning(format, args);
+        }
+    }
 }

--- a/src/RawRabbit.Logging.Serilog/LoggerFactory.cs
+++ b/src/RawRabbit.Logging.Serilog/LoggerFactory.cs
@@ -3,30 +3,30 @@ using Serilog.Core;
 
 namespace RawRabbit.Logging.Serilog
 {
-	public class LoggerFactory : ILoggerFactory
-	{
-		private readonly global::Serilog.ILogger _logger;
-		private readonly Func<string, global::Serilog.ILogger> _createFunc;
-		public LogLevel MinimumLevel { get; set; }
+    public class LoggerFactory : ILoggerFactory
+    {
+        private readonly global::Serilog.ILogger _logger;
+        private readonly Func<string, global::Serilog.ILogger> _createFunc;
+        public LogLevel MinimumLevel { get; set; }
 
-		public LoggerFactory(global::Serilog.ILogger logger)
-		{
-			_logger = logger;
-		}
+        public LoggerFactory(global::Serilog.ILogger logger)
+        {
+            _logger = logger;
+        }
 
-		public LoggerFactory(Func<string, global::Serilog.ILogger> createFunc = null)
-		{
-			_createFunc = createFunc ?? (category => global::Serilog.Log.ForContext(Constants.SourceContextPropertyName, category));
-		}
+        public LoggerFactory(Func<string, global::Serilog.ILogger> createFunc = null)
+        {
+            _createFunc = createFunc ?? (category => global::Serilog.Log.ForContext(Constants.SourceContextPropertyName, category));
+        }
 
-		public ILogger CreateLogger(string categoryName)
-		{
-			var serilog = _logger ?? _createFunc(categoryName);
-			return new Logger(serilog);
-		}
+        public ILogger CreateLogger(string categoryName)
+        {
+            var serilog = _logger ?? _createFunc(categoryName);
+            return new Logger(serilog);
+        }
 
-		public void Dispose()
-		{
-		}
-	}
+        public void Dispose()
+        {
+        }
+    }
 }

--- a/src/RawRabbit.Logging.Serilog/project.json
+++ b/src/RawRabbit.Logging.Serilog/project.json
@@ -1,22 +1,22 @@
 {
-	"title": "RawRabbit.Logging.Serilog",
-	"version": "1.10.2-*",
-	"authors": [ "par.dahlman" ],
-	"description": "Write RawRabbit's logs with Serilog",
+    "title": "RawRabbit.Logging.Serilog",
+    "version": "1.10.2-*",
+    "authors": [ "par.dahlman" ],
+    "description": "Write RawRabbit's logs with Serilog",
 
-	"packOptions": {
-		"iconUrl": "http://pardahlman.se/raw/icon.png",
-		"projectUrl": "https://github.com/pardahlman/RawRabbit",
-		"tags": [ "raw", "rabbit", "rawrabbit", "rabbitmq", "logger", "serilog" ],
-		"publishExclude": [ "**.xproj", "**.user", "**.vspscc" ]
-	},
+    "packOptions": {
+        "iconUrl": "http://pardahlman.se/raw/icon.png",
+        "projectUrl": "https://github.com/pardahlman/RawRabbit",
+        "tags": [ "raw", "rabbit", "rawrabbit", "rabbitmq", "logger", "serilog" ],
+        "publishExclude": [ "**.xproj", "**.user", "**.vspscc" ]
+    },
 
-	"dependencies": {
-		"RawRabbit": { "target": "project" },
-		"Serilog": "2.1.0"
-	},
-	"frameworks": {
-		"netstandard1.5": {},
-		"net451": {}
-	}
+    "dependencies": {
+        "RawRabbit": { "target": "project" },
+        "Serilog": "2.1.0"
+    },
+    "frameworks": {
+        "netstandard1.5": {},
+        "net451": {}
+    }
 }

--- a/src/RawRabbit.vNext/BusClientFactory.cs
+++ b/src/RawRabbit.vNext/BusClientFactory.cs
@@ -7,49 +7,49 @@ using RawRabbit.vNext.Disposable;
 
 namespace RawRabbit.vNext
 {
-	public class BusClientFactory
-	{
-		public static Disposable.IBusClient CreateDefault(TimeSpan requestTimeout)
-		{
-			var cfg = RawRabbitConfiguration.Local;
-			cfg.RequestTimeout = requestTimeout;
-			return CreateDefault(cfg);
-		}
+    public class BusClientFactory
+    {
+        public static Disposable.IBusClient CreateDefault(TimeSpan requestTimeout)
+        {
+            var cfg = RawRabbitConfiguration.Local;
+            cfg.RequestTimeout = requestTimeout;
+            return CreateDefault(cfg);
+        }
 
-		public static Disposable.IBusClient CreateDefault(RawRabbitConfiguration config)
-		{
-			var addCfg = new Action<IServiceCollection>(s => s.AddSingleton(p => config));
-			var services = new ServiceCollection().AddRawRabbit(null, addCfg);
-			return CreateDefault(services);
-		}
+        public static Disposable.IBusClient CreateDefault(RawRabbitConfiguration config)
+        {
+            var addCfg = new Action<IServiceCollection>(s => s.AddSingleton(p => config));
+            var services = new ServiceCollection().AddRawRabbit(null, addCfg);
+            return CreateDefault(services);
+        }
 
-		public static Disposable.IBusClient CreateDefault(Action<IServiceCollection> custom = null)
-		{
-			var services = new ServiceCollection().AddRawRabbit(null, custom);
-			return CreateDefault(services);
-		}
+        public static Disposable.IBusClient CreateDefault(Action<IServiceCollection> custom = null)
+        {
+            var services = new ServiceCollection().AddRawRabbit(null, custom);
+            return CreateDefault(services);
+        }
 
-		public static Disposable.IBusClient CreateDefault(Action<IConfigurationBuilder> config, Action<IServiceCollection> custom)
-		{
-			var services = new ServiceCollection().AddRawRabbit(config, custom);
-			return CreateDefault(services);
-		}
+        public static Disposable.IBusClient CreateDefault(Action<IConfigurationBuilder> config, Action<IServiceCollection> custom)
+        {
+            var services = new ServiceCollection().AddRawRabbit(config, custom);
+            return CreateDefault(services);
+        }
 
-		public static Disposable.IBusClient CreateDefault(IServiceCollection services)
-		{
-			var serviceProvider = services.BuildServiceProvider();
-			var client = serviceProvider.GetService<IBusClient>();
-			return new Disposable.BusClient(client);
-		}
+        public static Disposable.IBusClient CreateDefault(IServiceCollection services)
+        {
+            var serviceProvider = services.BuildServiceProvider();
+            var client = serviceProvider.GetService<IBusClient>();
+            return new Disposable.BusClient(client);
+        }
 
-		public static Disposable.IBusClient<TMessageContext> CreateDefault<TMessageContext>(Action<IConfigurationBuilder> config = null, Action<IServiceCollection> custom = null) where TMessageContext : IMessageContext
-		{
-			var serviceProvider = new ServiceCollection()
-				.AddRawRabbit<TMessageContext>(config, custom)
-				.BuildServiceProvider();
+        public static Disposable.IBusClient<TMessageContext> CreateDefault<TMessageContext>(Action<IConfigurationBuilder> config = null, Action<IServiceCollection> custom = null) where TMessageContext : IMessageContext
+        {
+            var serviceProvider = new ServiceCollection()
+                .AddRawRabbit<TMessageContext>(config, custom)
+                .BuildServiceProvider();
 
-			var client = serviceProvider.GetService<IBusClient<TMessageContext>>();
-			return new BusClient<TMessageContext>(client);
-		}
-	}
+            var client = serviceProvider.GetService<IBusClient<TMessageContext>>();
+            return new BusClient<TMessageContext>(client);
+        }
+    }
 }

--- a/src/RawRabbit.vNext/Disposable/BusClient.cs
+++ b/src/RawRabbit.vNext/Disposable/BusClient.cs
@@ -9,49 +9,49 @@ using RawRabbit.Context;
 
 namespace RawRabbit.vNext.Disposable
 {
-	public interface IBusClient : RawRabbit.IBusClient, IDisposable { }
+    public interface IBusClient : RawRabbit.IBusClient, IDisposable { }
 
-	public class BusClient : IBusClient
-	{
-		private readonly RawRabbit.IBusClient _client;
+    public class BusClient : IBusClient
+    {
+        private readonly RawRabbit.IBusClient _client;
 
-		public BusClient(RawRabbit.IBusClient client)
-		{
-			_client = client;
-		}
+        public BusClient(RawRabbit.IBusClient client)
+        {
+            _client = client;
+        }
 
-		public void Dispose()
-		{
-			var shutDownTask = ShutdownAsync(TimeSpan.Zero);
-			shutDownTask.GetAwaiter().GetResult();
-		}
+        public void Dispose()
+        {
+            var shutDownTask = ShutdownAsync(TimeSpan.Zero);
+            shutDownTask.GetAwaiter().GetResult();
+        }
 
-		#region Pass-through
-		public Task ShutdownAsync(TimeSpan? graceful = null)
-		{
-			return _client.ShutdownAsync(graceful);
-		}
+        #region Pass-through
+        public Task ShutdownAsync(TimeSpan? graceful = null)
+        {
+            return _client.ShutdownAsync(graceful);
+        }
 
-		public ISubscription SubscribeAsync<T>(Func<T, MessageContext, Task> subscribeMethod, Action<ISubscriptionConfigurationBuilder> configuration = null)
-		{
-			return _client.SubscribeAsync(subscribeMethod, configuration);
-		}
+        public ISubscription SubscribeAsync<T>(Func<T, MessageContext, Task> subscribeMethod, Action<ISubscriptionConfigurationBuilder> configuration = null)
+        {
+            return _client.SubscribeAsync(subscribeMethod, configuration);
+        }
 
-		public Task PublishAsync<T>(T message = default(T), Guid globalMessageId = new Guid(), Action<IPublishConfigurationBuilder> configuration = null)
-		{
-			return _client.PublishAsync(message, globalMessageId, configuration);
-		}
+        public Task PublishAsync<T>(T message = default(T), Guid globalMessageId = new Guid(), Action<IPublishConfigurationBuilder> configuration = null)
+        {
+            return _client.PublishAsync(message, globalMessageId, configuration);
+        }
 
-		public ISubscription RespondAsync<TRequest, TResponse>(Func<TRequest, MessageContext, Task<TResponse>> onMessage, Action<IResponderConfigurationBuilder> configuration = null)
-		{
-			return _client.RespondAsync(onMessage, configuration);
-		}
+        public ISubscription RespondAsync<TRequest, TResponse>(Func<TRequest, MessageContext, Task<TResponse>> onMessage, Action<IResponderConfigurationBuilder> configuration = null)
+        {
+            return _client.RespondAsync(onMessage, configuration);
+        }
 
-		public Task<TResponse> RequestAsync<TRequest, TResponse>(TRequest message = default(TRequest), Guid globalMessageId = new Guid(),
-			Action<IRequestConfigurationBuilder> configuration = null)
-		{
-			return _client.RequestAsync<TRequest, TResponse>(message, globalMessageId, configuration);
-		}
-		#endregion
-	}
+        public Task<TResponse> RequestAsync<TRequest, TResponse>(TRequest message = default(TRequest), Guid globalMessageId = new Guid(),
+            Action<IRequestConfigurationBuilder> configuration = null)
+        {
+            return _client.RequestAsync<TRequest, TResponse>(message, globalMessageId, configuration);
+        }
+        #endregion
+    }
 }

--- a/src/RawRabbit.vNext/Disposable/BusClientOfT.cs
+++ b/src/RawRabbit.vNext/Disposable/BusClientOfT.cs
@@ -9,50 +9,50 @@ using RawRabbit.Context;
 
 namespace RawRabbit.vNext.Disposable
 {
-	public interface IBusClient<out TMessageContext> : RawRabbit.IBusClient<TMessageContext>, IDisposable where TMessageContext : IMessageContext
-	{ }
+    public interface IBusClient<out TMessageContext> : RawRabbit.IBusClient<TMessageContext>, IDisposable where TMessageContext : IMessageContext
+    { }
 
-	public class BusClient<TMessageContext> : IBusClient<TMessageContext> where TMessageContext : IMessageContext
-	{
-		private readonly RawRabbit.IBusClient<TMessageContext> _client;
+    public class BusClient<TMessageContext> : IBusClient<TMessageContext> where TMessageContext : IMessageContext
+    {
+        private readonly RawRabbit.IBusClient<TMessageContext> _client;
 
-		public BusClient(RawRabbit.IBusClient<TMessageContext> client)
-		{
-			_client = client;
-		}
+        public BusClient(RawRabbit.IBusClient<TMessageContext> client)
+        {
+            _client = client;
+        }
 
-		public void Dispose()
-		{
-			var shutDownTask = ShutdownAsync(TimeSpan.Zero);
-			shutDownTask.GetAwaiter().GetResult();
-		}
+        public void Dispose()
+        {
+            var shutDownTask = ShutdownAsync(TimeSpan.Zero);
+            shutDownTask.GetAwaiter().GetResult();
+        }
 
-		#region Pass-through
-		public Task ShutdownAsync(TimeSpan? graceful = null)
-		{
-			return _client.ShutdownAsync(graceful);
-		}
+        #region Pass-through
+        public Task ShutdownAsync(TimeSpan? graceful = null)
+        {
+            return _client.ShutdownAsync(graceful);
+        }
 
-		public ISubscription SubscribeAsync<T>(Func<T, TMessageContext, Task> subscribeMethod, Action<ISubscriptionConfigurationBuilder> configuration = null)
-		{
-			return _client.SubscribeAsync(subscribeMethod, configuration);
-		}
+        public ISubscription SubscribeAsync<T>(Func<T, TMessageContext, Task> subscribeMethod, Action<ISubscriptionConfigurationBuilder> configuration = null)
+        {
+            return _client.SubscribeAsync(subscribeMethod, configuration);
+        }
 
-		public Task PublishAsync<T>(T message = default(T), Guid globalMessageId = new Guid(), Action<IPublishConfigurationBuilder> configuration = null)
-		{
-			return _client.PublishAsync(message, globalMessageId, configuration);
-		}
+        public Task PublishAsync<T>(T message = default(T), Guid globalMessageId = new Guid(), Action<IPublishConfigurationBuilder> configuration = null)
+        {
+            return _client.PublishAsync(message, globalMessageId, configuration);
+        }
 
-		public ISubscription RespondAsync<TRequest, TResponse>(Func<TRequest, TMessageContext, Task<TResponse>> onMessage, Action<IResponderConfigurationBuilder> configuration = null)
-		{
-			return _client.RespondAsync(onMessage, configuration);
-		}
+        public ISubscription RespondAsync<TRequest, TResponse>(Func<TRequest, TMessageContext, Task<TResponse>> onMessage, Action<IResponderConfigurationBuilder> configuration = null)
+        {
+            return _client.RespondAsync(onMessage, configuration);
+        }
 
-		public Task<TResponse> RequestAsync<TRequest, TResponse>(TRequest message = default(TRequest), Guid globalMessageId = new Guid(),
-			Action<IRequestConfigurationBuilder> configuration = null)
-		{
-			return _client.RequestAsync<TRequest, TResponse>(message, globalMessageId, configuration);
-		}
-		#endregion
-	}
+        public Task<TResponse> RequestAsync<TRequest, TResponse>(TRequest message = default(TRequest), Guid globalMessageId = new Guid(),
+            Action<IRequestConfigurationBuilder> configuration = null)
+        {
+            return _client.RequestAsync<TRequest, TResponse>(message, globalMessageId, configuration);
+        }
+        #endregion
+    }
 }

--- a/src/RawRabbit.vNext/IServiceCollectionExtensions.cs
+++ b/src/RawRabbit.vNext/IServiceCollectionExtensions.cs
@@ -24,97 +24,97 @@ using RawRabbit.Serialization;
 
 namespace RawRabbit.vNext
 {
-	public static class IServiceCollectionExtensions
-	{
-		public static IServiceCollection AddRawRabbit(this IServiceCollection collection, Action<IConfigurationBuilder> config = null, Action<IServiceCollection> custom = null)
-		{
-			return collection
-				.AddSingleton<IBusClient>(provider =>
-					{
-						LogManager.CurrentFactory = provider.GetService<ILoggerFactory>();
-						return ActivatorUtilities.CreateInstance<BusClient>(provider);
-					})
-				.AddRawRabbit<MessageContext>(config, custom);
-		}
+    public static class IServiceCollectionExtensions
+    {
+        public static IServiceCollection AddRawRabbit(this IServiceCollection collection, Action<IConfigurationBuilder> config = null, Action<IServiceCollection> custom = null)
+        {
+            return collection
+                .AddSingleton<IBusClient>(provider =>
+                    {
+                        LogManager.CurrentFactory = provider.GetService<ILoggerFactory>();
+                        return ActivatorUtilities.CreateInstance<BusClient>(provider);
+                    })
+                .AddRawRabbit<MessageContext>(config, custom);
+        }
 
-		public static IServiceCollection AddRawRabbit<TMessageContext>(this IServiceCollection collection, Action<IConfigurationBuilder> config = null, Action<IServiceCollection> custom = null) where TMessageContext : IMessageContext
-		{
-			if (config != null)
-			{
-				var builder = new ConfigurationBuilder();
-				config?.Invoke(builder);
-				var mainCfg = RawRabbitConfiguration.Local;
-				builder.Build().Bind(mainCfg);
-				mainCfg.Hostnames = mainCfg.Hostnames.Distinct(StringComparer.CurrentCultureIgnoreCase).ToList();
+        public static IServiceCollection AddRawRabbit<TMessageContext>(this IServiceCollection collection, Action<IConfigurationBuilder> config = null, Action<IServiceCollection> custom = null) where TMessageContext : IMessageContext
+        {
+            if (config != null)
+            {
+                var builder = new ConfigurationBuilder();
+                config?.Invoke(builder);
+                var mainCfg = RawRabbitConfiguration.Local;
+                builder.Build().Bind(mainCfg);
+                mainCfg.Hostnames = mainCfg.Hostnames.Distinct(StringComparer.CurrentCultureIgnoreCase).ToList();
 
-				collection.AddSingleton(c => mainCfg);
-			}
-			else
-			{
-				collection.TryAddSingleton(typeof(RawRabbitConfiguration), c => RawRabbitConfiguration.Local);
-			}
+                collection.AddSingleton(c => mainCfg);
+            }
+            else
+            {
+                collection.TryAddSingleton(typeof(RawRabbitConfiguration), c => RawRabbitConfiguration.Local);
+            }
 
-			collection
-				.AddSingleton< IConnectionFactory, ConnectionFactory>(provider =>
-				{
-					var cfg = provider.GetService<RawRabbitConfiguration>();
-					return new ConnectionFactory
-					{
-						VirtualHost = cfg.VirtualHost,
-						UserName = cfg.Username,
-						Password = cfg.Password,
-						Port = cfg.Port,
-						HostName = cfg.Hostnames.FirstOrDefault() ?? string.Empty,
-						AutomaticRecoveryEnabled = cfg.AutomaticRecovery,
-						TopologyRecoveryEnabled = cfg.TopologyRecovery,
-						NetworkRecoveryInterval = cfg.RecoveryInterval,
-						ClientProperties = provider.GetService<IClientPropertyProvider>().GetClientProperties(cfg),
-						Ssl = cfg.Ssl
-					};
-				})
-				.AddSingleton<IClientPropertyProvider, ClientPropertyProvider>()
-				.AddSingleton<ILoggerFactory, LoggerFactory>()
-				.AddTransient<IMessageSerializer, JsonMessageSerializer>()
-				.AddTransient(c => new JsonSerializer
-				{
-					TypeNameAssemblyFormat = FormatterAssemblyStyle.Simple,
-					Formatting = Formatting.None,
-					CheckAdditionalContent = true,
-					ContractResolver = new CamelCasePropertyNamesContractResolver(),
-					ObjectCreationHandling = ObjectCreationHandling.Auto,
-					DefaultValueHandling = DefaultValueHandling.Ignore,
-					TypeNameHandling = TypeNameHandling.All,
-					ReferenceLoopHandling = ReferenceLoopHandling.Serialize,
-					MissingMemberHandling = MissingMemberHandling.Ignore,
-					PreserveReferencesHandling = PreserveReferencesHandling.Objects,
-					NullValueHandling = NullValueHandling.Ignore
+            collection
+                .AddSingleton< IConnectionFactory, ConnectionFactory>(provider =>
+                {
+                    var cfg = provider.GetService<RawRabbitConfiguration>();
+                    return new ConnectionFactory
+                    {
+                        VirtualHost = cfg.VirtualHost,
+                        UserName = cfg.Username,
+                        Password = cfg.Password,
+                        Port = cfg.Port,
+                        HostName = cfg.Hostnames.FirstOrDefault() ?? string.Empty,
+                        AutomaticRecoveryEnabled = cfg.AutomaticRecovery,
+                        TopologyRecoveryEnabled = cfg.TopologyRecovery,
+                        NetworkRecoveryInterval = cfg.RecoveryInterval,
+                        ClientProperties = provider.GetService<IClientPropertyProvider>().GetClientProperties(cfg),
+                        Ssl = cfg.Ssl
+                    };
+                })
+                .AddSingleton<IClientPropertyProvider, ClientPropertyProvider>()
+                .AddSingleton<ILoggerFactory, LoggerFactory>()
+                .AddTransient<IMessageSerializer, JsonMessageSerializer>()
+                .AddTransient(c => new JsonSerializer
+                {
+                    TypeNameAssemblyFormat = FormatterAssemblyStyle.Simple,
+                    Formatting = Formatting.None,
+                    CheckAdditionalContent = true,
+                    ContractResolver = new CamelCasePropertyNamesContractResolver(),
+                    ObjectCreationHandling = ObjectCreationHandling.Auto,
+                    DefaultValueHandling = DefaultValueHandling.Ignore,
+                    TypeNameHandling = TypeNameHandling.All,
+                    ReferenceLoopHandling = ReferenceLoopHandling.Serialize,
+                    MissingMemberHandling = MissingMemberHandling.Ignore,
+                    PreserveReferencesHandling = PreserveReferencesHandling.Objects,
+                    NullValueHandling = NullValueHandling.Ignore
 
-				})
-				.AddTransient<IConsumerFactory, EventingBasicConsumerFactory>()
-				.AddTransient<IErrorHandlingStrategy, DefaultStrategy>()
-				.AddSingleton<IMessageContextProvider<TMessageContext>, MessageContextProvider<TMessageContext>>()
-				.AddSingleton<IContextEnhancer, ContextEnhancer>()
-				.AddSingleton<IBasicPropertiesProvider, BasicPropertiesProvider>()
-				.AddSingleton<IChannelFactory, ChannelFactory>()
-				.AddSingleton(c => ChannelFactoryConfiguration.Default)
-				.AddSingleton<ITopologyProvider, TopologyProvider>()
-				.AddTransient<IConfigurationEvaluator, ConfigurationEvaluator>()
-				.AddTransient<IPublishAcknowledger, PublishAcknowledger>(
-					p => new PublishAcknowledger(p.GetService<RawRabbitConfiguration>().PublishConfirmTimeout)
-				)
-				.AddSingleton<INamingConventions, NamingConventions>()
-				.AddTransient<ISubscriber<TMessageContext>, Subscriber<TMessageContext>>()
-				.AddTransient<IPublisher, Publisher<TMessageContext>>()
-				.AddTransient<IResponder<TMessageContext>, Responder<TMessageContext>>()
-				.AddTransient<IRequester, Requester<TMessageContext>>()
-				.AddSingleton<IBusClient<TMessageContext>>(provider =>
-				{
-					LogManager.CurrentFactory = provider.GetService<ILoggerFactory>();
-					return ActivatorUtilities.CreateInstance<BaseBusClient<TMessageContext>>(provider);
-				});
-			custom?.Invoke(collection);
+                })
+                .AddTransient<IConsumerFactory, EventingBasicConsumerFactory>()
+                .AddTransient<IErrorHandlingStrategy, DefaultStrategy>()
+                .AddSingleton<IMessageContextProvider<TMessageContext>, MessageContextProvider<TMessageContext>>()
+                .AddSingleton<IContextEnhancer, ContextEnhancer>()
+                .AddSingleton<IBasicPropertiesProvider, BasicPropertiesProvider>()
+                .AddSingleton<IChannelFactory, ChannelFactory>()
+                .AddSingleton(c => ChannelFactoryConfiguration.Default)
+                .AddSingleton<ITopologyProvider, TopologyProvider>()
+                .AddTransient<IConfigurationEvaluator, ConfigurationEvaluator>()
+                .AddTransient<IPublishAcknowledger, PublishAcknowledger>(
+                    p => new PublishAcknowledger(p.GetService<RawRabbitConfiguration>().PublishConfirmTimeout)
+                )
+                .AddSingleton<INamingConventions, NamingConventions>()
+                .AddTransient<ISubscriber<TMessageContext>, Subscriber<TMessageContext>>()
+                .AddTransient<IPublisher, Publisher<TMessageContext>>()
+                .AddTransient<IResponder<TMessageContext>, Responder<TMessageContext>>()
+                .AddTransient<IRequester, Requester<TMessageContext>>()
+                .AddSingleton<IBusClient<TMessageContext>>(provider =>
+                {
+                    LogManager.CurrentFactory = provider.GetService<ILoggerFactory>();
+                    return ActivatorUtilities.CreateInstance<BaseBusClient<TMessageContext>>(provider);
+                });
+            custom?.Invoke(collection);
 
-			return collection;
-		}
-	}
+            return collection;
+        }
+    }
 }

--- a/src/RawRabbit.vNext/Logging/LoggerAdapter.cs
+++ b/src/RawRabbit.vNext/Logging/LoggerAdapter.cs
@@ -4,33 +4,33 @@ using ILogger = RawRabbit.Logging.ILogger;
 
 namespace RawRabbit.vNext.Logging
 {
-	public class LoggerAdapter : ILogger
-	{
-		private readonly Microsoft.Extensions.Logging.ILogger _vNextLogger;
+    public class LoggerAdapter : ILogger
+    {
+        private readonly Microsoft.Extensions.Logging.ILogger _vNextLogger;
 
-		public LoggerAdapter(Microsoft.Extensions.Logging.ILogger vNextLogger)
-		{
-			_vNextLogger = vNextLogger;
-		}
+        public LoggerAdapter(Microsoft.Extensions.Logging.ILogger vNextLogger)
+        {
+            _vNextLogger = vNextLogger;
+        }
 
-		public void LogDebug(string format, params object[] args)
-		{
-			_vNextLogger.LogDebug(format,args);
-		}
+        public void LogDebug(string format, params object[] args)
+        {
+            _vNextLogger.LogDebug(format,args);
+        }
 
-		public void LogInformation(string format, params object[] args)
-		{
-			_vNextLogger.LogInformation(format, args);
-		}
+        public void LogInformation(string format, params object[] args)
+        {
+            _vNextLogger.LogInformation(format, args);
+        }
 
-		public void LogWarning(string format, params object[] args)
-		{
-			_vNextLogger.LogWarning(format, args);
-		}
+        public void LogWarning(string format, params object[] args)
+        {
+            _vNextLogger.LogWarning(format, args);
+        }
 
-		public void LogError(string message, Exception exception)
-		{
-			_vNextLogger.LogError(message, exception);
-		}
-	}
+        public void LogError(string message, Exception exception)
+        {
+            _vNextLogger.LogError(message, exception);
+        }
+    }
 }

--- a/src/RawRabbit.vNext/Logging/LoggingFactory.cs
+++ b/src/RawRabbit.vNext/Logging/LoggingFactory.cs
@@ -4,29 +4,29 @@ using RawRabbit.Logging;
 
 namespace RawRabbit.vNext.Logging
 {
-	public class LoggingFactory : ILoggerFactory
-	{
-		private readonly Microsoft.Extensions.Logging.ILoggerFactory _vNextFactory;
+    public class LoggingFactory : ILoggerFactory
+    {
+        private readonly Microsoft.Extensions.Logging.ILoggerFactory _vNextFactory;
 
-		public static ILoggerFactory ApplicationLogger(IServiceProvider provider)
-		{
-			return new LoggingFactory(provider.GetService<Microsoft.Extensions.Logging.ILoggerFactory>());
-		}
+        public static ILoggerFactory ApplicationLogger(IServiceProvider provider)
+        {
+            return new LoggingFactory(provider.GetService<Microsoft.Extensions.Logging.ILoggerFactory>());
+        }
 
-		public LoggingFactory(Microsoft.Extensions.Logging.ILoggerFactory vNextFactory)
-		{
-			_vNextFactory = vNextFactory;
-		}
+        public LoggingFactory(Microsoft.Extensions.Logging.ILoggerFactory vNextFactory)
+        {
+            _vNextFactory = vNextFactory;
+        }
 
-		public void Dispose()
-		{
-			_vNextFactory.Dispose();
-		}
+        public void Dispose()
+        {
+            _vNextFactory.Dispose();
+        }
 
-		public ILogger CreateLogger(string categoryName)
-		{
-			var vNextLogger =  _vNextFactory.CreateLogger(categoryName);
-			return new LoggerAdapter(vNextLogger);
-		}
-	}
+        public ILogger CreateLogger(string categoryName)
+        {
+            var vNextLogger =  _vNextFactory.CreateLogger(categoryName);
+            return new LoggerAdapter(vNextLogger);
+        }
+    }
 }

--- a/src/RawRabbit.vNext/project.json
+++ b/src/RawRabbit.vNext/project.json
@@ -1,24 +1,24 @@
 ﻿{
-	"version": "1.10.2-*",
-	"authors": [ "pardahlman", "enrique-avalon" ],
-	"description": "Take advantage of vNext for your RawRabbit setup. Extension for IServiceCollection, IConfiguration support and much more!",
-	"packOptions": {
-		"iconUrl": "http://pardahlman.se/raw/icon.png",
-		"projectUrl": "https://github.com/pardahlman/RawRabbit",
-		"tags": [ "rabbitmq", "raw", "rawrabbit", "attributes" ],
-		"publishExclude": [ "**.xproj", "**.user", "**.vspscc" ]
-	},
+    "version": "1.10.2-*",
+    "authors": [ "pardahlman", "enrique-avalon" ],
+    "description": "Take advantage of vNext for your RawRabbit setup. Extension for IServiceCollection, IConfiguration support and much more!",
+    "packOptions": {
+        "iconUrl": "http://pardahlman.se/raw/icon.png",
+        "projectUrl": "https://github.com/pardahlman/RawRabbit",
+        "tags": [ "rabbitmq", "raw", "rawrabbit", "attributes" ],
+        "publishExclude": [ "**.xproj", "**.user", "**.vspscc" ]
+    },
 
-	"dependencies": {
-		"RawRabbit": { "target": "project" },
-		"Microsoft.Extensions.DependencyInjection": "1.0.0",
-		"Microsoft.Extensions.Logging": "1.0.0",
-		"Microsoft.Extensions.Configuration": "1.0.0",
-		"Microsoft.Extensions.Configuration.Binder": "1.0.0"
-	},
+    "dependencies": {
+        "RawRabbit": { "target": "project" },
+        "Microsoft.Extensions.DependencyInjection": "1.0.0",
+        "Microsoft.Extensions.Logging": "1.0.0",
+        "Microsoft.Extensions.Configuration": "1.0.0",
+        "Microsoft.Extensions.Configuration.Binder": "1.0.0"
+    },
 
-	"frameworks": {
-		"netstandard1.5": {},
-		"net451": {}
-	}
+    "frameworks": {
+        "netstandard1.5": {},
+        "net451": {}
+    }
 }

--- a/src/RawRabbit/BusClient.cs
+++ b/src/RawRabbit/BusClient.cs
@@ -4,12 +4,12 @@ using RawRabbit.Operations.Abstraction;
 
 namespace RawRabbit
 {
-	public interface IBusClient : IBusClient<MessageContext> { }
+    public interface IBusClient : IBusClient<MessageContext> { }
 
-	public class BusClient : BaseBusClient<MessageContext>, IBusClient
-	{
-		public BusClient(IConfigurationEvaluator configEval, ISubscriber<MessageContext> subscriber, IPublisher publisher, IResponder<MessageContext> responder, IRequester requester)
-			: base(configEval, subscriber, publisher, responder, requester)
-		{ }
-	}
+    public class BusClient : BaseBusClient<MessageContext>, IBusClient
+    {
+        public BusClient(IConfigurationEvaluator configEval, ISubscriber<MessageContext> subscriber, IPublisher publisher, IResponder<MessageContext> responder, IRequester requester)
+            : base(configEval, subscriber, publisher, responder, requester)
+        { }
+    }
 }

--- a/src/RawRabbit/Channel/Abstraction/IChannelFactory.cs
+++ b/src/RawRabbit/Channel/Abstraction/IChannelFactory.cs
@@ -4,20 +4,20 @@ using RabbitMQ.Client;
 
 namespace RawRabbit.Channel.Abstraction
 {
-	public interface IChannelFactory : IDisposable
-	{
-		IModel CreateChannel(IConnection connection = null);
+    public interface IChannelFactory : IDisposable
+    {
+        IModel CreateChannel(IConnection connection = null);
 
-		/// <summary>
-		/// Retrieves a channel that is disposed by the channel factory
-		/// </summary>
-		/// <returns>A new or existing instance of an IModel</returns>
-		Task<IModel> GetChannelAsync();
-		/// <summary>
-		/// Creates a new istance of a channal that the caller is responsible
-		/// in closing and disposing.
-		/// </summary>
-		/// <returns>A new instance of an IModel</returns>
-		Task<IModel> CreateChannelAsync(IConnection connection = null);
-	}
+        /// <summary>
+        /// Retrieves a channel that is disposed by the channel factory
+        /// </summary>
+        /// <returns>A new or existing instance of an IModel</returns>
+        Task<IModel> GetChannelAsync();
+        /// <summary>
+        /// Creates a new istance of a channal that the caller is responsible
+        /// in closing and disposing.
+        /// </summary>
+        /// <returns>A new instance of an IModel</returns>
+        Task<IModel> CreateChannelAsync(IConnection connection = null);
+    }
 }

--- a/src/RawRabbit/Channel/ChannelFactory.cs
+++ b/src/RawRabbit/Channel/ChannelFactory.cs
@@ -13,339 +13,339 @@ using RawRabbit.Logging;
 
 namespace RawRabbit.Channel
 {
-	public class ChannelFactory : IChannelFactory
-	{
-		private readonly ConcurrentQueue<TaskCompletionSource<IModel>> _requestQueue;
-		private readonly ILogger _logger = LogManager.GetLogger<ChannelFactory>();
-		internal readonly ChannelFactoryConfiguration _channelConfig;
-		private readonly IConnectionFactory _connectionFactory;
-		private readonly RawRabbitConfiguration _config;
-		internal readonly LinkedList<IModel> _channels;
-		private LinkedListNode<IModel> _current;
-		private readonly object _channelLock = new object();
-		private readonly object _processLock = new object();
-		private Timer _scaleTimer;
-		private IConnection _connection;
-		private bool _processingRequests;
+    public class ChannelFactory : IChannelFactory
+    {
+        private readonly ConcurrentQueue<TaskCompletionSource<IModel>> _requestQueue;
+        private readonly ILogger _logger = LogManager.GetLogger<ChannelFactory>();
+        internal readonly ChannelFactoryConfiguration _channelConfig;
+        private readonly IConnectionFactory _connectionFactory;
+        private readonly RawRabbitConfiguration _config;
+        internal readonly LinkedList<IModel> _channels;
+        private LinkedListNode<IModel> _current;
+        private readonly object _channelLock = new object();
+        private readonly object _processLock = new object();
+        private Timer _scaleTimer;
+        private IConnection _connection;
+        private bool _processingRequests;
 
-		public ChannelFactory(IConnectionFactory connectionFactory, RawRabbitConfiguration config, ChannelFactoryConfiguration channelConfig)
-		{
-			_connectionFactory = connectionFactory;
-			_config = config;
-			_channelConfig = channelConfig;
-			_requestQueue = new ConcurrentQueue<TaskCompletionSource<IModel>>();
-			_channels = new LinkedList<IModel>();
+        public ChannelFactory(IConnectionFactory connectionFactory, RawRabbitConfiguration config, ChannelFactoryConfiguration channelConfig)
+        {
+            _connectionFactory = connectionFactory;
+            _config = config;
+            _channelConfig = channelConfig;
+            _requestQueue = new ConcurrentQueue<TaskCompletionSource<IModel>>();
+            _channels = new LinkedList<IModel>();
 
-			ConnectToBroker();
-			Initialize();
-		}
+            ConnectToBroker();
+            Initialize();
+        }
 
-		protected virtual void ConnectToBroker()
-		{
-			try
-			{
-				_connection = _connectionFactory.CreateConnection(_config.Hostnames);
-				SetupConnectionRecovery(_connection);
-			}
-			catch (BrokerUnreachableException e)
-			{
-				_logger.LogError("Unable to connect to broker", e);
-				throw e.InnerException;
-			}
-		}
+        protected virtual void ConnectToBroker()
+        {
+            try
+            {
+                _connection = _connectionFactory.CreateConnection(_config.Hostnames);
+                SetupConnectionRecovery(_connection);
+            }
+            catch (BrokerUnreachableException e)
+            {
+                _logger.LogError("Unable to connect to broker", e);
+                throw e.InnerException;
+            }
+        }
 
-		protected virtual void SetupConnectionRecovery(IConnection connection = null)
-		{
-			connection = connection ?? _connection;
-			var recoverable = connection as IRecoverable;
-			if (recoverable == null)
-			{
-				_logger.LogInformation("Connection is not Recoverable. Failed connection will cause unhandled exception to be thrown.");
-				return;
-			}
-			_logger.LogDebug("Setting up Connection Recovery");
-			recoverable.Recovery += (sender, args) =>
-			{
-				_logger.LogInformation($"Connection has been recovered. Starting channel processing.");
-				EnsureRequestsAreHandled();
-			};
-		}
+        protected virtual void SetupConnectionRecovery(IConnection connection = null)
+        {
+            connection = connection ?? _connection;
+            var recoverable = connection as IRecoverable;
+            if (recoverable == null)
+            {
+                _logger.LogInformation("Connection is not Recoverable. Failed connection will cause unhandled exception to be thrown.");
+                return;
+            }
+            _logger.LogDebug("Setting up Connection Recovery");
+            recoverable.Recovery += (sender, args) =>
+            {
+                _logger.LogInformation($"Connection has been recovered. Starting channel processing.");
+                EnsureRequestsAreHandled();
+            };
+        }
 
-		internal virtual void Initialize()
-		{
-			_logger.LogDebug($"Initiating {_channelConfig.InitialChannelCount} channels.");
-			for (var i = 0; i < _channelConfig.InitialChannelCount; i++)
-			{
-				if (i > _channelConfig.MaxChannelCount)
-				{
-					_logger.LogDebug($"Trying to create channel number {i}, but max allowed channels are {_channelConfig.MaxChannelCount}");
-					continue;
-				}
-				CreateAndWireupAsync().Wait();
-			}
-			_current = _channels.First;
+        internal virtual void Initialize()
+        {
+            _logger.LogDebug($"Initiating {_channelConfig.InitialChannelCount} channels.");
+            for (var i = 0; i < _channelConfig.InitialChannelCount; i++)
+            {
+                if (i > _channelConfig.MaxChannelCount)
+                {
+                    _logger.LogDebug($"Trying to create channel number {i}, but max allowed channels are {_channelConfig.MaxChannelCount}");
+                    continue;
+                }
+                CreateAndWireupAsync().Wait();
+            }
+            _current = _channels.First;
 
-			if (_channelConfig.EnableScaleDown || _channelConfig.EnableScaleUp)
-			{
-				_logger.LogInformation($"Scaling is enabled with interval set to {_channelConfig.ScaleInterval}.");
-				_scaleTimer = new Timer(state =>
-				{
-					AdjustChannelCount(_channels.Count, _requestQueue.Count);
-				}, null, _channelConfig.ScaleInterval, _channelConfig.ScaleInterval);
-			}
-			else
-			{
-				_logger.LogInformation("Channel scaling is disabled.");
-			}
-		}
+            if (_channelConfig.EnableScaleDown || _channelConfig.EnableScaleUp)
+            {
+                _logger.LogInformation($"Scaling is enabled with interval set to {_channelConfig.ScaleInterval}.");
+                _scaleTimer = new Timer(state =>
+                {
+                    AdjustChannelCount(_channels.Count, _requestQueue.Count);
+                }, null, _channelConfig.ScaleInterval, _channelConfig.ScaleInterval);
+            }
+            else
+            {
+                _logger.LogInformation("Channel scaling is disabled.");
+            }
+        }
 
-		internal virtual void AdjustChannelCount(int channelCount, int requestCount)
-		{
-			if (channelCount == 0)
-			{
-				_logger.LogWarning("Channel count is 0. Skipping channel scaling.");
-				return;
-			}
+        internal virtual void AdjustChannelCount(int channelCount, int requestCount)
+        {
+            if (channelCount == 0)
+            {
+                _logger.LogWarning("Channel count is 0. Skipping channel scaling.");
+                return;
+            }
 
-			var workPerChannel = requestCount / channelCount;
-			var canCreateChannel = channelCount < _channelConfig.MaxChannelCount;
-			var canCloseChannel = channelCount > 1;
-			_logger.LogDebug($"Begining channel scaling.\n  Channel count: {channelCount}\n  Work per channel: {workPerChannel}");
+            var workPerChannel = requestCount / channelCount;
+            var canCreateChannel = channelCount < _channelConfig.MaxChannelCount;
+            var canCloseChannel = channelCount > 1;
+            _logger.LogDebug($"Begining channel scaling.\n  Channel count: {channelCount}\n  Work per channel: {workPerChannel}");
 
-			if (_channelConfig.EnableScaleUp && canCreateChannel && workPerChannel > _channelConfig.WorkThreshold)
-			{
-				CreateAndWireupAsync();
-				return;
-			}
-			if (_channelConfig.EnableScaleDown && canCloseChannel && requestCount == 0)
-			{
-				var toClose = _channels.Last.Value;
-				_logger.LogInformation($"Channel '{toClose.ChannelNumber}' will be closed in {_channelConfig.GracefulCloseInterval}.");
-				_channels.Remove(toClose);
+            if (_channelConfig.EnableScaleUp && canCreateChannel && workPerChannel > _channelConfig.WorkThreshold)
+            {
+                CreateAndWireupAsync();
+                return;
+            }
+            if (_channelConfig.EnableScaleDown && canCloseChannel && requestCount == 0)
+            {
+                var toClose = _channels.Last.Value;
+                _logger.LogInformation($"Channel '{toClose.ChannelNumber}' will be closed in {_channelConfig.GracefulCloseInterval}.");
+                _channels.Remove(toClose);
 
-				Timer graceful = null;
-				graceful = new Timer(state =>
-				{
-					graceful?.Dispose();
-					toClose.Dispose();
-				}, null, _channelConfig.GracefulCloseInterval, new TimeSpan(-1));
-			}
-		}
+                Timer graceful = null;
+                graceful = new Timer(state =>
+                {
+                    graceful?.Dispose();
+                    toClose.Dispose();
+                }, null, _channelConfig.GracefulCloseInterval, new TimeSpan(-1));
+            }
+        }
 
-		public void Dispose()
-		{
-			foreach (var channel in _channels)
-			{
-				channel?.Dispose();
-			}
-			_connection?.Dispose();
-			_scaleTimer?.Dispose();
-		}
+        public void Dispose()
+        {
+            foreach (var channel in _channels)
+            {
+                channel?.Dispose();
+            }
+            _connection?.Dispose();
+            _scaleTimer?.Dispose();
+        }
 
-		public IModel GetChannel()
-		{
-			return GetChannelAsync().Result;
-		}
+        public IModel GetChannel()
+        {
+            return GetChannelAsync().Result;
+        }
 
-		public IModel CreateChannel(IConnection connection = null)
-		{
-			return CreateChannelAsync(connection).Result;
-		}
+        public IModel CreateChannel(IConnection connection = null)
+        {
+            return CreateChannelAsync(connection).Result;
+        }
 
-		public Task<IModel> GetChannelAsync()
-		{
-			var tcs = new TaskCompletionSource<IModel>();
-			_requestQueue.Enqueue(tcs);
-			if (_connection.IsOpen)
-			{
-				EnsureRequestsAreHandled();
-			}
-			else
-			{
-				var recoverable = _connection as IRecoverable;
-				if (recoverable == null)
-				{
-					throw new ChannelAvailabilityException("Unable to retrieve chanel. Connection to broker is closed and not recoverable.");
-				}
-			}
-			return tcs.Task;
-		}
+        public Task<IModel> GetChannelAsync()
+        {
+            var tcs = new TaskCompletionSource<IModel>();
+            _requestQueue.Enqueue(tcs);
+            if (_connection.IsOpen)
+            {
+                EnsureRequestsAreHandled();
+            }
+            else
+            {
+                var recoverable = _connection as IRecoverable;
+                if (recoverable == null)
+                {
+                    throw new ChannelAvailabilityException("Unable to retrieve chanel. Connection to broker is closed and not recoverable.");
+                }
+            }
+            return tcs.Task;
+        }
 
-		private void EnsureRequestsAreHandled()
-		{
-			if (_processingRequests)
-			{
-				return;
-			}
-			if (!_channels.Any() && _channelConfig.InitialChannelCount > 0)
-			{
-				_logger.LogInformation("Currently no available channels.");
-				return;
-			}
-			lock (_processLock)
-			{
-				if (_processingRequests)
-				{
-					return;
-				}
-				_processingRequests = true;
-				_logger.LogDebug("Begining to process 'GetChannel' requests.");
-			}
+        private void EnsureRequestsAreHandled()
+        {
+            if (_processingRequests)
+            {
+                return;
+            }
+            if (!_channels.Any() && _channelConfig.InitialChannelCount > 0)
+            {
+                _logger.LogInformation("Currently no available channels.");
+                return;
+            }
+            lock (_processLock)
+            {
+                if (_processingRequests)
+                {
+                    return;
+                }
+                _processingRequests = true;
+                _logger.LogDebug("Begining to process 'GetChannel' requests.");
+            }
 
-			TaskCompletionSource<IModel> channelTcs;
-			while (_requestQueue.TryDequeue(out channelTcs))
-			{
-				lock (_channelLock)
-				{
-					if (_current == null && _channelConfig.InitialChannelCount == 0)
-					{
-						CreateAndWireupAsync().Wait();
-						_current = _channels.First;
-					}
-					_current = _current.Next ?? _channels.First;
+            TaskCompletionSource<IModel> channelTcs;
+            while (_requestQueue.TryDequeue(out channelTcs))
+            {
+                lock (_channelLock)
+                {
+                    if (_current == null && _channelConfig.InitialChannelCount == 0)
+                    {
+                        CreateAndWireupAsync().Wait();
+                        _current = _channels.First;
+                    }
+                    _current = _current.Next ?? _channels.First;
 
-					if (_current.Value.IsOpen)
-					{
-						channelTcs.TrySetResult(_current.Value);
-						continue;
-					}
+                    if (_current.Value.IsOpen)
+                    {
+                        channelTcs.TrySetResult(_current.Value);
+                        continue;
+                    }
 
-					_logger.LogInformation($"Channel '{_current.Value.ChannelNumber}' is closed. Removing it from pool.");
-					_channels.Remove(_current);
+                    _logger.LogInformation($"Channel '{_current.Value.ChannelNumber}' is closed. Removing it from pool.");
+                    _channels.Remove(_current);
 
-					if (_current.Value.CloseReason.Initiator == ShutdownInitiator.Application)
-					{
-						_logger.LogInformation($"Channel '{_current.Value.ChannelNumber}' is closed by application. Disposing channel.");
-						_current.Value.Dispose();
-						if (!_channels.Any())
-						{
-							var newChannelTask = CreateAndWireupAsync();
-							newChannelTask.Wait();
-							_current = _channels.Last;
-							channelTcs.TrySetResult(_current.Value);
-							continue;
-						}
-					}
-				}
+                    if (_current.Value.CloseReason.Initiator == ShutdownInitiator.Application)
+                    {
+                        _logger.LogInformation($"Channel '{_current.Value.ChannelNumber}' is closed by application. Disposing channel.");
+                        _current.Value.Dispose();
+                        if (!_channels.Any())
+                        {
+                            var newChannelTask = CreateAndWireupAsync();
+                            newChannelTask.Wait();
+                            _current = _channels.Last;
+                            channelTcs.TrySetResult(_current.Value);
+                            continue;
+                        }
+                    }
+                }
 
-				var openChannel = _channels.FirstOrDefault(c => c.IsOpen);
-				if (openChannel != null)
-				{
-					_logger.LogInformation($"Using channel '{openChannel.ChannelNumber}', which is open.");
-					channelTcs.TrySetResult(openChannel);
-					continue;
-				}
-				var isRecoverable = _channels.Any(c => c is IRecoverable);
-				if (!isRecoverable)
-				{
-					_processingRequests = false;
-					throw new ChannelAvailabilityException("Unable to retreive channel. All existing channels are closed and none of them are recoverable.");
-				}
+                var openChannel = _channels.FirstOrDefault(c => c.IsOpen);
+                if (openChannel != null)
+                {
+                    _logger.LogInformation($"Using channel '{openChannel.ChannelNumber}', which is open.");
+                    channelTcs.TrySetResult(openChannel);
+                    continue;
+                }
+                var isRecoverable = _channels.Any(c => c is IRecoverable);
+                if (!isRecoverable)
+                {
+                    _processingRequests = false;
+                    throw new ChannelAvailabilityException("Unable to retreive channel. All existing channels are closed and none of them are recoverable.");
+                }
 
-				_logger.LogInformation("Unable to find an open channel. Requeue TaskCompletionSource for future process and abort execution.");
-				_requestQueue.Enqueue(channelTcs);
-				_processingRequests = false;
-				return;
-			}
-			_processingRequests = false;
-			_logger.LogDebug("'GetChannel' has been processed.");
-		}
+                _logger.LogInformation("Unable to find an open channel. Requeue TaskCompletionSource for future process and abort execution.");
+                _requestQueue.Enqueue(channelTcs);
+                _processingRequests = false;
+                return;
+            }
+            _processingRequests = false;
+            _logger.LogDebug("'GetChannel' has been processed.");
+        }
 
-		public Task<IModel> CreateChannelAsync(IConnection connection = null)
-		{
-			return connection != null
-				? Task.FromResult(connection.CreateModel())
-				: GetConnectionAsync().ContinueWith(tConnection => tConnection.Result.CreateModel());
-		}
+        public Task<IModel> CreateChannelAsync(IConnection connection = null)
+        {
+            return connection != null
+                ? Task.FromResult(connection.CreateModel())
+                : GetConnectionAsync().ContinueWith(tConnection => tConnection.Result.CreateModel());
+        }
 
-		internal virtual Task<IModel> CreateAndWireupAsync()
-		{
-			return GetConnectionAsync()
-				.ContinueWith(tConnection =>
-				{
-					var channel = tConnection.Result.CreateModel();
-					_logger.LogInformation($"Channel '{channel.ChannelNumber}' has been created.");
-					var recoverable = channel as IRecoverable;
-					if (recoverable != null)
-					{
-						recoverable.Recovery += (sender, args) =>
-						{
-							if (!_channels.Contains(channel))
-							{
-								_logger.LogInformation($"Channel '{_current.Value.ChannelNumber}' is recovered. Adding it to pool.");
-								_channels.AddLast(channel);
-							}
-						};
-					}
-					_channels.AddLast(new LinkedListNode<IModel>(channel));
-					return channel;
-				});
-		}
+        internal virtual Task<IModel> CreateAndWireupAsync()
+        {
+            return GetConnectionAsync()
+                .ContinueWith(tConnection =>
+                {
+                    var channel = tConnection.Result.CreateModel();
+                    _logger.LogInformation($"Channel '{channel.ChannelNumber}' has been created.");
+                    var recoverable = channel as IRecoverable;
+                    if (recoverable != null)
+                    {
+                        recoverable.Recovery += (sender, args) =>
+                        {
+                            if (!_channels.Contains(channel))
+                            {
+                                _logger.LogInformation($"Channel '{_current.Value.ChannelNumber}' is recovered. Adding it to pool.");
+                                _channels.AddLast(channel);
+                            }
+                        };
+                    }
+                    _channels.AddLast(new LinkedListNode<IModel>(channel));
+                    return channel;
+                });
+        }
 
-		private Task<IConnection> GetConnectionAsync()
-		{
-			if (_connection == null)
-			{
-				_logger.LogDebug($"Creating a new connection for {_config.Hostnames.Count} hosts.");
-				_connection = _connectionFactory.CreateConnection(_config.Hostnames);
-			}
-			if (_connection.IsOpen)
-			{
-				_logger.LogDebug("Existing connection is open and will be used.");
-				return Task.FromResult(_connection);
-			}
-			_logger.LogInformation("The existing connection is not open.");
+        private Task<IConnection> GetConnectionAsync()
+        {
+            if (_connection == null)
+            {
+                _logger.LogDebug($"Creating a new connection for {_config.Hostnames.Count} hosts.");
+                _connection = _connectionFactory.CreateConnection(_config.Hostnames);
+            }
+            if (_connection.IsOpen)
+            {
+                _logger.LogDebug("Existing connection is open and will be used.");
+                return Task.FromResult(_connection);
+            }
+            _logger.LogInformation("The existing connection is not open.");
 
-			if (_connection.CloseReason.Initiator == ShutdownInitiator.Application)
-			{
-				_logger.LogInformation("Connection is closed with Application as initiator. It will not be recovered.");
-				_connection.Dispose();
-				throw new Exception("Application shutdown is initiated by the Application. A new connection will not be created.");
-			}
+            if (_connection.CloseReason.Initiator == ShutdownInitiator.Application)
+            {
+                _logger.LogInformation("Connection is closed with Application as initiator. It will not be recovered.");
+                _connection.Dispose();
+                throw new Exception("Application shutdown is initiated by the Application. A new connection will not be created.");
+            }
 
-			var recoverable = _connection as IRecoverable;
-			if (recoverable == null)
-			{
-				_logger.LogInformation("Connection is not recoverable, trying to create a new connection.");
-				_connection.Dispose();
-				throw new Exception("The non recoverable connection is closed. A channel can not be obtained.");
-			}
+            var recoverable = _connection as IRecoverable;
+            if (recoverable == null)
+            {
+                _logger.LogInformation("Connection is not recoverable, trying to create a new connection.");
+                _connection.Dispose();
+                throw new Exception("The non recoverable connection is closed. A channel can not be obtained.");
+            }
 
-			_logger.LogDebug("Connection is recoverable. Waiting for 'Recovery' event to be triggered. ");
-			var recoverTcs = new TaskCompletionSource<IConnection>();
+            _logger.LogDebug("Connection is recoverable. Waiting for 'Recovery' event to be triggered. ");
+            var recoverTcs = new TaskCompletionSource<IConnection>();
 
-			EventHandler<EventArgs> completeTask = null;
-			completeTask = (sender, args) =>
-			{
-				_logger.LogDebug("Connection has been recovered!");
-				recoverTcs.TrySetResult(recoverable as IConnection);
-				recoverable.Recovery -= completeTask;
-			};
+            EventHandler<EventArgs> completeTask = null;
+            completeTask = (sender, args) =>
+            {
+                _logger.LogDebug("Connection has been recovered!");
+                recoverTcs.TrySetResult(recoverable as IConnection);
+                recoverable.Recovery -= completeTask;
+            };
 
-			recoverable.Recovery += completeTask;
-			return recoverTcs.Task;
-		}
-	}
+            recoverable.Recovery += completeTask;
+            return recoverTcs.Task;
+        }
+    }
 
-	public class ChannelFactoryConfiguration
-	{
-		public bool EnableScaleUp { get; set; }
-		public bool EnableScaleDown { get; set; }
-		public TimeSpan ScaleInterval { get; set; }
-		public TimeSpan GracefulCloseInterval { get; set; }
-		public int MaxChannelCount { get; set; }
-		public int InitialChannelCount { get; set; }
-		public int WorkThreshold { get; set; }
+    public class ChannelFactoryConfiguration
+    {
+        public bool EnableScaleUp { get; set; }
+        public bool EnableScaleDown { get; set; }
+        public TimeSpan ScaleInterval { get; set; }
+        public TimeSpan GracefulCloseInterval { get; set; }
+        public int MaxChannelCount { get; set; }
+        public int InitialChannelCount { get; set; }
+        public int WorkThreshold { get; set; }
 
-		public static ChannelFactoryConfiguration Default => new ChannelFactoryConfiguration
-		{
-			InitialChannelCount = 0,
-			MaxChannelCount = 1,
-			GracefulCloseInterval = TimeSpan.FromMinutes(30),
-			WorkThreshold = 20000,
-			ScaleInterval = TimeSpan.FromSeconds(10),
-			EnableScaleUp = false,
-			EnableScaleDown = false
-		};
-	}
+        public static ChannelFactoryConfiguration Default => new ChannelFactoryConfiguration
+        {
+            InitialChannelCount = 0,
+            MaxChannelCount = 1,
+            GracefulCloseInterval = TimeSpan.FromMinutes(30),
+            WorkThreshold = 20000,
+            ScaleInterval = TimeSpan.FromSeconds(10),
+            EnableScaleUp = false,
+            EnableScaleDown = false
+        };
+    }
 }

--- a/src/RawRabbit/Channel/ThreadBasedChannelFactory.cs
+++ b/src/RawRabbit/Channel/ThreadBasedChannelFactory.cs
@@ -11,190 +11,190 @@ using RawRabbit.Logging;
 
 namespace RawRabbit.Channel
 {
-	public class ThreadBasedChannelFactory : IChannelFactory
-	{
-		private readonly IConnectionFactory _connectionFactory;
-		private ThreadLocal<IModel> _threadChannels; 
-		private IConnection _connection;
-		private readonly ILogger _logger = LogManager.GetLogger<ThreadBasedChannelFactory>();
-		private readonly RawRabbitConfiguration _config;
-		private readonly ConcurrentDictionary<IModel, DateTime> _accessDictionary;
-		private readonly System.Threading.Timer _closeTimer;
+    public class ThreadBasedChannelFactory : IChannelFactory
+    {
+        private readonly IConnectionFactory _connectionFactory;
+        private ThreadLocal<IModel> _threadChannels; 
+        private IConnection _connection;
+        private readonly ILogger _logger = LogManager.GetLogger<ThreadBasedChannelFactory>();
+        private readonly RawRabbitConfiguration _config;
+        private readonly ConcurrentDictionary<IModel, DateTime> _accessDictionary;
+        private readonly System.Threading.Timer _closeTimer;
 
-		public ThreadBasedChannelFactory(RawRabbitConfiguration config, IConnectionFactory connectionFactory)
-		{
-			_connectionFactory = connectionFactory;
-			_accessDictionary = new ConcurrentDictionary<IModel, DateTime>();
-			_config = config;
-			_threadChannels = new ThreadLocal<IModel>(true);
+        public ThreadBasedChannelFactory(RawRabbitConfiguration config, IConnectionFactory connectionFactory)
+        {
+            _connectionFactory = connectionFactory;
+            _accessDictionary = new ConcurrentDictionary<IModel, DateTime>();
+            _config = config;
+            _threadChannels = new ThreadLocal<IModel>(true);
 
-			try
-			{
-				_logger.LogDebug("Connecting to primary host.");
-				_connection = _connectionFactory.CreateConnection(_config.Hostnames);
-				_logger.LogInformation("Successfully established connection.");
-			}
-			catch (BrokerUnreachableException e)
-			{
-				_logger.LogError("Unable to connect to broker", e);
-				throw e.InnerException;
-			}
-			_closeTimer = new System.Threading.Timer(state =>
-			{
-				var enumerator = _accessDictionary.GetEnumerator();
-				while (enumerator.MoveNext())
-				{
-					if (DateTime.Now - enumerator.Current.Value > _config.RequestTimeout)
-					{
-						DateTime lastUsed;
-						if (_accessDictionary.TryRemove(enumerator.Current.Key, out lastUsed))
-						{
-							_logger.LogInformation($"Channel {enumerator.Current.Key.ChannelNumber} was last used {lastUsed}. Closing...");
-							enumerator.Current.Key.Close();
-						}
-					}
-				}
-			}, null, _config.RequestTimeout, _config.RequestTimeout);
-		}
+            try
+            {
+                _logger.LogDebug("Connecting to primary host.");
+                _connection = _connectionFactory.CreateConnection(_config.Hostnames);
+                _logger.LogInformation("Successfully established connection.");
+            }
+            catch (BrokerUnreachableException e)
+            {
+                _logger.LogError("Unable to connect to broker", e);
+                throw e.InnerException;
+            }
+            _closeTimer = new System.Threading.Timer(state =>
+            {
+                var enumerator = _accessDictionary.GetEnumerator();
+                while (enumerator.MoveNext())
+                {
+                    if (DateTime.Now - enumerator.Current.Value > _config.RequestTimeout)
+                    {
+                        DateTime lastUsed;
+                        if (_accessDictionary.TryRemove(enumerator.Current.Key, out lastUsed))
+                        {
+                            _logger.LogInformation($"Channel {enumerator.Current.Key.ChannelNumber} was last used {lastUsed}. Closing...");
+                            enumerator.Current.Key.Close();
+                        }
+                    }
+                }
+            }, null, _config.RequestTimeout, _config.RequestTimeout);
+        }
 
-		public void Dispose()
-		{
-			_connection?.Dispose();
-			foreach (var channel in _threadChannels?.Values ?? Enumerable.Empty<IModel>())
-			{
-				channel?.Dispose();
-			}
-			_threadChannels?.Dispose();
-			_closeTimer?.Dispose();
-			_threadChannels = null;
-		}
+        public void Dispose()
+        {
+            _connection?.Dispose();
+            foreach (var channel in _threadChannels?.Values ?? Enumerable.Empty<IModel>())
+            {
+                channel?.Dispose();
+            }
+            _threadChannels?.Dispose();
+            _closeTimer?.Dispose();
+            _threadChannels = null;
+        }
 
-		public Task<IModel> GetChannelAsync()
-		{
-			if (_threadChannels.Value?.IsOpen ?? false)
-			{
-				_logger.LogDebug($"Using existing channel with id '{_threadChannels.Value.ChannelNumber}' on thread '{Thread.CurrentThread.ManagedThreadId}'");
-				_accessDictionary.AddOrUpdate(_threadChannels.Value, DateTime.Now, (model, time) => DateTime.Now);
-				return Task.FromResult(_threadChannels.Value);
-			}
+        public Task<IModel> GetChannelAsync()
+        {
+            if (_threadChannels.Value?.IsOpen ?? false)
+            {
+                _logger.LogDebug($"Using existing channel with id '{_threadChannels.Value.ChannelNumber}' on thread '{Thread.CurrentThread.ManagedThreadId}'");
+                _accessDictionary.AddOrUpdate(_threadChannels.Value, DateTime.Now, (model, time) => DateTime.Now);
+                return Task.FromResult(_threadChannels.Value);
+            }
 
-			return GetConnectionAsync()
-				.ContinueWith(connectionTask => GetOrCreateChannelAsync(connectionTask.Result))
-				.Unwrap()
-				.ContinueWith(tChannel =>
-				{
-					_accessDictionary.AddOrUpdate(tChannel.Result, DateTime.Now, (model, time) => DateTime.Now);
-					return tChannel.Result;
-				});
-		}
+            return GetConnectionAsync()
+                .ContinueWith(connectionTask => GetOrCreateChannelAsync(connectionTask.Result))
+                .Unwrap()
+                .ContinueWith(tChannel =>
+                {
+                    _accessDictionary.AddOrUpdate(tChannel.Result, DateTime.Now, (model, time) => DateTime.Now);
+                    return tChannel.Result;
+                });
+        }
 
-		private Task<IModel> GetOrCreateChannelAsync(IConnection connection)
-		{
-			if (!connection?.IsOpen ?? true)
-			{
-				_logger.LogInformation("Connection is not open or defined. Waiting for a open connection.");
-				return GetConnectionAsync()
-						.ContinueWith(c => GetOrCreateChannelAsync(c.Result))
-						.Unwrap();
-			}
-			if (_threadChannels.Value == null)
-			{
-				_logger.LogInformation($"Creating a new channel for thread with id '{Thread.CurrentThread.ManagedThreadId}'");
-				_threadChannels.Value = connection.CreateModel();
-				if (_config.AutoCloseConnection && !connection.AutoClose)
-				{
-					_logger.LogInformation($"Setting AutoClose to true for current connection");
-					connection.AutoClose = _config.AutoCloseConnection;
-				}
-				return Task.FromResult(_threadChannels.Value);
-			}
-			if (_threadChannels.Value.IsOpen)
-			{
-				_logger.LogDebug($"Using open channel with id {_threadChannels.Value.ChannelNumber}");
-				return Task.FromResult(_threadChannels.Value);
-			}
+        private Task<IModel> GetOrCreateChannelAsync(IConnection connection)
+        {
+            if (!connection?.IsOpen ?? true)
+            {
+                _logger.LogInformation("Connection is not open or defined. Waiting for a open connection.");
+                return GetConnectionAsync()
+                        .ContinueWith(c => GetOrCreateChannelAsync(c.Result))
+                        .Unwrap();
+            }
+            if (_threadChannels.Value == null)
+            {
+                _logger.LogInformation($"Creating a new channel for thread with id '{Thread.CurrentThread.ManagedThreadId}'");
+                _threadChannels.Value = connection.CreateModel();
+                if (_config.AutoCloseConnection && !connection.AutoClose)
+                {
+                    _logger.LogInformation($"Setting AutoClose to true for current connection");
+                    connection.AutoClose = _config.AutoCloseConnection;
+                }
+                return Task.FromResult(_threadChannels.Value);
+            }
+            if (_threadChannels.Value.IsOpen)
+            {
+                _logger.LogDebug($"Using open channel with id {_threadChannels.Value.ChannelNumber}");
+                return Task.FromResult(_threadChannels.Value);
+            }
 
-			_logger.LogInformation($"Channel {_threadChannels.Value.ChannelNumber} is closed.");
-			if (_threadChannels.Value.CloseReason?.Initiator == ShutdownInitiator.Application)
-			{
-				_logger.LogInformation($"Channel {_threadChannels.Value.ChannelNumber} is closed by application and will not be recovered.");
-				_threadChannels.Value.Dispose();
-				_threadChannels.Value = connection.CreateModel();
-				return Task.FromResult(_threadChannels.Value);
-			}
+            _logger.LogInformation($"Channel {_threadChannels.Value.ChannelNumber} is closed.");
+            if (_threadChannels.Value.CloseReason?.Initiator == ShutdownInitiator.Application)
+            {
+                _logger.LogInformation($"Channel {_threadChannels.Value.ChannelNumber} is closed by application and will not be recovered.");
+                _threadChannels.Value.Dispose();
+                _threadChannels.Value = connection.CreateModel();
+                return Task.FromResult(_threadChannels.Value);
+            }
 
-			var recoveryChannel = _threadChannels.Value as IRecoverable;
-			if (recoveryChannel == null)
-			{
-				_logger.LogInformation("Channel is not recoverable. Opening a new channel.");
-				_threadChannels.Value.Dispose();
-				_threadChannels.Value = connection.CreateModel();
-				return Task.FromResult(_threadChannels.Value);
-			}
+            var recoveryChannel = _threadChannels.Value as IRecoverable;
+            if (recoveryChannel == null)
+            {
+                _logger.LogInformation("Channel is not recoverable. Opening a new channel.");
+                _threadChannels.Value.Dispose();
+                _threadChannels.Value = connection.CreateModel();
+                return Task.FromResult(_threadChannels.Value);
+            }
 
-			_logger.LogDebug("Channel is recoverable. Waiting for 'Recovery' event to be triggered.");
-			var recoverTcs = new TaskCompletionSource<IModel>();
-			recoveryChannel.Recovery += (sender, args) =>
-			{
-				recoverTcs.SetResult(recoveryChannel as IModel);
-			};
-			return recoverTcs.Task;
-		}
+            _logger.LogDebug("Channel is recoverable. Waiting for 'Recovery' event to be triggered.");
+            var recoverTcs = new TaskCompletionSource<IModel>();
+            recoveryChannel.Recovery += (sender, args) =>
+            {
+                recoverTcs.SetResult(recoveryChannel as IModel);
+            };
+            return recoverTcs.Task;
+        }
 
-		private Task<IConnection> GetConnectionAsync()
-		{
-			if (_connection == null)
-			{
-				_logger.LogDebug($"Creating a new connection for {_config.Hostnames.Count} hosts.");
-				_connection = _connectionFactory.CreateConnection(_config.Hostnames);
-			}
-			if (_connection.IsOpen)
-			{
-				_logger.LogDebug("Existing connection is open and will be used.");
-				return Task.FromResult(_connection);
-			}
+        private Task<IConnection> GetConnectionAsync()
+        {
+            if (_connection == null)
+            {
+                _logger.LogDebug($"Creating a new connection for {_config.Hostnames.Count} hosts.");
+                _connection = _connectionFactory.CreateConnection(_config.Hostnames);
+            }
+            if (_connection.IsOpen)
+            {
+                _logger.LogDebug("Existing connection is open and will be used.");
+                return Task.FromResult(_connection);
+            }
 
-			_logger.LogInformation("The existing connection is not open.");
-			var recoverable = _connection as IRecoverable;
-			if (recoverable == null)
-			{
-				_logger.LogInformation("Connection is not recoverable, trying to create a new connection.");
-				_connection.Dispose();
-				try
-				{
-					_connection = _connectionFactory.CreateConnection(_config.Hostnames);
-					return Task.FromResult(_connection);
-				}
-				catch (BrokerUnreachableException)
-				{
-					_logger.LogInformation("None of the hosts are reachable. Waiting five seconds and try again.");
-					return Task
-						.Delay(TimeSpan.FromSeconds(5))
-						.ContinueWith(t => _connectionFactory.CreateConnection(_config.Hostnames));
-				}
-			}
+            _logger.LogInformation("The existing connection is not open.");
+            var recoverable = _connection as IRecoverable;
+            if (recoverable == null)
+            {
+                _logger.LogInformation("Connection is not recoverable, trying to create a new connection.");
+                _connection.Dispose();
+                try
+                {
+                    _connection = _connectionFactory.CreateConnection(_config.Hostnames);
+                    return Task.FromResult(_connection);
+                }
+                catch (BrokerUnreachableException)
+                {
+                    _logger.LogInformation("None of the hosts are reachable. Waiting five seconds and try again.");
+                    return Task
+                        .Delay(TimeSpan.FromSeconds(5))
+                        .ContinueWith(t => _connectionFactory.CreateConnection(_config.Hostnames));
+                }
+            }
 
-			_logger.LogDebug("Connection is recoverable. Waiting for 'Recovery' event to be triggered. ");
-			var recoverTcs = new TaskCompletionSource<IConnection>();
-			recoverable.Recovery += (sender, args) =>
-			{
-				_logger.LogDebug("Connection has been recovered!");
-				recoverTcs.TrySetResult(recoverable as IConnection);
-			};
-			return recoverTcs.Task;
-		}
+            _logger.LogDebug("Connection is recoverable. Waiting for 'Recovery' event to be triggered. ");
+            var recoverTcs = new TaskCompletionSource<IConnection>();
+            recoverable.Recovery += (sender, args) =>
+            {
+                _logger.LogDebug("Connection has been recovered!");
+                recoverTcs.TrySetResult(recoverable as IConnection);
+            };
+            return recoverTcs.Task;
+        }
 
-		public IModel CreateChannel(IConnection connection = null)
-		{
-			return CreateChannelAsync(connection).Result;
-		}
+        public IModel CreateChannel(IConnection connection = null)
+        {
+            return CreateChannelAsync(connection).Result;
+        }
 
-		public Task<IModel> CreateChannelAsync(IConnection connection = null)
-		{
-			var connectionTask = connection != null
-				? Task.FromResult(connection)
-				: GetConnectionAsync();
-			return connectionTask.ContinueWith(c => c.Result.CreateModel());
-		}
-	}
+        public Task<IModel> CreateChannelAsync(IConnection connection = null)
+        {
+            var connectionTask = connection != null
+                ? Task.FromResult(connection)
+                : GetConnectionAsync();
+            return connectionTask.ContinueWith(c => c.Result.CreateModel());
+        }
+    }
 }

--- a/src/RawRabbit/Common/BaseBusClient.cs
+++ b/src/RawRabbit/Common/BaseBusClient.cs
@@ -10,67 +10,67 @@ using RawRabbit.Operations.Abstraction;
 
 namespace RawRabbit.Common
 {
-	public class BaseBusClient<TMessageContext> : IBusClient<TMessageContext> where TMessageContext : IMessageContext
-	{
-		private readonly IConfigurationEvaluator _configEval;
-		private readonly ISubscriber<TMessageContext> _subscriber;
-		private readonly IPublisher _publisher;
-		private readonly IResponder<TMessageContext> _responder;
-		private readonly IRequester _requester;
-		private readonly ILogger _logger = LogManager.GetLogger<BaseBusClient<TMessageContext>>();
-			
-		public BaseBusClient(
-			IConfigurationEvaluator configEval,
-			ISubscriber<TMessageContext> subscriber,
-			IPublisher publisher,
-			IResponder<TMessageContext> responder,
-			IRequester requester)
-		{
-			_configEval = configEval;
-			_subscriber = subscriber;
-			_publisher = publisher;
-			_responder = responder;
-			_requester = requester;
-			_logger.LogInformation("BusClient initialized.");
-		}
+    public class BaseBusClient<TMessageContext> : IBusClient<TMessageContext> where TMessageContext : IMessageContext
+    {
+        private readonly IConfigurationEvaluator _configEval;
+        private readonly ISubscriber<TMessageContext> _subscriber;
+        private readonly IPublisher _publisher;
+        private readonly IResponder<TMessageContext> _responder;
+        private readonly IRequester _requester;
+        private readonly ILogger _logger = LogManager.GetLogger<BaseBusClient<TMessageContext>>();
+            
+        public BaseBusClient(
+            IConfigurationEvaluator configEval,
+            ISubscriber<TMessageContext> subscriber,
+            IPublisher publisher,
+            IResponder<TMessageContext> responder,
+            IRequester requester)
+        {
+            _configEval = configEval;
+            _subscriber = subscriber;
+            _publisher = publisher;
+            _responder = responder;
+            _requester = requester;
+            _logger.LogInformation("BusClient initialized.");
+        }
 
-		public ISubscription SubscribeAsync<T>(Func<T, TMessageContext, Task> subscribeMethod, Action<ISubscriptionConfigurationBuilder> configuration = null)
-		{
-			var config = _configEval.GetConfiguration<T>(configuration);
-			_logger.LogInformation($"Subscribing to message '{typeof(T).Name}' on exchange '{config.Exchange.ExchangeName}' with routing key {config.RoutingKey}.");
-			return _subscriber.SubscribeAsync(subscribeMethod, config);
-		}
+        public ISubscription SubscribeAsync<T>(Func<T, TMessageContext, Task> subscribeMethod, Action<ISubscriptionConfigurationBuilder> configuration = null)
+        {
+            var config = _configEval.GetConfiguration<T>(configuration);
+            _logger.LogInformation($"Subscribing to message '{typeof(T).Name}' on exchange '{config.Exchange.ExchangeName}' with routing key {config.RoutingKey}.");
+            return _subscriber.SubscribeAsync(subscribeMethod, config);
+        }
 
-		public Task PublishAsync<T>(T message = default(T), Guid globalMessageId = new Guid(), Action<IPublishConfigurationBuilder> configuration = null)
-		{
-			var config = _configEval.GetConfiguration<T>(configuration);
-			_logger.LogDebug($"Initiating publish for message '{typeof(T).Name}' on exchange '{config.Exchange.ExchangeName}' with routing key {config.RoutingKey}.");
-			return _publisher.PublishAsync(message, globalMessageId, config);
-		}
+        public Task PublishAsync<T>(T message = default(T), Guid globalMessageId = new Guid(), Action<IPublishConfigurationBuilder> configuration = null)
+        {
+            var config = _configEval.GetConfiguration<T>(configuration);
+            _logger.LogDebug($"Initiating publish for message '{typeof(T).Name}' on exchange '{config.Exchange.ExchangeName}' with routing key {config.RoutingKey}.");
+            return _publisher.PublishAsync(message, globalMessageId, config);
+        }
 
-		public ISubscription RespondAsync<TRequest, TResponse>(Func<TRequest, TMessageContext, Task<TResponse>> onMessage, Action<IResponderConfigurationBuilder> configuration = null)
-		{
-			var config = _configEval.GetConfiguration<TRequest, TResponse>(configuration);
-			_logger.LogInformation($"Responding to to requests '{typeof(TRequest).Name}' with '{typeof(TResponse).Name}'.");
-			return _responder.RespondAsync(onMessage, config);
-		}
+        public ISubscription RespondAsync<TRequest, TResponse>(Func<TRequest, TMessageContext, Task<TResponse>> onMessage, Action<IResponderConfigurationBuilder> configuration = null)
+        {
+            var config = _configEval.GetConfiguration<TRequest, TResponse>(configuration);
+            _logger.LogInformation($"Responding to to requests '{typeof(TRequest).Name}' with '{typeof(TResponse).Name}'.");
+            return _responder.RespondAsync(onMessage, config);
+        }
 
-		public Task<TResponse> RequestAsync<TRequest, TResponse>(TRequest message = default(TRequest), Guid globalMessageId = new Guid(), Action<IRequestConfigurationBuilder> configuration = null)
-		{
-			var config = _configEval.GetConfiguration<TRequest, TResponse>(configuration);
-			_logger.LogDebug($"Requsting message '{typeof(TRequest).Name}' on exchange '{config.Exchange.ExchangeName}' with routing key {config.RoutingKey}.");
-			return _requester.RequestAsync<TRequest, TResponse>(message, globalMessageId, config);
-		}
+        public Task<TResponse> RequestAsync<TRequest, TResponse>(TRequest message = default(TRequest), Guid globalMessageId = new Guid(), Action<IRequestConfigurationBuilder> configuration = null)
+        {
+            var config = _configEval.GetConfiguration<TRequest, TResponse>(configuration);
+            _logger.LogDebug($"Requsting message '{typeof(TRequest).Name}' on exchange '{config.Exchange.ExchangeName}' with routing key {config.RoutingKey}.");
+            return _requester.RequestAsync<TRequest, TResponse>(message, globalMessageId, config);
+        }
 
-		public Task ShutdownAsync(TimeSpan? graceful = null)
-		{
-			_logger.LogDebug("Shutting Down BusClient and its dependencies.");
+        public Task ShutdownAsync(TimeSpan? graceful = null)
+        {
+            _logger.LogDebug("Shutting Down BusClient and its dependencies.");
 
-			var subTask = (_subscriber as IShutdown)?.ShutdownAsync(graceful) ?? Task.FromResult(true);
-			var pubTask = (_publisher as IShutdown)?.ShutdownAsync(graceful) ?? Task.FromResult(true);
-			var reqTask = (_requester as IShutdown)?.ShutdownAsync(graceful) ?? Task.FromResult(true);
-			var respTask = (_responder as IShutdown)?.ShutdownAsync(graceful) ?? Task.FromResult(true);
-			return Task.WhenAll(subTask, pubTask, reqTask, respTask);
-		}
-	}
+            var subTask = (_subscriber as IShutdown)?.ShutdownAsync(graceful) ?? Task.FromResult(true);
+            var pubTask = (_publisher as IShutdown)?.ShutdownAsync(graceful) ?? Task.FromResult(true);
+            var reqTask = (_requester as IShutdown)?.ShutdownAsync(graceful) ?? Task.FromResult(true);
+            var respTask = (_responder as IShutdown)?.ShutdownAsync(graceful) ?? Task.FromResult(true);
+            return Task.WhenAll(subTask, pubTask, reqTask, respTask);
+        }
+    }
 }

--- a/src/RawRabbit/Common/BasicPropertiesProvider.cs
+++ b/src/RawRabbit/Common/BasicPropertiesProvider.cs
@@ -7,52 +7,52 @@ using RawRabbit.Configuration;
 
 namespace RawRabbit.Common
 {
-	public interface IBasicPropertiesProvider
-	{
-		IBasicProperties GetProperties<TMessage>(Action<IBasicProperties> custom = null);
-	}
+    public interface IBasicPropertiesProvider
+    {
+        IBasicProperties GetProperties<TMessage>(Action<IBasicProperties> custom = null);
+    }
 
-	public class BasicPropertiesProvider : IBasicPropertiesProvider
-	{
-		private readonly RawRabbitConfiguration _config;
+    public class BasicPropertiesProvider : IBasicPropertiesProvider
+    {
+        private readonly RawRabbitConfiguration _config;
 
-		public BasicPropertiesProvider(RawRabbitConfiguration config)
-		{
-			_config = config;
-		}
+        public BasicPropertiesProvider(RawRabbitConfiguration config)
+        {
+            _config = config;
+        }
 
-		public IBasicProperties GetProperties<TMessage>(Action<IBasicProperties> custom = null)
-		{
-			var properties = new BasicProperties
-			{
-				MessageId = Guid.NewGuid().ToString(),
-				Headers = new Dictionary<string, object>(),
-				Persistent = _config.PersistentDeliveryMode
-			};
-			custom?.Invoke(properties);
-			properties.Headers.Add(PropertyHeaders.Sent, DateTime.UtcNow.ToString("u"));
-			properties.Headers.Add(PropertyHeaders.MessageType, GetTypeName(typeof(TMessage)));
-			return properties;
-		}
+        public IBasicProperties GetProperties<TMessage>(Action<IBasicProperties> custom = null)
+        {
+            var properties = new BasicProperties
+            {
+                MessageId = Guid.NewGuid().ToString(),
+                Headers = new Dictionary<string, object>(),
+                Persistent = _config.PersistentDeliveryMode
+            };
+            custom?.Invoke(properties);
+            properties.Headers.Add(PropertyHeaders.Sent, DateTime.UtcNow.ToString("u"));
+            properties.Headers.Add(PropertyHeaders.MessageType, GetTypeName(typeof(TMessage)));
+            return properties;
+        }
 
-		private string GetTypeName(Type type)
-		{
-			var name = $"{type.Namespace}.{type.Name}";
-			if (type.GenericTypeArguments.Length > 0)
-			{
-				var shouldInsertComma = false;
-				name += '[';
-				foreach (var genericType in type.GenericTypeArguments)
-				{
-					if (shouldInsertComma)
-						name += ",";
-					name += $"[{GetTypeName(genericType)}]";
-					shouldInsertComma = true;
-				}
-				name += ']';
-			}
-			name += $", {type.GetTypeInfo().Assembly.GetName().Name}";
-			return name;
-		}
-	}
+        private string GetTypeName(Type type)
+        {
+            var name = $"{type.Namespace}.{type.Name}";
+            if (type.GenericTypeArguments.Length > 0)
+            {
+                var shouldInsertComma = false;
+                name += '[';
+                foreach (var genericType in type.GenericTypeArguments)
+                {
+                    if (shouldInsertComma)
+                        name += ",";
+                    name += $"[{GetTypeName(genericType)}]";
+                    shouldInsertComma = true;
+                }
+                name += ']';
+            }
+            name += $", {type.GetTypeInfo().Assembly.GetName().Name}";
+            return name;
+        }
+    }
 }

--- a/src/RawRabbit/Common/ClientPropertyProvider.cs
+++ b/src/RawRabbit/Common/ClientPropertyProvider.cs
@@ -5,31 +5,31 @@ using RawRabbit.Configuration;
 
 namespace RawRabbit.Common
 {
-	public interface IClientPropertyProvider
-	{
-		IDictionary<string, object> GetClientProperties(RawRabbitConfiguration cfg = null);
-	}
+    public interface IClientPropertyProvider
+    {
+        IDictionary<string, object> GetClientProperties(RawRabbitConfiguration cfg = null);
+    }
 
-	public class ClientPropertyProvider : IClientPropertyProvider
-	{
-		public IDictionary<string, object> GetClientProperties(RawRabbitConfiguration cfg = null)
-		{
-			var props = new Dictionary<string, object>
-			{
-				{ "product", "RawRabbit" },
-				{ "version", typeof(BusClient).GetTypeInfo().Assembly.GetName().Version.ToString() },
-				{ "platform", ".NET" },
-				{ "client_directory", typeof(BusClient).GetTypeInfo().Assembly.CodeBase},
-				{ "client_server", Environment.MachineName },
-			};
+    public class ClientPropertyProvider : IClientPropertyProvider
+    {
+        public IDictionary<string, object> GetClientProperties(RawRabbitConfiguration cfg = null)
+        {
+            var props = new Dictionary<string, object>
+            {
+                { "product", "RawRabbit" },
+                { "version", typeof(BusClient).GetTypeInfo().Assembly.GetName().Version.ToString() },
+                { "platform", ".NET" },
+                { "client_directory", typeof(BusClient).GetTypeInfo().Assembly.CodeBase},
+                { "client_server", Environment.MachineName },
+            };
 
-			if (cfg != null)
-			{
-				props.Add("request_timeout", cfg.RequestTimeout.ToString("g"));
-				props.Add("broker_username", cfg.Username);
-			}
+            if (cfg != null)
+            {
+                props.Add("request_timeout", cfg.RequestTimeout.ToString("g"));
+                props.Add("broker_username", cfg.Username);
+            }
 
-			return props;
-		}
-	}
+            return props;
+        }
+    }
 }

--- a/src/RawRabbit/Common/ConfigurationEvaluator.cs
+++ b/src/RawRabbit/Common/ConfigurationEvaluator.cs
@@ -9,126 +9,126 @@ using RawRabbit.Configuration.Subscribe;
 
 namespace RawRabbit.Common
 {
-	public interface IConfigurationEvaluator
-	{
-		SubscriptionConfiguration GetConfiguration<TMessage>(Action<ISubscriptionConfigurationBuilder> configuration = null);
-		PublishConfiguration GetConfiguration<TMessage>(Action<IPublishConfigurationBuilder> configuration);
-		ResponderConfiguration GetConfiguration<TRequest, TResponse>(Action<IResponderConfigurationBuilder> configuration);
-		RequestConfiguration GetConfiguration<TRequest, TResponse>(Action<IRequestConfigurationBuilder> configuration);
+    public interface IConfigurationEvaluator
+    {
+        SubscriptionConfiguration GetConfiguration<TMessage>(Action<ISubscriptionConfigurationBuilder> configuration = null);
+        PublishConfiguration GetConfiguration<TMessage>(Action<IPublishConfigurationBuilder> configuration);
+        ResponderConfiguration GetConfiguration<TRequest, TResponse>(Action<IResponderConfigurationBuilder> configuration);
+        RequestConfiguration GetConfiguration<TRequest, TResponse>(Action<IRequestConfigurationBuilder> configuration);
 
-		SubscriptionConfiguration GetConfiguration(Type messageType, Action<ISubscriptionConfigurationBuilder> configuration = null);
-		PublishConfiguration GetConfiguration(Type messageType, Action<IPublishConfigurationBuilder> configuration);
-		ResponderConfiguration GetConfiguration(Type requestType, Type responseType, Action<IResponderConfigurationBuilder> configuration);
-		RequestConfiguration GetConfiguration(Type requestType, Type responseType, Action<IRequestConfigurationBuilder> configuration);
-	}
+        SubscriptionConfiguration GetConfiguration(Type messageType, Action<ISubscriptionConfigurationBuilder> configuration = null);
+        PublishConfiguration GetConfiguration(Type messageType, Action<IPublishConfigurationBuilder> configuration);
+        ResponderConfiguration GetConfiguration(Type requestType, Type responseType, Action<IResponderConfigurationBuilder> configuration);
+        RequestConfiguration GetConfiguration(Type requestType, Type responseType, Action<IRequestConfigurationBuilder> configuration);
+    }
 
-	public class ConfigurationEvaluator : IConfigurationEvaluator
-	{
-		private readonly RawRabbitConfiguration _clientConfig;
-		private readonly INamingConventions _conventions;
-		private readonly string _directReplyTo = "amq.rabbitmq.reply-to";
+    public class ConfigurationEvaluator : IConfigurationEvaluator
+    {
+        private readonly RawRabbitConfiguration _clientConfig;
+        private readonly INamingConventions _conventions;
+        private readonly string _directReplyTo = "amq.rabbitmq.reply-to";
 
-		public ConfigurationEvaluator(RawRabbitConfiguration clientConfig, INamingConventions conventions)
-		{
-			_clientConfig = clientConfig;
-			_conventions = conventions;
-		}
+        public ConfigurationEvaluator(RawRabbitConfiguration clientConfig, INamingConventions conventions)
+        {
+            _clientConfig = clientConfig;
+            _conventions = conventions;
+        }
 
-		public SubscriptionConfiguration GetConfiguration<TMessage>(Action<ISubscriptionConfigurationBuilder> configuration = null)
-		{
-			return GetConfiguration(typeof(TMessage), configuration);
-		}
+        public SubscriptionConfiguration GetConfiguration<TMessage>(Action<ISubscriptionConfigurationBuilder> configuration = null)
+        {
+            return GetConfiguration(typeof(TMessage), configuration);
+        }
 
-		public PublishConfiguration GetConfiguration<TMessage>(Action<IPublishConfigurationBuilder> configuration)
-		{
-			return GetConfiguration(typeof(TMessage), configuration);
-		}
+        public PublishConfiguration GetConfiguration<TMessage>(Action<IPublishConfigurationBuilder> configuration)
+        {
+            return GetConfiguration(typeof(TMessage), configuration);
+        }
 
-		public ResponderConfiguration GetConfiguration<TRequest, TResponse>(Action<IResponderConfigurationBuilder> configuration)
-		{
-			return GetConfiguration(typeof(TRequest), typeof(TResponse), configuration);
-		}
+        public ResponderConfiguration GetConfiguration<TRequest, TResponse>(Action<IResponderConfigurationBuilder> configuration)
+        {
+            return GetConfiguration(typeof(TRequest), typeof(TResponse), configuration);
+        }
 
-		public RequestConfiguration GetConfiguration<TRequest, TResponse>(Action<IRequestConfigurationBuilder> configuration)
-		{
-			return GetConfiguration(typeof(TRequest), typeof(TResponse), configuration);
-		}
+        public RequestConfiguration GetConfiguration<TRequest, TResponse>(Action<IRequestConfigurationBuilder> configuration)
+        {
+            return GetConfiguration(typeof(TRequest), typeof(TResponse), configuration);
+        }
 
-		public SubscriptionConfiguration GetConfiguration(Type messageType, Action<ISubscriptionConfigurationBuilder> configuration = null)
-		{
-			var routingKey = _conventions.QueueNamingConvention(messageType);
-			var queueConfig = new QueueConfiguration(_clientConfig.Queue)
-			{
-				QueueName = routingKey,
-				NameSuffix = _conventions.SubscriberQueueSuffix(messageType)
-			};
+        public SubscriptionConfiguration GetConfiguration(Type messageType, Action<ISubscriptionConfigurationBuilder> configuration = null)
+        {
+            var routingKey = _conventions.QueueNamingConvention(messageType);
+            var queueConfig = new QueueConfiguration(_clientConfig.Queue)
+            {
+                QueueName = routingKey,
+                NameSuffix = _conventions.SubscriberQueueSuffix(messageType)
+            };
 
-			var exchangeConfig = new ExchangeConfiguration(_clientConfig.Exchange)
-			{
-				ExchangeName = _conventions.ExchangeNamingConvention(messageType)
-			};
+            var exchangeConfig = new ExchangeConfiguration(_clientConfig.Exchange)
+            {
+                ExchangeName = _conventions.ExchangeNamingConvention(messageType)
+            };
 
-			var builder = new SubscriptionConfigurationBuilder(queueConfig, exchangeConfig, routingKey);
-			configuration?.Invoke(builder);
-			return builder.Configuration;
-		}
+            var builder = new SubscriptionConfigurationBuilder(queueConfig, exchangeConfig, routingKey);
+            configuration?.Invoke(builder);
+            return builder.Configuration;
+        }
 
-		public PublishConfiguration GetConfiguration(Type messageType, Action<IPublishConfigurationBuilder> configuration)
-		{
-			var exchangeConfig = new ExchangeConfiguration(_clientConfig.Exchange)
-			{
-				ExchangeName = _conventions.ExchangeNamingConvention(messageType)
-			};
-			var routingKey = _conventions.QueueNamingConvention(messageType);
-			var builder = new PublishConfigurationBuilder(exchangeConfig, routingKey);
-			configuration?.Invoke(builder);
-			return builder.Configuration;
-		}
+        public PublishConfiguration GetConfiguration(Type messageType, Action<IPublishConfigurationBuilder> configuration)
+        {
+            var exchangeConfig = new ExchangeConfiguration(_clientConfig.Exchange)
+            {
+                ExchangeName = _conventions.ExchangeNamingConvention(messageType)
+            };
+            var routingKey = _conventions.QueueNamingConvention(messageType);
+            var builder = new PublishConfigurationBuilder(exchangeConfig, routingKey);
+            configuration?.Invoke(builder);
+            return builder.Configuration;
+        }
 
-		public ResponderConfiguration GetConfiguration(Type requestType, Type responseType, Action<IResponderConfigurationBuilder> configuration)
-		{
-			var queueConfig = new QueueConfiguration(_clientConfig.Queue)
-			{
-				QueueName = _conventions.QueueNamingConvention(requestType)
-			};
+        public ResponderConfiguration GetConfiguration(Type requestType, Type responseType, Action<IResponderConfigurationBuilder> configuration)
+        {
+            var queueConfig = new QueueConfiguration(_clientConfig.Queue)
+            {
+                QueueName = _conventions.QueueNamingConvention(requestType)
+            };
 
-			var exchangeConfig = new ExchangeConfiguration(_clientConfig.Exchange)
-			{
-				ExchangeName = _conventions.ExchangeNamingConvention(requestType)
-			};
+            var exchangeConfig = new ExchangeConfiguration(_clientConfig.Exchange)
+            {
+                ExchangeName = _conventions.ExchangeNamingConvention(requestType)
+            };
 
-			var builder = new ResponderConfigurationBuilder(queueConfig, exchangeConfig);
-			configuration?.Invoke(builder);
-			return builder.Configuration;
-		}
+            var builder = new ResponderConfigurationBuilder(queueConfig, exchangeConfig);
+            configuration?.Invoke(builder);
+            return builder.Configuration;
+        }
 
-		public RequestConfiguration GetConfiguration(Type requestType, Type responseType, Action<IRequestConfigurationBuilder> configuration)
-		{
-			// leverage direct reply to: https://www.rabbitmq.com/direct-reply-to.html
-			var replyQueueConfig = new QueueConfiguration
-			{
-				QueueName = _directReplyTo,
-				AutoDelete = true,
-				Durable = false,
-				Exclusive = true
-			};
+        public RequestConfiguration GetConfiguration(Type requestType, Type responseType, Action<IRequestConfigurationBuilder> configuration)
+        {
+            // leverage direct reply to: https://www.rabbitmq.com/direct-reply-to.html
+            var replyQueueConfig = new QueueConfiguration
+            {
+                QueueName = _directReplyTo,
+                AutoDelete = true,
+                Durable = false,
+                Exclusive = true
+            };
 
-			var exchangeConfig = new ExchangeConfiguration(_clientConfig.Exchange)
-			{
-				ExchangeName = _conventions.ExchangeNamingConvention(requestType)
-			};
+            var exchangeConfig = new ExchangeConfiguration(_clientConfig.Exchange)
+            {
+                ExchangeName = _conventions.ExchangeNamingConvention(requestType)
+            };
 
-			var defaultConfig = new RequestConfiguration
-			{
-				ReplyQueue = replyQueueConfig,
-				Exchange = exchangeConfig,
-				RoutingKey = _conventions.QueueNamingConvention(requestType),
-				ReplyQueueRoutingKey = replyQueueConfig.QueueName
-			};
+            var defaultConfig = new RequestConfiguration
+            {
+                ReplyQueue = replyQueueConfig,
+                Exchange = exchangeConfig,
+                RoutingKey = _conventions.QueueNamingConvention(requestType),
+                ReplyQueueRoutingKey = replyQueueConfig.QueueName
+            };
 
-			var builder = new RequestConfigurationBuilder(defaultConfig);
-			configuration?.Invoke(builder);
-			return builder.Configuration;
-		}
-	}
+            var builder = new RequestConfigurationBuilder(defaultConfig);
+            configuration?.Invoke(builder);
+            return builder.Configuration;
+        }
+    }
 }

--- a/src/RawRabbit/Common/ConnectionStringParser.cs
+++ b/src/RawRabbit/Common/ConnectionStringParser.cs
@@ -6,74 +6,74 @@ using RawRabbit.Configuration;
 
 namespace RawRabbit.Common
 {
-	public class ConnectionStringParser
-	{
-		private static readonly Regex MainRegex = new Regex(@"((?<username>.*):(?<password>.*)@)?(?<hosts>[^\/\?:]*)(:(?<port>[^\/\?]*))?(?<vhost>\/[^\?]*)?(\?(?<parameters>.*))?");
-		private static readonly Regex ParametersRegex = new Regex(@"(?<name>[^?=&]+)=(?<value>[^&]*)?");
-		private static readonly RawRabbitConfiguration Defaults = RawRabbitConfiguration.Local;
+    public class ConnectionStringParser
+    {
+        private static readonly Regex MainRegex = new Regex(@"((?<username>.*):(?<password>.*)@)?(?<hosts>[^\/\?:]*)(:(?<port>[^\/\?]*))?(?<vhost>\/[^\?]*)?(\?(?<parameters>.*))?");
+        private static readonly Regex ParametersRegex = new Regex(@"(?<name>[^?=&]+)=(?<value>[^&]*)?");
+        private static readonly RawRabbitConfiguration Defaults = RawRabbitConfiguration.Local;
 
-		public static RawRabbitConfiguration Parse(string connectionString)
-		{
-			var mainMatch = MainRegex.Match(connectionString);
-			var port = Defaults.Port;
-			if (RegexMatchGroupIsNonEmpty(mainMatch, "port"))
-			{
-				var suppliedPort = mainMatch.Groups["port"].Value;
-				if (!int.TryParse(suppliedPort, out port))
-				{
-					throw new FormatException($"The supplied port '{suppliedPort}' in the connection string is not a number");
-				}
-			}
+        public static RawRabbitConfiguration Parse(string connectionString)
+        {
+            var mainMatch = MainRegex.Match(connectionString);
+            var port = Defaults.Port;
+            if (RegexMatchGroupIsNonEmpty(mainMatch, "port"))
+            {
+                var suppliedPort = mainMatch.Groups["port"].Value;
+                if (!int.TryParse(suppliedPort, out port))
+                {
+                    throw new FormatException($"The supplied port '{suppliedPort}' in the connection string is not a number");
+                }
+            }
 
-			var cfg = new RawRabbitConfiguration
-			{
-				Username = RegexMatchGroupIsNonEmpty(mainMatch, "username") ? mainMatch.Groups["username"].Value : Defaults.Username,
-				Password = RegexMatchGroupIsNonEmpty(mainMatch, "password") ? mainMatch.Groups["password"].Value : Defaults.Password,
-				Hostnames = mainMatch.Groups["hosts"].Value.Split(',').ToList(),
-				Port = port,
-				VirtualHost = ExctractVirutalHost(mainMatch)
-			};
+            var cfg = new RawRabbitConfiguration
+            {
+                Username = RegexMatchGroupIsNonEmpty(mainMatch, "username") ? mainMatch.Groups["username"].Value : Defaults.Username,
+                Password = RegexMatchGroupIsNonEmpty(mainMatch, "password") ? mainMatch.Groups["password"].Value : Defaults.Password,
+                Hostnames = mainMatch.Groups["hosts"].Value.Split(',').ToList(),
+                Port = port,
+                VirtualHost = ExctractVirutalHost(mainMatch)
+            };
 
-			var parametersMatches = ParametersRegex.Matches(mainMatch.Groups["parameters"].Value);
-			foreach (Match match in parametersMatches)
-			{
-				var name = match.Groups["name"].Value.ToLower();
-				var val = match.Groups["value"].Value.ToLower();
-				var propertyInfo = cfg
-					.GetType()
-					.GetTypeInfo()
-					.GetProperty(name, BindingFlags.IgnoreCase | BindingFlags.Public | BindingFlags.Instance);
+            var parametersMatches = ParametersRegex.Matches(mainMatch.Groups["parameters"].Value);
+            foreach (Match match in parametersMatches)
+            {
+                var name = match.Groups["name"].Value.ToLower();
+                var val = match.Groups["value"].Value.ToLower();
+                var propertyInfo = cfg
+                    .GetType()
+                    .GetTypeInfo()
+                    .GetProperty(name, BindingFlags.IgnoreCase | BindingFlags.Public | BindingFlags.Instance);
 
-				if (propertyInfo == null)
-				{
-					throw new ArgumentException($"No configuration property named '{name}'");
-				}
+                if (propertyInfo == null)
+                {
+                    throw new ArgumentException($"No configuration property named '{name}'");
+                }
 
-				if (propertyInfo.PropertyType == typeof (TimeSpan))
-				{
-					var convertedValue = TimeSpan.FromSeconds(int.Parse(val));
-					propertyInfo.SetValue(cfg, convertedValue, null);
-				}
-				else
-				{
-					propertyInfo.SetValue(cfg, Convert.ChangeType(val, propertyInfo.PropertyType), null);
-				}
-			}
+                if (propertyInfo.PropertyType == typeof (TimeSpan))
+                {
+                    var convertedValue = TimeSpan.FromSeconds(int.Parse(val));
+                    propertyInfo.SetValue(cfg, convertedValue, null);
+                }
+                else
+                {
+                    propertyInfo.SetValue(cfg, Convert.ChangeType(val, propertyInfo.PropertyType), null);
+                }
+            }
 
-			return cfg;
-		}
+            return cfg;
+        }
 
-		private static string ExctractVirutalHost(Match mainMatch)
-		{
-			var vhost = RegexMatchGroupIsNonEmpty(mainMatch, "vhost") ? mainMatch.Groups["vhost"].Value : Defaults.VirtualHost;
-			return string.Equals(vhost, Defaults.VirtualHost, StringComparison.CurrentCultureIgnoreCase)
-				? vhost
-				: vhost.Substring(1);
-		}
+        private static string ExctractVirutalHost(Match mainMatch)
+        {
+            var vhost = RegexMatchGroupIsNonEmpty(mainMatch, "vhost") ? mainMatch.Groups["vhost"].Value : Defaults.VirtualHost;
+            return string.Equals(vhost, Defaults.VirtualHost, StringComparison.CurrentCultureIgnoreCase)
+                ? vhost
+                : vhost.Substring(1);
+        }
 
-		private static bool RegexMatchGroupIsNonEmpty(Match match, string groupName)
-		{
-			return match.Groups[groupName].Success && match.Groups[groupName].Length > 0;
-		}
-	}
+        private static bool RegexMatchGroupIsNonEmpty(Match match, string groupName)
+        {
+            return match.Groups[groupName].Success && match.Groups[groupName].Length > 0;
+        }
+    }
 }

--- a/src/RawRabbit/Common/IDictionaryExtensions.cs
+++ b/src/RawRabbit/Common/IDictionaryExtensions.cs
@@ -2,11 +2,11 @@
 
 namespace RawRabbit.Common
 {
-	public static class IDictionaryExtensions
-	{
-		public static TValue GetOrDefault<TKey, TValue>(this IDictionary<TKey, TValue> dictionary, TKey key)
-		{
-			return dictionary.ContainsKey(key) ? dictionary[key] : default(TValue);
-		}
-	}
+    public static class IDictionaryExtensions
+    {
+        public static TValue GetOrDefault<TKey, TValue>(this IDictionary<TKey, TValue> dictionary, TKey key)
+        {
+            return dictionary.ContainsKey(key) ? dictionary[key] : default(TValue);
+        }
+    }
 }

--- a/src/RawRabbit/Common/IShutdown.cs
+++ b/src/RawRabbit/Common/IShutdown.cs
@@ -3,13 +3,13 @@ using System.Threading.Tasks;
 
 namespace RawRabbit.Common
 {
-	public interface IShutdown
-	{
-		/// <summary>
-		/// Shuts down the client and disposes all resources such as channels, connections and subscribers.
-		/// </summary>
-		/// <param name="graceful">The amout of time to wait for Consumer methods to process message before shutting down its channel</param>
-		/// <returns></returns>
-		Task ShutdownAsync(TimeSpan? graceful = null);
-	}
+    public interface IShutdown
+    {
+        /// <summary>
+        /// Shuts down the client and disposes all resources such as channels, connections and subscribers.
+        /// </summary>
+        /// <param name="graceful">The amout of time to wait for Consumer methods to process message before shutting down its channel</param>
+        /// <returns></returns>
+        Task ShutdownAsync(TimeSpan? graceful = null);
+    }
 }

--- a/src/RawRabbit/Common/NamingConventions.cs
+++ b/src/RawRabbit/Common/NamingConventions.cs
@@ -9,143 +9,143 @@ using System.Text.RegularExpressions;
 
 namespace RawRabbit.Common
 {
-	public interface INamingConventions
-	{
-		Func<Type, string> ExchangeNamingConvention { get; set; }
-		Func<Type, string> QueueNamingConvention { get; set; }
-		Func<string> ErrorExchangeNamingConvention { get; set; }
-		Func<string> ErrorQueueNamingConvention { get; set; }
-		Func<string> DeadLetterExchangeNamingConvention { get; set; }
-		Func<TimeSpan,string> RetryLaterExchangeConvention { get; set; }
-		Func<string> RetryQueueNamingConvention { get; set; }
-		Func<Type, string> SubscriberQueueSuffix { get; set; }
-	}
+    public interface INamingConventions
+    {
+        Func<Type, string> ExchangeNamingConvention { get; set; }
+        Func<Type, string> QueueNamingConvention { get; set; }
+        Func<string> ErrorExchangeNamingConvention { get; set; }
+        Func<string> ErrorQueueNamingConvention { get; set; }
+        Func<string> DeadLetterExchangeNamingConvention { get; set; }
+        Func<TimeSpan,string> RetryLaterExchangeConvention { get; set; }
+        Func<string> RetryQueueNamingConvention { get; set; }
+        Func<Type, string> SubscriberQueueSuffix { get; set; }
+    }
 
-	public class NamingConventions : INamingConventions
-	{
-		private readonly ConcurrentDictionary<Type, int> _subscriberCounter;
-		private readonly string _applicationName;
-		private const string IisWorkerProcessName = "w3wp";
-		private static readonly Regex DllRegex = new Regex(@"(?<ApplicationName>[^\\]*).dll", RegexOptions.Compiled);
-		private static readonly Regex ConsoleOrServiceRegex = new Regex(@"(?<ApplicationName>[^\\]*).exe", RegexOptions.Compiled);
-		private static readonly Regex IisHostedAppRegexVer1 = new Regex(@"-ap\s\\""(?<ApplicationName>[^\\]+)");
-		private static readonly Regex IisHostedAppRegexVer2 = new Regex(@"\\\\apppools\\\\(?<ApplicationName>[^\\]+)");
+    public class NamingConventions : INamingConventions
+    {
+        private readonly ConcurrentDictionary<Type, int> _subscriberCounter;
+        private readonly string _applicationName;
+        private const string IisWorkerProcessName = "w3wp";
+        private static readonly Regex DllRegex = new Regex(@"(?<ApplicationName>[^\\]*).dll", RegexOptions.Compiled);
+        private static readonly Regex ConsoleOrServiceRegex = new Regex(@"(?<ApplicationName>[^\\]*).exe", RegexOptions.Compiled);
+        private static readonly Regex IisHostedAppRegexVer1 = new Regex(@"-ap\s\\""(?<ApplicationName>[^\\]+)");
+        private static readonly Regex IisHostedAppRegexVer2 = new Regex(@"\\\\apppools\\\\(?<ApplicationName>[^\\]+)");
 
-		public virtual Func<Type, string> ExchangeNamingConvention { get; set; }
-		public virtual Func<Type, string> QueueNamingConvention { get; set; }
-		public virtual Func<Type, Type, string> RpcExchangeNamingConvention { get; set; }
-		public virtual Func<string> ErrorExchangeNamingConvention { get; set; }
-		public virtual Func<string> ErrorQueueNamingConvention { get; set; }
-		public virtual Func<string> DeadLetterExchangeNamingConvention { get; set; }
-		public virtual Func<TimeSpan, string> RetryLaterExchangeConvention { get; set; }
-		public virtual Func<string> RetryQueueNamingConvention { get; set; }
-		public virtual Func<Type, string> SubscriberQueueSuffix { get; set; }
+        public virtual Func<Type, string> ExchangeNamingConvention { get; set; }
+        public virtual Func<Type, string> QueueNamingConvention { get; set; }
+        public virtual Func<Type, Type, string> RpcExchangeNamingConvention { get; set; }
+        public virtual Func<string> ErrorExchangeNamingConvention { get; set; }
+        public virtual Func<string> ErrorQueueNamingConvention { get; set; }
+        public virtual Func<string> DeadLetterExchangeNamingConvention { get; set; }
+        public virtual Func<TimeSpan, string> RetryLaterExchangeConvention { get; set; }
+        public virtual Func<string> RetryQueueNamingConvention { get; set; }
+        public virtual Func<Type, string> SubscriberQueueSuffix { get; set; }
 
-		public NamingConventions()
-		{
-			_subscriberCounter = new ConcurrentDictionary<Type,int>();
-			_applicationName = GetApplicationName(string.Join(" ", Environment.GetCommandLineArgs()));
+        public NamingConventions()
+        {
+            _subscriberCounter = new ConcurrentDictionary<Type,int>();
+            _applicationName = GetApplicationName(string.Join(" ", Environment.GetCommandLineArgs()));
 
-			ExchangeNamingConvention = type => type?.Namespace?.ToLower() ?? string.Empty;
-			QueueNamingConvention = type => CreateShortAfqn(type);
-			ErrorQueueNamingConvention = () => "default_error_queue";
-			ErrorExchangeNamingConvention = () => "default_error_exchange";
-			DeadLetterExchangeNamingConvention = () => "default_dead_letter_exchange";
-			RetryQueueNamingConvention = () => $"retry_{Guid.NewGuid()}";
-			SubscriberQueueSuffix = GetSubscriberQueueSuffix;
-			RetryLaterExchangeConvention = span => $"rety_in_{span.TotalMilliseconds}_ms";
-		}
+            ExchangeNamingConvention = type => type?.Namespace?.ToLower() ?? string.Empty;
+            QueueNamingConvention = type => CreateShortAfqn(type);
+            ErrorQueueNamingConvention = () => "default_error_queue";
+            ErrorExchangeNamingConvention = () => "default_error_exchange";
+            DeadLetterExchangeNamingConvention = () => "default_dead_letter_exchange";
+            RetryQueueNamingConvention = () => $"retry_{Guid.NewGuid()}";
+            SubscriberQueueSuffix = GetSubscriberQueueSuffix;
+            RetryLaterExchangeConvention = span => $"rety_in_{span.TotalMilliseconds}_ms";
+        }
 
-		private string GetSubscriberQueueSuffix(Type messageType)
-		{
-			var sb = new StringBuilder(_applicationName);
+        private string GetSubscriberQueueSuffix(Type messageType)
+        {
+            var sb = new StringBuilder(_applicationName);
 
-			_subscriberCounter.AddOrUpdate(
-				key: messageType,
-				addValueFactory: type =>
-				{
-					var next = 0;
-					return next;
-				},
-				updateValueFactory:(type, i) =>
-				{
-					var next = i+1;
-					sb.Append($"_{next}");
-					return next;
-				});
+            _subscriberCounter.AddOrUpdate(
+                key: messageType,
+                addValueFactory: type =>
+                {
+                    var next = 0;
+                    return next;
+                },
+                updateValueFactory:(type, i) =>
+                {
+                    var next = i+1;
+                    sb.Append($"_{next}");
+                    return next;
+                });
 
-			return sb.ToString();
-		}
+            return sb.ToString();
+        }
 
-		public static string GetApplicationName(params string[] commandLine)
-		{
-			var match = ConsoleOrServiceRegex.Match(commandLine.FirstOrDefault() ?? string.Empty);
-			var applicationName = string.Empty;
+        public static string GetApplicationName(params string[] commandLine)
+        {
+            var match = ConsoleOrServiceRegex.Match(commandLine.FirstOrDefault() ?? string.Empty);
+            var applicationName = string.Empty;
 
-			if (commandLine == null)
-			{
-				return string.Empty;
-			}
-			if (match.Success && match.Groups["ApplicationName"].Value != IisWorkerProcessName)
-			{
-				applicationName = match.Groups["ApplicationName"].Value;
-				if (applicationName.EndsWith(".vshost"))
-					applicationName = applicationName.Remove(applicationName.Length - ".vshost".Length);
-			}
-			else
-			{
-				match = IisHostedAppRegexVer1.Match(commandLine.FirstOrDefault() ?? string.Empty);
-				if (match.Success)
-				{
-					applicationName = match.Groups["ApplicationName"].Value;
-				}
-				else
-				{
-					match = IisHostedAppRegexVer2.Match(commandLine.FirstOrDefault() ?? string.Empty);
-					if (match.Success)
-					{
-						applicationName = match.Groups["ApplicationName"].Value;
-					}
-					else
-					{
-						var index = commandLine.Length > 1 ? 1 : 0;
-						if (DllRegex.IsMatch(commandLine[index]))
-						{
-							applicationName = DllRegex.Match(commandLine[index]).Groups["ApplicationName"].Value;
-						}
-					}
-				}
-			}
-			
-			return applicationName.Replace(".","_").ToLower();
-		}
+            if (commandLine == null)
+            {
+                return string.Empty;
+            }
+            if (match.Success && match.Groups["ApplicationName"].Value != IisWorkerProcessName)
+            {
+                applicationName = match.Groups["ApplicationName"].Value;
+                if (applicationName.EndsWith(".vshost"))
+                    applicationName = applicationName.Remove(applicationName.Length - ".vshost".Length);
+            }
+            else
+            {
+                match = IisHostedAppRegexVer1.Match(commandLine.FirstOrDefault() ?? string.Empty);
+                if (match.Success)
+                {
+                    applicationName = match.Groups["ApplicationName"].Value;
+                }
+                else
+                {
+                    match = IisHostedAppRegexVer2.Match(commandLine.FirstOrDefault() ?? string.Empty);
+                    if (match.Success)
+                    {
+                        applicationName = match.Groups["ApplicationName"].Value;
+                    }
+                    else
+                    {
+                        var index = commandLine.Length > 1 ? 1 : 0;
+                        if (DllRegex.IsMatch(commandLine[index]))
+                        {
+                            applicationName = DllRegex.Match(commandLine[index]).Groups["ApplicationName"].Value;
+                        }
+                    }
+                }
+            }
+            
+            return applicationName.Replace(".","_").ToLower();
+        }
 
-		private static string CreateShortAfqn(Type type, string path = "", string delimeter = ".")
-		{
-			var t = $"{path}{(string.IsNullOrEmpty(path) ? string.Empty : delimeter)}{GetNonGenericTypeName(type)}";
+        private static string CreateShortAfqn(Type type, string path = "", string delimeter = ".")
+        {
+            var t = $"{path}{(string.IsNullOrEmpty(path) ? string.Empty : delimeter)}{GetNonGenericTypeName(type)}";
 
-			if (type.GetTypeInfo().IsGenericType)
-			{
-				t += "[";
-				foreach (var argument in type.GenericTypeArguments)
-				{
-					t = CreateShortAfqn(argument, t, t.EndsWith("[") ? string.Empty : ",");
-				}
-				t += "]";
-			}
+            if (type.GetTypeInfo().IsGenericType)
+            {
+                t += "[";
+                foreach (var argument in type.GenericTypeArguments)
+                {
+                    t = CreateShortAfqn(argument, t, t.EndsWith("[") ? string.Empty : ",");
+                }
+                t += "]";
+            }
 
-			return (t.Length > 254
-				? string.Concat("...", t.Substring(t.Length - 250))
-				: t).ToLowerInvariant();
-		}
+            return (t.Length > 254
+                ? string.Concat("...", t.Substring(t.Length - 250))
+                : t).ToLowerInvariant();
+        }
 
-		public static string GetNonGenericTypeName(Type type)
-		{
-			var name = !type.GetTypeInfo().IsGenericType
-				? new[] { type.Name }
-				: type.Name.Split('`');
+        public static string GetNonGenericTypeName(Type type)
+        {
+            var name = !type.GetTypeInfo().IsGenericType
+                ? new[] { type.Name }
+                : type.Name.Split('`');
 
-			return name[0];
-		}
-	}
+            return name[0];
+        }
+    }
 }

--- a/src/RawRabbit/Common/PropertyHeaders.cs
+++ b/src/RawRabbit/Common/PropertyHeaders.cs
@@ -1,14 +1,14 @@
 ﻿namespace RawRabbit.Common
 {
-	public class PropertyHeaders
-	{
-		public static readonly string MessageType = "message_type";
-		public static readonly string Sent = "sent";
-		public static readonly string ApproximateRetry = "approx_retry";
-		public static readonly string Death = "x-death";
-		public static readonly string EstimatedRetry = "approx_retry";
-		public static readonly string RetryCount = "retry_count";
-		public static readonly string Context = "message_context";
-		public static readonly string ExceptionHeader = "exception";
-	}
+    public class PropertyHeaders
+    {
+        public static readonly string MessageType = "message_type";
+        public static readonly string Sent = "sent";
+        public static readonly string ApproximateRetry = "approx_retry";
+        public static readonly string Death = "x-death";
+        public static readonly string EstimatedRetry = "approx_retry";
+        public static readonly string RetryCount = "retry_count";
+        public static readonly string Context = "message_context";
+        public static readonly string ExceptionHeader = "exception";
+    }
 }

--- a/src/RawRabbit/Common/PublishAcknowledger.cs
+++ b/src/RawRabbit/Common/PublishAcknowledger.cs
@@ -8,130 +8,130 @@ using RawRabbit.Logging;
 
 namespace RawRabbit.Common
 {
-	public interface IPublishAcknowledger
-	{
-		Task GetAckTask(IModel result);
-	}
+    public interface IPublishAcknowledger
+    {
+        Task GetAckTask(IModel result);
+    }
 
-	public class NoAckAcknowledger : IPublishAcknowledger
-	{
-		public static Task Completed = Task.FromResult(0ul);
+    public class NoAckAcknowledger : IPublishAcknowledger
+    {
+        public static Task Completed = Task.FromResult(0ul);
 
-		public Task GetAckTask(IModel result)
-		{
-			return Completed;
-		}
-	}
+        public Task GetAckTask(IModel result)
+        {
+            return Completed;
+        }
+    }
 
-	public class PublishAcknowledger : IPublishAcknowledger
-	{
-		private readonly TimeSpan _publishTimeout;
-		private readonly ILogger _logger = LogManager.GetLogger<PublishAcknowledger>();
-		private readonly ConcurrentDictionary<string, TaskCompletionSource<ulong>> _deliveredAckDictionary;
-		private readonly ConcurrentDictionary<string, Timer> _ackTimers;
+    public class PublishAcknowledger : IPublishAcknowledger
+    {
+        private readonly TimeSpan _publishTimeout;
+        private readonly ILogger _logger = LogManager.GetLogger<PublishAcknowledger>();
+        private readonly ConcurrentDictionary<string, TaskCompletionSource<ulong>> _deliveredAckDictionary;
+        private readonly ConcurrentDictionary<string, Timer> _ackTimers;
 
-		public PublishAcknowledger(TimeSpan publishTimeout)
-		{
-			_publishTimeout = publishTimeout;
-			_deliveredAckDictionary = new ConcurrentDictionary<string, TaskCompletionSource<ulong>>();
-			_ackTimers = new ConcurrentDictionary<string, Timer>();
-		}
+        public PublishAcknowledger(TimeSpan publishTimeout)
+        {
+            _publishTimeout = publishTimeout;
+            _deliveredAckDictionary = new ConcurrentDictionary<string, TaskCompletionSource<ulong>>();
+            _ackTimers = new ConcurrentDictionary<string, Timer>();
+        }
 
-		public Task GetAckTask(IModel channel)
-		{
-			if (channel.NextPublishSeqNo == 0UL)
-			{
-				_logger.LogInformation($"Setting 'Publish Acknowledge' for channel '{channel.ChannelNumber}'");
-				channel.ConfirmSelect();
-				channel.BasicAcks += (sender, args) =>
-				{
-					var model = sender as IModel;
-					_logger.LogInformation($"Recieved ack for {args.DeliveryTag}/{model.ChannelNumber} with multiple set to '{args.Multiple}'");
-					if (args.Multiple)
-					{
-						for (var i = args.DeliveryTag; i > 0; i--)
-						{
-							CompleteConfirm(model, i, true);
-						}
-					}
-					else
-					{
-						CompleteConfirm(model, args.DeliveryTag);
-					}
-				};
-			}
+        public Task GetAckTask(IModel channel)
+        {
+            if (channel.NextPublishSeqNo == 0UL)
+            {
+                _logger.LogInformation($"Setting 'Publish Acknowledge' for channel '{channel.ChannelNumber}'");
+                channel.ConfirmSelect();
+                channel.BasicAcks += (sender, args) =>
+                {
+                    var model = sender as IModel;
+                    _logger.LogInformation($"Recieved ack for {args.DeliveryTag}/{model.ChannelNumber} with multiple set to '{args.Multiple}'");
+                    if (args.Multiple)
+                    {
+                        for (var i = args.DeliveryTag; i > 0; i--)
+                        {
+                            CompleteConfirm(model, i, true);
+                        }
+                    }
+                    else
+                    {
+                        CompleteConfirm(model, args.DeliveryTag);
+                    }
+                };
+            }
 
-			var key = CreatePublishKey(channel, channel.NextPublishSeqNo);
-			var tcs = new TaskCompletionSource<ulong>();
-			if (!_deliveredAckDictionary.TryAdd(key, tcs))
-			{
-				_logger.LogWarning($"Unable to add delivery tag {key} to ack list.");
-			}
-			_ackTimers.TryAdd(key, new Timer(state =>
-			{
-				_logger.LogWarning($"Ack for {key} has timed out.");
-				TryDisposeTimer(key);
+            var key = CreatePublishKey(channel, channel.NextPublishSeqNo);
+            var tcs = new TaskCompletionSource<ulong>();
+            if (!_deliveredAckDictionary.TryAdd(key, tcs))
+            {
+                _logger.LogWarning($"Unable to add delivery tag {key} to ack list.");
+            }
+            _ackTimers.TryAdd(key, new Timer(state =>
+            {
+                _logger.LogWarning($"Ack for {key} has timed out.");
+                TryDisposeTimer(key);
 
-				TaskCompletionSource<ulong> ackTcs;
-				if (!_deliveredAckDictionary.TryGetValue(key, out ackTcs))
-				{
-					_logger.LogWarning($"Unable to get TaskCompletionSource for {key}");
-					return;
-				}
-				ackTcs.TrySetException(new PublishConfirmException($"The broker did not send a publish acknowledgement for message {key} within {_publishTimeout.ToString("g")}."));
-			}, channel, _publishTimeout, new TimeSpan(-1)));
-			return tcs.Task;
-		}
+                TaskCompletionSource<ulong> ackTcs;
+                if (!_deliveredAckDictionary.TryGetValue(key, out ackTcs))
+                {
+                    _logger.LogWarning($"Unable to get TaskCompletionSource for {key}");
+                    return;
+                }
+                ackTcs.TrySetException(new PublishConfirmException($"The broker did not send a publish acknowledgement for message {key} within {_publishTimeout.ToString("g")}."));
+            }, channel, _publishTimeout, new TimeSpan(-1)));
+            return tcs.Task;
+        }
 
-		private void CompleteConfirm(IModel channel, ulong tag, bool multiple = false)
-		{
-			var key = CreatePublishKey(channel, tag);
-			TryDisposeTimer(key);
-			TaskCompletionSource<ulong> tcs;
-			if (!_deliveredAckDictionary.TryRemove(key, out tcs))
-			{
-				if (!multiple)
-				{
-					_logger.LogWarning($"Unable to remove task completion source for Publish Confirm on '{key}'.");
-				}
-			}
-			else
-			{
-				if (tcs.TrySetResult(tag))
-				{
-					_logger.LogDebug($"Successfully confirmed publish {key}");
-				}
-				else
-				{
-					if (tcs.Task.IsFaulted)
-					{
-						_logger.LogDebug($"Unable to set result for '{key}'. Task has been faulted.");
-					}
-					else if (!multiple)
-					{
-						_logger.LogWarning($"Unable to set result for Publish Confirm on key '{key}'.");
-					}
-				}
-			}
-		}
+        private void CompleteConfirm(IModel channel, ulong tag, bool multiple = false)
+        {
+            var key = CreatePublishKey(channel, tag);
+            TryDisposeTimer(key);
+            TaskCompletionSource<ulong> tcs;
+            if (!_deliveredAckDictionary.TryRemove(key, out tcs))
+            {
+                if (!multiple)
+                {
+                    _logger.LogWarning($"Unable to remove task completion source for Publish Confirm on '{key}'.");
+                }
+            }
+            else
+            {
+                if (tcs.TrySetResult(tag))
+                {
+                    _logger.LogDebug($"Successfully confirmed publish {key}");
+                }
+                else
+                {
+                    if (tcs.Task.IsFaulted)
+                    {
+                        _logger.LogDebug($"Unable to set result for '{key}'. Task has been faulted.");
+                    }
+                    else if (!multiple)
+                    {
+                        _logger.LogWarning($"Unable to set result for Publish Confirm on key '{key}'.");
+                    }
+                }
+            }
+        }
 
-		private static string CreatePublishKey(IModel channel, ulong nextTag)
-		{
-			return $"{nextTag}/{channel.ChannelNumber}";
-		}
+        private static string CreatePublishKey(IModel channel, ulong nextTag)
+        {
+            return $"{nextTag}/{channel.ChannelNumber}";
+        }
 
-		private void TryDisposeTimer(string key)
-		{
-			Timer ackTimer;
-			if (!_ackTimers.TryGetValue(key, out ackTimer))
-			{
-				_logger.LogDebug($"Unable to get ack timer for {key}.");
-			}
-			else
-			{
-				_logger.LogDebug($"Disposed ack timer for {key}");
-				ackTimer.Dispose();
-			}
-		}
-	}
+        private void TryDisposeTimer(string key)
+        {
+            Timer ackTimer;
+            if (!_ackTimers.TryGetValue(key, out ackTimer))
+            {
+                _logger.LogDebug($"Unable to get ack timer for {key}.");
+            }
+            else
+            {
+                _logger.LogDebug($"Disposed ack timer for {key}");
+                ackTimer.Dispose();
+            }
+        }
+    }
 }

--- a/src/RawRabbit/Common/QueueArgument.cs
+++ b/src/RawRabbit/Common/QueueArgument.cs
@@ -1,36 +1,36 @@
 ﻿namespace RawRabbit.Common
 {
-	public class QueueArgument
-	{
-		/// <summary>
-		/// Indicates that the queue is a priority queue that honours the <br />
-		/// priority property of a recieved message.
-		/// </summary>
-		public static readonly string MaxPriority = "x-max-priority";
+    public class QueueArgument
+    {
+        /// <summary>
+        /// Indicates that the queue is a priority queue that honours the <br />
+        /// priority property of a recieved message.
+        /// </summary>
+        public static readonly string MaxPriority = "x-max-priority";
 
-		/// <summary>
-		/// Sets what exchange that will be used as a dead letter exchange. <br/>
-		/// More information: https://www.rabbitmq.com/dlx.html
-		/// </summary>
-		public static readonly string DeadLetterExchange = "x-dead-letter-exchange";
+        /// <summary>
+        /// Sets what exchange that will be used as a dead letter exchange. <br/>
+        /// More information: https://www.rabbitmq.com/dlx.html
+        /// </summary>
+        public static readonly string DeadLetterExchange = "x-dead-letter-exchange";
 
-		/// <summary>
-		/// Sets the Time To Live (TTL) in milliseconds for messages in the queue.
-		/// </summary>
-		public static readonly string MessageTtl = "x-message-ttl";
+        /// <summary>
+        /// Sets the Time To Live (TTL) in milliseconds for messages in the queue.
+        /// </summary>
+        public static readonly string MessageTtl = "x-message-ttl";
 
-		/// <summary>
-		/// Set QueueMode for a queue. Valid modes are "default" and "layz".<br />
-		/// The messages for a lazy queue is held on disc and only loaded to
-		/// RAM when requested by consumer.
-		/// </summary>
-		public static readonly string QueueMode = "x-queue-mode";
+        /// <summary>
+        /// Set QueueMode for a queue. Valid modes are "default" and "layz".<br />
+        /// The messages for a lazy queue is held on disc and only loaded to
+        /// RAM when requested by consumer.
+        /// </summary>
+        public static readonly string QueueMode = "x-queue-mode";
 
-		/// <summary>
-		/// Controls for how long a queue can be unused before it is automatically deleted.
-		/// Unused means the queue has no consumers, the queue has not been redeclared, and
-		/// basic.get has not been invoked for a duration of at least the expiration period
-		/// </summary>
-		public static readonly string Expires = "x-expires";
-	}
+        /// <summary>
+        /// Controls for how long a queue can be unused before it is automatically deleted.
+        /// Unused means the queue has no consumers, the queue has not been redeclared, and
+        /// basic.get has not been invoked for a duration of at least the expiration period
+        /// </summary>
+        public static readonly string Expires = "x-expires";
+    }
 }

--- a/src/RawRabbit/Common/Subscription.cs
+++ b/src/RawRabbit/Common/Subscription.cs
@@ -4,37 +4,37 @@ using RawRabbit.Consumer.Abstraction;
 
 namespace RawRabbit.Common
 {
-	public interface ISubscription : IDisposable
-	{
-		string QueueName { get; }
-		string ConsumerTag { get; }
-		bool Active { get;  }
-	}
+    public interface ISubscription : IDisposable
+    {
+        string QueueName { get; }
+        string ConsumerTag { get; }
+        bool Active { get;  }
+    }
 
-	public class Subscription : ISubscription
-	{
-		public string QueueName { get; }
-		public string ConsumerTag { get; }
-		public bool Active { get; set; }
+    public class Subscription : ISubscription
+    {
+        public string QueueName { get; }
+        public string ConsumerTag { get; }
+        public bool Active { get; set; }
 
-		private readonly IRawConsumer _consumer;
+        private readonly IRawConsumer _consumer;
 
-		public Subscription(IRawConsumer consumer, string queueName)
-		{
-			_consumer = consumer;
-			var basicConsumer = consumer as DefaultBasicConsumer;
-			if (basicConsumer == null)
-			{
-				return;
-			}
-			QueueName = queueName;
-			ConsumerTag = basicConsumer.ConsumerTag;
-		}
+        public Subscription(IRawConsumer consumer, string queueName)
+        {
+            _consumer = consumer;
+            var basicConsumer = consumer as DefaultBasicConsumer;
+            if (basicConsumer == null)
+            {
+                return;
+            }
+            QueueName = queueName;
+            ConsumerTag = basicConsumer.ConsumerTag;
+        }
 
-		public void Dispose()
-		{
-			Active = false;
-			_consumer.Disconnect();
-		}
-	}
+        public void Dispose()
+        {
+            Active = false;
+            _consumer.Disconnect();
+        }
+    }
 }

--- a/src/RawRabbit/Common/TopologyProvider.cs
+++ b/src/RawRabbit/Common/TopologyProvider.cs
@@ -12,366 +12,366 @@ using RawRabbit.Logging;
 
 namespace RawRabbit.Common
 {
-	public interface ITopologyProvider
-	{
-		Task DeclareExchangeAsync(ExchangeConfiguration exchange);
-		Task DeclareQueueAsync(QueueConfiguration queue);
-		Task BindQueueAsync(QueueConfiguration queue, ExchangeConfiguration exchange, string routingKey);
-		Task UnbindQueueAsync(QueueConfiguration queue, ExchangeConfiguration exchange, string routingKey);
-		bool IsInitialized(ExchangeConfiguration exchange);
-		bool IsInitialized(QueueConfiguration exchange);
-	}
+    public interface ITopologyProvider
+    {
+        Task DeclareExchangeAsync(ExchangeConfiguration exchange);
+        Task DeclareQueueAsync(QueueConfiguration queue);
+        Task BindQueueAsync(QueueConfiguration queue, ExchangeConfiguration exchange, string routingKey);
+        Task UnbindQueueAsync(QueueConfiguration queue, ExchangeConfiguration exchange, string routingKey);
+        bool IsInitialized(ExchangeConfiguration exchange);
+        bool IsInitialized(QueueConfiguration exchange);
+    }
 
-	public class TopologyProvider : ITopologyProvider, IDisposable
-	{
-		private readonly IChannelFactory _channelFactory;
-		private IModel _channel;
-		private bool _processing;
-		private readonly object _processLock = new object();
-		private readonly Task _completed = Task.FromResult(true);
-		private readonly Timer _disposeTimer;
-		private readonly List<string> _initExchanges;
-		private readonly List<string> _initQueues;
-		private readonly List<string> _queueBinds;
-		private readonly ConcurrentQueue<ScheduledTopologyTask> _topologyTasks;
-		private readonly ILogger _logger = LogManager.GetLogger<TopologyProvider>();
+    public class TopologyProvider : ITopologyProvider, IDisposable
+    {
+        private readonly IChannelFactory _channelFactory;
+        private IModel _channel;
+        private bool _processing;
+        private readonly object _processLock = new object();
+        private readonly Task _completed = Task.FromResult(true);
+        private readonly Timer _disposeTimer;
+        private readonly List<string> _initExchanges;
+        private readonly List<string> _initQueues;
+        private readonly List<string> _queueBinds;
+        private readonly ConcurrentQueue<ScheduledTopologyTask> _topologyTasks;
+        private readonly ILogger _logger = LogManager.GetLogger<TopologyProvider>();
 
-		public TopologyProvider(IChannelFactory channelFactory)
-		{
-			_channelFactory = channelFactory;
-			_initExchanges = new List<string>();
-			_initQueues = new List<string>();
-			_queueBinds = new List<string>();
-			_topologyTasks = new ConcurrentQueue<ScheduledTopologyTask>();
-			_disposeTimer = new Timer(state =>
-			{
-				_logger.LogInformation("Disposing topology channel (if exists).");
-				_channel?.Dispose();
-				_disposeTimer.Change(TimeSpan.FromHours(1), new TimeSpan(-1));
-			}, null, TimeSpan.FromSeconds(2), new TimeSpan(-1));
-		}
+        public TopologyProvider(IChannelFactory channelFactory)
+        {
+            _channelFactory = channelFactory;
+            _initExchanges = new List<string>();
+            _initQueues = new List<string>();
+            _queueBinds = new List<string>();
+            _topologyTasks = new ConcurrentQueue<ScheduledTopologyTask>();
+            _disposeTimer = new Timer(state =>
+            {
+                _logger.LogInformation("Disposing topology channel (if exists).");
+                _channel?.Dispose();
+                _disposeTimer.Change(TimeSpan.FromHours(1), new TimeSpan(-1));
+            }, null, TimeSpan.FromSeconds(2), new TimeSpan(-1));
+        }
 
-		public Task DeclareExchangeAsync(ExchangeConfiguration exchange)
-		{
-			if (IsInitialized(exchange))
-			{
-				return _completed;
-			}
+        public Task DeclareExchangeAsync(ExchangeConfiguration exchange)
+        {
+            if (IsInitialized(exchange))
+            {
+                return _completed;
+            }
 
-			var scheduled = new ScheduledExchangeTask(exchange);
-			_topologyTasks.Enqueue(scheduled);
-			EnsureWorker();
-			return scheduled.TaskCompletionSource.Task;
-		}
+            var scheduled = new ScheduledExchangeTask(exchange);
+            _topologyTasks.Enqueue(scheduled);
+            EnsureWorker();
+            return scheduled.TaskCompletionSource.Task;
+        }
 
-		public Task DeclareQueueAsync(QueueConfiguration queue)
-		{
-			if (IsInitialized(queue))
-			{
-				return _completed;
-			}
+        public Task DeclareQueueAsync(QueueConfiguration queue)
+        {
+            if (IsInitialized(queue))
+            {
+                return _completed;
+            }
 
-			var scheduled = new ScheduledQueueTask(queue);
-			_topologyTasks.Enqueue(scheduled);
-			EnsureWorker();
-			return scheduled.TaskCompletionSource.Task;
-		}
+            var scheduled = new ScheduledQueueTask(queue);
+            _topologyTasks.Enqueue(scheduled);
+            EnsureWorker();
+            return scheduled.TaskCompletionSource.Task;
+        }
 
-		public Task BindQueueAsync(QueueConfiguration queue, ExchangeConfiguration exchange, string routingKey)
-		{
-			if (exchange.IsDefaultExchange())
-			{
-				/*
-					"The default exchange is implicitly bound to every queue,
-					with a routing key equal to the queue name. It it not possible
-					to explicitly bind to, or unbind from the default exchange."
-				*/
-				return _completed;
-			}
-			if (queue.IsDirectReplyTo())
-			{
-				/*
-					"Consume from the pseudo-queue amq.rabbitmq.reply-to in no-ack mode. There is no need to
-					declare this "queue" first, although the client can do so if it wants."
-					- https://www.rabbitmq.com/direct-reply-to.html
-				*/
-				return _completed;
-			}
-			var bindKey = $"{queue.FullQueueName}_{exchange.ExchangeName}_{routingKey}";
-			if (_queueBinds.Contains(bindKey))
-			{
-				return _completed;
-			}
-			var scheduled = new ScheduledBindQueueTask
-			{
-				Queue = queue,
-				Exchange = exchange,
-				RoutingKey = routingKey
-			};
-			_topologyTasks.Enqueue(scheduled);
-			EnsureWorker();
-			return scheduled.TaskCompletionSource.Task;
-		}
+        public Task BindQueueAsync(QueueConfiguration queue, ExchangeConfiguration exchange, string routingKey)
+        {
+            if (exchange.IsDefaultExchange())
+            {
+                /*
+                    "The default exchange is implicitly bound to every queue,
+                    with a routing key equal to the queue name. It it not possible
+                    to explicitly bind to, or unbind from the default exchange."
+                */
+                return _completed;
+            }
+            if (queue.IsDirectReplyTo())
+            {
+                /*
+                    "Consume from the pseudo-queue amq.rabbitmq.reply-to in no-ack mode. There is no need to
+                    declare this "queue" first, although the client can do so if it wants."
+                    - https://www.rabbitmq.com/direct-reply-to.html
+                */
+                return _completed;
+            }
+            var bindKey = $"{queue.FullQueueName}_{exchange.ExchangeName}_{routingKey}";
+            if (_queueBinds.Contains(bindKey))
+            {
+                return _completed;
+            }
+            var scheduled = new ScheduledBindQueueTask
+            {
+                Queue = queue,
+                Exchange = exchange,
+                RoutingKey = routingKey
+            };
+            _topologyTasks.Enqueue(scheduled);
+            EnsureWorker();
+            return scheduled.TaskCompletionSource.Task;
+        }
 
-		public Task UnbindQueueAsync(QueueConfiguration queue, ExchangeConfiguration exchange, string routingKey)
-		{
-			var scheduled = new ScheduledUnbindQueueTask
-			{
-				Queue = queue,
-				Exchange = exchange,
-				RoutingKey = routingKey
-			};
-			_topologyTasks.Enqueue(scheduled);
-			EnsureWorker();
-			return scheduled.TaskCompletionSource.Task;
-		}
+        public Task UnbindQueueAsync(QueueConfiguration queue, ExchangeConfiguration exchange, string routingKey)
+        {
+            var scheduled = new ScheduledUnbindQueueTask
+            {
+                Queue = queue,
+                Exchange = exchange,
+                RoutingKey = routingKey
+            };
+            _topologyTasks.Enqueue(scheduled);
+            EnsureWorker();
+            return scheduled.TaskCompletionSource.Task;
+        }
 
-		public bool IsInitialized(ExchangeConfiguration exchange)
-		{
-			return exchange.IsDefaultExchange() || exchange.AssumeInitialized || _initExchanges.Contains(exchange.ExchangeName);
-		}
+        public bool IsInitialized(ExchangeConfiguration exchange)
+        {
+            return exchange.IsDefaultExchange() || exchange.AssumeInitialized || _initExchanges.Contains(exchange.ExchangeName);
+        }
 
-		public bool IsInitialized(QueueConfiguration queue)
-		{
-			return queue.IsDirectReplyTo() || _initQueues.Contains(queue.FullQueueName);
-		}
+        public bool IsInitialized(QueueConfiguration queue)
+        {
+            return queue.IsDirectReplyTo() || _initQueues.Contains(queue.FullQueueName);
+        }
 
-		private void BindQueueToExchange(ScheduledBindQueueTask bind)
-		{
-			var bindKey = $"{bind.Queue.FullQueueName}_{bind.Exchange.ExchangeName}_{bind.RoutingKey}";
-			if (_queueBinds.Contains(bindKey))
-			{
-				return;
-			}
+        private void BindQueueToExchange(ScheduledBindQueueTask bind)
+        {
+            var bindKey = $"{bind.Queue.FullQueueName}_{bind.Exchange.ExchangeName}_{bind.RoutingKey}";
+            if (_queueBinds.Contains(bindKey))
+            {
+                return;
+            }
 
-			DeclareQueue(bind.Queue);
-			DeclareExchange(bind.Exchange);
+            DeclareQueue(bind.Queue);
+            DeclareExchange(bind.Exchange);
 
-			_logger.LogInformation($"Binding queue '{bind.Queue.FullQueueName}' to exchange '{bind.Exchange.ExchangeName}' with routing key '{bind.RoutingKey}'");
+            _logger.LogInformation($"Binding queue '{bind.Queue.FullQueueName}' to exchange '{bind.Exchange.ExchangeName}' with routing key '{bind.RoutingKey}'");
 
-			var channel = GetOrCreateChannel();
-			channel.QueueBind(
-				queue: bind.Queue.FullQueueName,
-				exchange: bind.Exchange.ExchangeName,
-				routingKey: bind.RoutingKey
-				);
-			_queueBinds.Add(bindKey);
-		}
+            var channel = GetOrCreateChannel();
+            channel.QueueBind(
+                queue: bind.Queue.FullQueueName,
+                exchange: bind.Exchange.ExchangeName,
+                routingKey: bind.RoutingKey
+                );
+            _queueBinds.Add(bindKey);
+        }
 
-		private void UnbindQueueFromExchange(ScheduledUnbindQueueTask bind)
-		{
-			_logger.LogInformation($"Unbinding queue '{bind.Queue.FullQueueName}' from exchange '{bind.Exchange.ExchangeName}' with routing key '{bind.RoutingKey}'");
+        private void UnbindQueueFromExchange(ScheduledUnbindQueueTask bind)
+        {
+            _logger.LogInformation($"Unbinding queue '{bind.Queue.FullQueueName}' from exchange '{bind.Exchange.ExchangeName}' with routing key '{bind.RoutingKey}'");
 
-			var channel = GetOrCreateChannel();
-			channel.QueueUnbind(
-				queue: bind.Queue.FullQueueName,
-				exchange: bind.Exchange.ExchangeName,
-				routingKey: bind.RoutingKey,
-				arguments: null
-			);
-			var bindKey = $"{bind.Queue.FullQueueName}_{bind.Exchange.ExchangeName}_{bind.RoutingKey}";
-			if (_queueBinds.Contains(bindKey))
-			{
-				_queueBinds.Remove(bindKey);
-			}
-		}
+            var channel = GetOrCreateChannel();
+            channel.QueueUnbind(
+                queue: bind.Queue.FullQueueName,
+                exchange: bind.Exchange.ExchangeName,
+                routingKey: bind.RoutingKey,
+                arguments: null
+            );
+            var bindKey = $"{bind.Queue.FullQueueName}_{bind.Exchange.ExchangeName}_{bind.RoutingKey}";
+            if (_queueBinds.Contains(bindKey))
+            {
+                _queueBinds.Remove(bindKey);
+            }
+        }
 
-		private void DeclareQueue(QueueConfiguration queue)
-		{
-			if (IsInitialized(queue))
-			{
-				return;
-			}
+        private void DeclareQueue(QueueConfiguration queue)
+        {
+            if (IsInitialized(queue))
+            {
+                return;
+            }
 
-			_logger.LogInformation($"Declaring queue '{queue.FullQueueName}'.");
+            _logger.LogInformation($"Declaring queue '{queue.FullQueueName}'.");
 
-			var channel = GetOrCreateChannel();
-			channel.QueueDeclare(
-				queue.FullQueueName,
-				queue.Durable,
-				queue.Exclusive,
-				queue.AutoDelete,
-				queue.Arguments);
+            var channel = GetOrCreateChannel();
+            channel.QueueDeclare(
+                queue.FullQueueName,
+                queue.Durable,
+                queue.Exclusive,
+                queue.AutoDelete,
+                queue.Arguments);
 
-			if (queue.AutoDelete)
-			{
-				_initQueues.Add(queue.FullQueueName);
-			}
-		}
+            if (queue.AutoDelete)
+            {
+                _initQueues.Add(queue.FullQueueName);
+            }
+        }
 
-		private void DeclareExchange(ExchangeConfiguration exchange)
-		{
-			if (IsInitialized(exchange))
-			{
-				return;
-			}
+        private void DeclareExchange(ExchangeConfiguration exchange)
+        {
+            if (IsInitialized(exchange))
+            {
+                return;
+            }
 
-			_logger.LogInformation($"Declaring exchange '{exchange.ExchangeName}'.");
-			var channel = GetOrCreateChannel();
-			channel.ExchangeDeclare(
-				exchange.ExchangeName,
-				exchange.ExchangeType,
-				exchange.Durable,
-				exchange.AutoDelete,
-				exchange.Arguments);
-			if (!exchange.AutoDelete)
-			{
-				_initExchanges.Add(exchange.ExchangeName);
-			}
-		}
+            _logger.LogInformation($"Declaring exchange '{exchange.ExchangeName}'.");
+            var channel = GetOrCreateChannel();
+            channel.ExchangeDeclare(
+                exchange.ExchangeName,
+                exchange.ExchangeType,
+                exchange.Durable,
+                exchange.AutoDelete,
+                exchange.Arguments);
+            if (!exchange.AutoDelete)
+            {
+                _initExchanges.Add(exchange.ExchangeName);
+            }
+        }
 
-		private void EnsureWorker()
-		{
-			if (_processing)
-			{
-				return;
-			}
-			lock (_processLock)
-			{
-				if (_processing)
-				{
-					return;
-				}
-				_processing = true;
-				_logger.LogDebug($"Start processing topology work.");
-			}
+        private void EnsureWorker()
+        {
+            if (_processing)
+            {
+                return;
+            }
+            lock (_processLock)
+            {
+                if (_processing)
+                {
+                    return;
+                }
+                _processing = true;
+                _logger.LogDebug($"Start processing topology work.");
+            }
 
-			ScheduledTopologyTask topologyTask;
-			while (_topologyTasks.TryDequeue(out topologyTask))
-			{
-				var exchange = topologyTask as ScheduledExchangeTask;
-				if (exchange != null)
-				{
-					try
-					{
-						DeclareExchange(exchange.Configuration);
-						exchange.TaskCompletionSource.TrySetResult(true);
-					}
-					catch (Exception e)
-					{
-						_logger.LogError($"Unable to declare exchange {exchange.Configuration.ExchangeName}", e);
-						exchange.TaskCompletionSource.TrySetException(e);
-					}
+            ScheduledTopologyTask topologyTask;
+            while (_topologyTasks.TryDequeue(out topologyTask))
+            {
+                var exchange = topologyTask as ScheduledExchangeTask;
+                if (exchange != null)
+                {
+                    try
+                    {
+                        DeclareExchange(exchange.Configuration);
+                        exchange.TaskCompletionSource.TrySetResult(true);
+                    }
+                    catch (Exception e)
+                    {
+                        _logger.LogError($"Unable to declare exchange {exchange.Configuration.ExchangeName}", e);
+                        exchange.TaskCompletionSource.TrySetException(e);
+                    }
 
-					continue;
-				}
+                    continue;
+                }
 
-				var queue = topologyTask as ScheduledQueueTask;
-				if (queue != null)
-				{
-					try
-					{
-						DeclareQueue(queue.Configuration);
-						queue.TaskCompletionSource.TrySetResult(true);
-					}
-					catch (Exception e)
-					{
-						_logger.LogError($"Unable to declare queue", e);
-						queue.TaskCompletionSource.TrySetException(e);
-					}
+                var queue = topologyTask as ScheduledQueueTask;
+                if (queue != null)
+                {
+                    try
+                    {
+                        DeclareQueue(queue.Configuration);
+                        queue.TaskCompletionSource.TrySetResult(true);
+                    }
+                    catch (Exception e)
+                    {
+                        _logger.LogError($"Unable to declare queue", e);
+                        queue.TaskCompletionSource.TrySetException(e);
+                    }
 
-					continue;
-				}
+                    continue;
+                }
 
-				var bind = topologyTask as ScheduledBindQueueTask;
-				if (bind != null)
-				{
-					try
-					{
-						BindQueueToExchange(bind);
-						bind.TaskCompletionSource.TrySetResult(true);
-					}
-					catch (Exception e)
-					{
-						_logger.LogError($"Unable to bind queue", e);
-						bind.TaskCompletionSource.TrySetException(e);
-					}
-					continue;
-				}
+                var bind = topologyTask as ScheduledBindQueueTask;
+                if (bind != null)
+                {
+                    try
+                    {
+                        BindQueueToExchange(bind);
+                        bind.TaskCompletionSource.TrySetResult(true);
+                    }
+                    catch (Exception e)
+                    {
+                        _logger.LogError($"Unable to bind queue", e);
+                        bind.TaskCompletionSource.TrySetException(e);
+                    }
+                    continue;
+                }
 
-				var unbind = topologyTask as ScheduledUnbindQueueTask;
-				if (unbind != null)
-				{
-					try
-					{
-						UnbindQueueFromExchange(unbind);
-						unbind.TaskCompletionSource.TrySetResult(true);
-					}
-					catch (Exception e)
-					{
-						_logger.LogError($"Unable to unbind queue", e);
-						unbind.TaskCompletionSource.TrySetException(e);
-					}
-					
-					continue;
-				}
+                var unbind = topologyTask as ScheduledUnbindQueueTask;
+                if (unbind != null)
+                {
+                    try
+                    {
+                        UnbindQueueFromExchange(unbind);
+                        unbind.TaskCompletionSource.TrySetResult(true);
+                    }
+                    catch (Exception e)
+                    {
+                        _logger.LogError($"Unable to unbind queue", e);
+                        unbind.TaskCompletionSource.TrySetException(e);
+                    }
+                    
+                    continue;
+                }
 
-				throw new Exception("Unable to cast topology task.");
-			}
-			_processing = false;
-			_logger.LogDebug($"Done processing topology work.");
-		}
+                throw new Exception("Unable to cast topology task.");
+            }
+            _processing = false;
+            _logger.LogDebug($"Done processing topology work.");
+        }
 
-		private IModel GetOrCreateChannel()
-		{
-			_disposeTimer.Change(TimeSpan.FromSeconds(2), new TimeSpan(-1));
-			if (_channel?.IsOpen ?? false)
-			{
-				return _channel;
-			}
+        private IModel GetOrCreateChannel()
+        {
+            _disposeTimer.Change(TimeSpan.FromSeconds(2), new TimeSpan(-1));
+            if (_channel?.IsOpen ?? false)
+            {
+                return _channel;
+            }
 
-			var channelTask = _channelFactory.CreateChannelAsync();
-			channelTask.Wait();
-			_channel = channelTask.Result;
-			return _channel;
-		}
+            var channelTask = _channelFactory.CreateChannelAsync();
+            channelTask.Wait();
+            _channel = channelTask.Result;
+            return _channel;
+        }
 
-		public void Dispose()
-		{
-			_channelFactory?.Dispose();
-		}
+        public void Dispose()
+        {
+            _channelFactory?.Dispose();
+        }
 
-		#region Classes for Scheduled Tasks
-		private abstract class ScheduledTopologyTask
-		{
-			protected ScheduledTopologyTask()
-			{
-				TaskCompletionSource = new TaskCompletionSource<bool>();
-			}
-			public TaskCompletionSource<bool> TaskCompletionSource { get; }
-		}
+        #region Classes for Scheduled Tasks
+        private abstract class ScheduledTopologyTask
+        {
+            protected ScheduledTopologyTask()
+            {
+                TaskCompletionSource = new TaskCompletionSource<bool>();
+            }
+            public TaskCompletionSource<bool> TaskCompletionSource { get; }
+        }
 
-		private class ScheduledQueueTask : ScheduledTopologyTask
-		{
-			public ScheduledQueueTask(QueueConfiguration queue)
-			{
-				Configuration = queue;
-			}
-			public QueueConfiguration Configuration { get; }
-		}
+        private class ScheduledQueueTask : ScheduledTopologyTask
+        {
+            public ScheduledQueueTask(QueueConfiguration queue)
+            {
+                Configuration = queue;
+            }
+            public QueueConfiguration Configuration { get; }
+        }
 
-		private class ScheduledExchangeTask : ScheduledTopologyTask
-		{
-			public ScheduledExchangeTask(ExchangeConfiguration exchange)
-			{
-				Configuration = exchange;
-			}
-			public ExchangeConfiguration Configuration { get; }
-		}
+        private class ScheduledExchangeTask : ScheduledTopologyTask
+        {
+            public ScheduledExchangeTask(ExchangeConfiguration exchange)
+            {
+                Configuration = exchange;
+            }
+            public ExchangeConfiguration Configuration { get; }
+        }
 
-		private class ScheduledBindQueueTask : ScheduledTopologyTask
-		{
-			public ExchangeConfiguration Exchange { get; set; }
-			public QueueConfiguration Queue { get; set; }
-			public string RoutingKey { get; set; }
-		}
+        private class ScheduledBindQueueTask : ScheduledTopologyTask
+        {
+            public ExchangeConfiguration Exchange { get; set; }
+            public QueueConfiguration Queue { get; set; }
+            public string RoutingKey { get; set; }
+        }
 
-		private class ScheduledUnbindQueueTask : ScheduledTopologyTask
-		{
-			public ExchangeConfiguration Exchange { get; set; }
-			public QueueConfiguration Queue { get; set; }
-			public string RoutingKey { get; set; }
-		}
-		#endregion
-	}
+        private class ScheduledUnbindQueueTask : ScheduledTopologyTask
+        {
+            public ExchangeConfiguration Exchange { get; set; }
+            public QueueConfiguration Queue { get; set; }
+            public string RoutingKey { get; set; }
+        }
+        #endregion
+    }
 }

--- a/src/RawRabbit/Configuration/Exchange/ExchangeConfiguration.cs
+++ b/src/RawRabbit/Configuration/Exchange/ExchangeConfiguration.cs
@@ -2,32 +2,32 @@
 
 namespace RawRabbit.Configuration.Exchange
 {
-	public class ExchangeConfiguration
-	{
-		public string ExchangeName { get; set; }
-		public string ExchangeType { get; set; }
-		public bool Durable { get; set; }
-		public bool AutoDelete { get; set; }
-		public IDictionary<string,object> Arguments { get; set; }
-		public bool AssumeInitialized { get; set; }
+    public class ExchangeConfiguration
+    {
+        public string ExchangeName { get; set; }
+        public string ExchangeType { get; set; }
+        public bool Durable { get; set; }
+        public bool AutoDelete { get; set; }
+        public IDictionary<string,object> Arguments { get; set; }
+        public bool AssumeInitialized { get; set; }
 
-		public ExchangeConfiguration()
-		{
-			Arguments = new Dictionary<string, object>();
-		}
+        public ExchangeConfiguration()
+        {
+            Arguments = new Dictionary<string, object>();
+        }
 
-		public ExchangeConfiguration(GeneralExchangeConfiguration exchange) : this()
-		{
-			Durable = exchange.Durable;
-			AutoDelete = exchange.AutoDelete;
-			ExchangeType = exchange.Type.ToString().ToLower();
-		}
+        public ExchangeConfiguration(GeneralExchangeConfiguration exchange) : this()
+        {
+            Durable = exchange.Durable;
+            AutoDelete = exchange.AutoDelete;
+            ExchangeType = exchange.Type.ToString().ToLower();
+        }
 
-		public static ExchangeConfiguration Default => new ExchangeConfiguration
-		{
-			ExchangeName = "",
-			ExchangeType = RabbitMQ.Client.ExchangeType.Topic
-		};
+        public static ExchangeConfiguration Default => new ExchangeConfiguration
+        {
+            ExchangeName = "",
+            ExchangeType = RabbitMQ.Client.ExchangeType.Topic
+        };
 
-	}
+    }
 }

--- a/src/RawRabbit/Configuration/Exchange/ExchangeConfigurationBuilder.cs
+++ b/src/RawRabbit/Configuration/Exchange/ExchangeConfigurationBuilder.cs
@@ -1,48 +1,48 @@
 ﻿namespace RawRabbit.Configuration.Exchange
 {
-	public class ExchangeConfigurationBuilder : IExchangeConfigurationBuilder
-	{
-		public ExchangeConfiguration Configuration { get; }
+    public class ExchangeConfigurationBuilder : IExchangeConfigurationBuilder
+    {
+        public ExchangeConfiguration Configuration { get; }
 
-		public ExchangeConfigurationBuilder(ExchangeConfiguration initialExchange = null)
-		{
-			Configuration = initialExchange ?? ExchangeConfiguration.Default;
-		}
+        public ExchangeConfigurationBuilder(ExchangeConfiguration initialExchange = null)
+        {
+            Configuration = initialExchange ?? ExchangeConfiguration.Default;
+        }
 
-		public IExchangeConfigurationBuilder WithName(string exchangeName)
-		{
-			Configuration.ExchangeName = exchangeName;
-			return this;
-		}
+        public IExchangeConfigurationBuilder WithName(string exchangeName)
+        {
+            Configuration.ExchangeName = exchangeName;
+            return this;
+        }
 
-		public IExchangeConfigurationBuilder WithType(ExchangeType exchangeType)
-		{
-			Configuration.ExchangeType = exchangeType.ToString().ToLower();
-			return this;
-		}
+        public IExchangeConfigurationBuilder WithType(ExchangeType exchangeType)
+        {
+            Configuration.ExchangeType = exchangeType.ToString().ToLower();
+            return this;
+        }
 
-		public IExchangeConfigurationBuilder WithDurability(bool durable = true)
-		{
-			Configuration.Durable = durable;
-			return this;
-		}
+        public IExchangeConfigurationBuilder WithDurability(bool durable = true)
+        {
+            Configuration.Durable = durable;
+            return this;
+        }
 
-		public IExchangeConfigurationBuilder WithAutoDelete(bool autoDelete = true)
-		{
-			Configuration.AutoDelete = autoDelete;
-			return this;
-		}
+        public IExchangeConfigurationBuilder WithAutoDelete(bool autoDelete = true)
+        {
+            Configuration.AutoDelete = autoDelete;
+            return this;
+        }
 
-		public IExchangeConfigurationBuilder WithArgument(string name, string value)
-		{
-			Configuration.Arguments.Add(name, value);
-			return this;
-		}
+        public IExchangeConfigurationBuilder WithArgument(string name, string value)
+        {
+            Configuration.Arguments.Add(name, value);
+            return this;
+        }
 
-		public IExchangeConfigurationBuilder AssumeInitialized(bool asumption = true)
-		{
-			Configuration.AssumeInitialized = asumption;
-			return this;
-		}
-	}
+        public IExchangeConfigurationBuilder AssumeInitialized(bool asumption = true)
+        {
+            Configuration.AssumeInitialized = asumption;
+            return this;
+        }
+    }
 }

--- a/src/RawRabbit/Configuration/Exchange/ExchangeConfigurationExtensions.cs
+++ b/src/RawRabbit/Configuration/Exchange/ExchangeConfigurationExtensions.cs
@@ -1,10 +1,10 @@
 ﻿namespace RawRabbit.Configuration.Exchange
 {
-	public static class ExchangeConfigurationExtensions
-	{
-		public static bool IsDefaultExchange(this ExchangeConfiguration configuration)
-		{
-			return string.IsNullOrEmpty(configuration.ExchangeName);
-		}
-	}
+    public static class ExchangeConfigurationExtensions
+    {
+        public static bool IsDefaultExchange(this ExchangeConfiguration configuration)
+        {
+            return string.IsNullOrEmpty(configuration.ExchangeName);
+        }
+    }
 }

--- a/src/RawRabbit/Configuration/Exchange/ExchangeType.cs
+++ b/src/RawRabbit/Configuration/Exchange/ExchangeType.cs
@@ -1,32 +1,32 @@
 ﻿namespace RawRabbit.Configuration.Exchange
 {
-	public enum ExchangeType
-	{
-		Unknown,
+    public enum ExchangeType
+    {
+        Unknown,
 
-		/// <summary>
-		/// Direct exchanges delivers messages to queues based on the message routing key. A direct exchange is ideal for the<br/>
-		/// unicast routing of messages (although they can be used for multicast routing as well).
-		/// </summary>
-		Direct,
+        /// <summary>
+        /// Direct exchanges delivers messages to queues based on the message routing key. A direct exchange is ideal for the<br/>
+        /// unicast routing of messages (although they can be used for multicast routing as well).
+        /// </summary>
+        Direct,
 
-		/// <summary>
-		/// Fanout exchanges routes messages to all of the queues that are bound to it and the routing key is ignored. <br/>
-		/// If N queues   are bound to a fanout exchange, when a new message is published to that exchange a copy of <br/>
-		/// the message is delivered to all N queues. Fanout exchanges are ideal for the broadcast routing of messages.
-		/// </summary>
-		Fanout,
+        /// <summary>
+        /// Fanout exchanges routes messages to all of the queues that are bound to it and the routing key is ignored. <br/>
+        /// If N queues   are bound to a fanout exchange, when a new message is published to that exchange a copy of <br/>
+        /// the message is delivered to all N queues. Fanout exchanges are ideal for the broadcast routing of messages.
+        /// </summary>
+        Fanout,
 
-		/// <summary>
-		/// Headers exchanges is designed for routing on multiple attributes that are more easily expressed as message headers than<br/>
-		/// a routing key. Headers exchanges ignore the routing key attribute
-		/// </summary>
-		Headers,
+        /// <summary>
+        /// Headers exchanges is designed for routing on multiple attributes that are more easily expressed as message headers than<br/>
+        /// a routing key. Headers exchanges ignore the routing key attribute
+        /// </summary>
+        Headers,
 
-		/// <summary>
-		/// Topic exchanges route messages to one or many queues based on matching between a message routing key and the pattern<br/>
-		/// that was used to bind a queue to an exchange.
-		/// </summary>
-		Topic
-	}
+        /// <summary>
+        /// Topic exchanges route messages to one or many queues based on matching between a message routing key and the pattern<br/>
+        /// that was used to bind a queue to an exchange.
+        /// </summary>
+        Topic
+    }
 }

--- a/src/RawRabbit/Configuration/Exchange/IExchangeConfigurationBuilder.cs
+++ b/src/RawRabbit/Configuration/Exchange/IExchangeConfigurationBuilder.cs
@@ -1,12 +1,12 @@
 ﻿namespace RawRabbit.Configuration.Exchange
 {
-	public interface IExchangeConfigurationBuilder
-	{
-		IExchangeConfigurationBuilder WithName(string exchangeName);
-		IExchangeConfigurationBuilder WithType(ExchangeType exchangeType);
-		IExchangeConfigurationBuilder WithDurability(bool durable = true);
-		IExchangeConfigurationBuilder WithAutoDelete(bool autoDelete= true);
-		IExchangeConfigurationBuilder WithArgument(string name, string value);
-		IExchangeConfigurationBuilder AssumeInitialized(bool asumption = true);
-	}
+    public interface IExchangeConfigurationBuilder
+    {
+        IExchangeConfigurationBuilder WithName(string exchangeName);
+        IExchangeConfigurationBuilder WithType(ExchangeType exchangeType);
+        IExchangeConfigurationBuilder WithDurability(bool durable = true);
+        IExchangeConfigurationBuilder WithAutoDelete(bool autoDelete= true);
+        IExchangeConfigurationBuilder WithArgument(string name, string value);
+        IExchangeConfigurationBuilder AssumeInitialized(bool asumption = true);
+    }
 }

--- a/src/RawRabbit/Configuration/Publish/IPublishConfigurationBuilder.cs
+++ b/src/RawRabbit/Configuration/Publish/IPublishConfigurationBuilder.cs
@@ -5,11 +5,11 @@ using RawRabbit.Configuration.Exchange;
 
 namespace RawRabbit.Configuration.Publish
 {
-	public interface IPublishConfigurationBuilder
-	{
-		IPublishConfigurationBuilder WithExchange(Action<IExchangeConfigurationBuilder> exchange);
-		IPublishConfigurationBuilder WithRoutingKey(string routingKey);
-		IPublishConfigurationBuilder WithProperties(Action<IBasicProperties> properties);
-		IPublishConfigurationBuilder WithMandatoryDelivery(EventHandler<BasicReturnEventArgs> basicReturn);
-	}
+    public interface IPublishConfigurationBuilder
+    {
+        IPublishConfigurationBuilder WithExchange(Action<IExchangeConfigurationBuilder> exchange);
+        IPublishConfigurationBuilder WithRoutingKey(string routingKey);
+        IPublishConfigurationBuilder WithProperties(Action<IBasicProperties> properties);
+        IPublishConfigurationBuilder WithMandatoryDelivery(EventHandler<BasicReturnEventArgs> basicReturn);
+    }
 }

--- a/src/RawRabbit/Configuration/Publish/PublishConfiguration.cs
+++ b/src/RawRabbit/Configuration/Publish/PublishConfiguration.cs
@@ -5,11 +5,11 @@ using RawRabbit.Configuration.Exchange;
 
 namespace RawRabbit.Configuration.Publish
 {
-	public class PublishConfiguration
-	{
-		public ExchangeConfiguration Exchange { get; set; }
-		public string RoutingKey { get; set; }
-		public Action<IBasicProperties> PropertyModifier { get; set; }
-		public EventHandler<BasicReturnEventArgs> BasicReturn { get; set; }
-	}
+    public class PublishConfiguration
+    {
+        public ExchangeConfiguration Exchange { get; set; }
+        public string RoutingKey { get; set; }
+        public Action<IBasicProperties> PropertyModifier { get; set; }
+        public EventHandler<BasicReturnEventArgs> BasicReturn { get; set; }
+    }
 }

--- a/src/RawRabbit/Configuration/Publish/PublishConfigurationBuilder.cs
+++ b/src/RawRabbit/Configuration/Publish/PublishConfigurationBuilder.cs
@@ -6,56 +6,56 @@ using RawRabbit.Configuration.Request;
 
 namespace RawRabbit.Configuration.Publish
 {
-	public class PublishConfigurationBuilder : IPublishConfigurationBuilder
-	{
-		private readonly ExchangeConfigurationBuilder _exchange;
-		private string _routingKey;
-		private Action<IBasicProperties> _properties;
-		private const string _oneOrMoreWords = "#";
-		private EventHandler<BasicReturnEventArgs> _basicReturn;
+    public class PublishConfigurationBuilder : IPublishConfigurationBuilder
+    {
+        private readonly ExchangeConfigurationBuilder _exchange;
+        private string _routingKey;
+        private Action<IBasicProperties> _properties;
+        private const string _oneOrMoreWords = "#";
+        private EventHandler<BasicReturnEventArgs> _basicReturn;
 
-		public PublishConfiguration Configuration => new PublishConfiguration
-		{
-			Exchange = _exchange.Configuration,
-			RoutingKey = _routingKey,
-			PropertyModifier = _properties ?? (b => {}),
-			BasicReturn = _basicReturn
-		};
+        public PublishConfiguration Configuration => new PublishConfiguration
+        {
+            Exchange = _exchange.Configuration,
+            RoutingKey = _routingKey,
+            PropertyModifier = _properties ?? (b => {}),
+            BasicReturn = _basicReturn
+        };
 
-		public PublishConfigurationBuilder(ExchangeConfiguration defaultExchange = null, string routingKey =null)
-		{
-			_exchange = new ExchangeConfigurationBuilder(defaultExchange);
-			_routingKey = routingKey ?? _oneOrMoreWords;
-		}
+        public PublishConfigurationBuilder(ExchangeConfiguration defaultExchange = null, string routingKey =null)
+        {
+            _exchange = new ExchangeConfigurationBuilder(defaultExchange);
+            _routingKey = routingKey ?? _oneOrMoreWords;
+        }
 
-		public PublishConfigurationBuilder(RequestConfiguration defaultConfig)
-		{
-			_exchange = new ExchangeConfigurationBuilder(defaultConfig.Exchange);
-		}
+        public PublishConfigurationBuilder(RequestConfiguration defaultConfig)
+        {
+            _exchange = new ExchangeConfigurationBuilder(defaultConfig.Exchange);
+        }
 
-		public IPublishConfigurationBuilder WithExchange(Action<IExchangeConfigurationBuilder> exchange)
-		{
-			exchange(_exchange);
-			Configuration.Exchange = _exchange.Configuration;
-			return this;
-		}
+        public IPublishConfigurationBuilder WithExchange(Action<IExchangeConfigurationBuilder> exchange)
+        {
+            exchange(_exchange);
+            Configuration.Exchange = _exchange.Configuration;
+            return this;
+        }
 
-		public IPublishConfigurationBuilder WithRoutingKey(string routingKey)
-		{
-			_routingKey = routingKey;
-			return this;
-		}
+        public IPublishConfigurationBuilder WithRoutingKey(string routingKey)
+        {
+            _routingKey = routingKey;
+            return this;
+        }
 
-		public IPublishConfigurationBuilder WithProperties(Action<IBasicProperties> properties)
-		{
-			_properties = properties;
-			return this;
-		}
+        public IPublishConfigurationBuilder WithProperties(Action<IBasicProperties> properties)
+        {
+            _properties = properties;
+            return this;
+        }
 
-		public IPublishConfigurationBuilder WithMandatoryDelivery(EventHandler<BasicReturnEventArgs> basicReturn)
-		{
-			_basicReturn = basicReturn;
-			return this;
-		}
-	}
+        public IPublishConfigurationBuilder WithMandatoryDelivery(EventHandler<BasicReturnEventArgs> basicReturn)
+        {
+            _basicReturn = basicReturn;
+            return this;
+        }
+    }
 }

--- a/src/RawRabbit/Configuration/Queue/IQueueConfigurationBuilder.cs
+++ b/src/RawRabbit/Configuration/Queue/IQueueConfigurationBuilder.cs
@@ -1,12 +1,12 @@
 ﻿namespace RawRabbit.Configuration.Queue
 {
-	public interface IQueueConfigurationBuilder
-	{
-		IQueueConfigurationBuilder WithName(string queueName);
-		IQueueConfigurationBuilder WithAutoDelete(bool autoDelete = true);
-		IQueueConfigurationBuilder WithDurability(bool durable = true);
-		IQueueConfigurationBuilder WithExclusivity(bool exclusive = true);
-		IQueueConfigurationBuilder WithArgument(string key, object value);
-		
-	}
+    public interface IQueueConfigurationBuilder
+    {
+        IQueueConfigurationBuilder WithName(string queueName);
+        IQueueConfigurationBuilder WithAutoDelete(bool autoDelete = true);
+        IQueueConfigurationBuilder WithDurability(bool durable = true);
+        IQueueConfigurationBuilder WithExclusivity(bool exclusive = true);
+        IQueueConfigurationBuilder WithArgument(string key, object value);
+        
+    }
 }

--- a/src/RawRabbit/Configuration/Queue/QueueConfiguration.cs
+++ b/src/RawRabbit/Configuration/Queue/QueueConfiguration.cs
@@ -2,41 +2,41 @@
 
 namespace RawRabbit.Configuration.Queue
 {
-	public class QueueConfiguration
-	{
-		public string FullQueueName
-		{
-			get
-			{
-				var fullQueueName =  string.IsNullOrEmpty(NameSuffix)
-					? QueueName
-					: $"{QueueName}_{NameSuffix}";
+    public class QueueConfiguration
+    {
+        public string FullQueueName
+        {
+            get
+            {
+                var fullQueueName =  string.IsNullOrEmpty(NameSuffix)
+                    ? QueueName
+                    : $"{QueueName}_{NameSuffix}";
 
-				return fullQueueName.Length > 254
-					? string.Concat("...", fullQueueName.Substring(fullQueueName.Length - 250))
-					: fullQueueName;
-			}
-		}
+                return fullQueueName.Length > 254
+                    ? string.Concat("...", fullQueueName.Substring(fullQueueName.Length - 250))
+                    : fullQueueName;
+            }
+        }
 
-		public string QueueName { get; set; }
-		public string NameSuffix { get; set; }
-		public bool Durable { get; set; }
-		public bool Exclusive { get; set; }
-		public bool AutoDelete { get; set; }
-		public Dictionary<string, object> Arguments { get; set; }
+        public string QueueName { get; set; }
+        public string NameSuffix { get; set; }
+        public bool Durable { get; set; }
+        public bool Exclusive { get; set; }
+        public bool AutoDelete { get; set; }
+        public Dictionary<string, object> Arguments { get; set; }
 
-		public QueueConfiguration()
-		{
-			Arguments = new Dictionary<string, object>();
-		}
+        public QueueConfiguration()
+        {
+            Arguments = new Dictionary<string, object>();
+        }
 
-		public QueueConfiguration(GeneralQueueConfiguration cfg) : this()
-		{
-			Durable = cfg.Durable;
-			AutoDelete = cfg.AutoDelete;
-			Exclusive = cfg.Exclusive;
-		}
+        public QueueConfiguration(GeneralQueueConfiguration cfg) : this()
+        {
+            Durable = cfg.Durable;
+            AutoDelete = cfg.AutoDelete;
+            Exclusive = cfg.Exclusive;
+        }
 
-		public static QueueConfiguration Default => new QueueConfiguration { };
-	}
+        public static QueueConfiguration Default => new QueueConfiguration { };
+    }
 }

--- a/src/RawRabbit/Configuration/Queue/QueueConfigurationBuilder.cs
+++ b/src/RawRabbit/Configuration/Queue/QueueConfigurationBuilder.cs
@@ -1,48 +1,48 @@
 ﻿namespace RawRabbit.Configuration.Queue
 {
-	public class QueueConfigurationBuilder : IQueueConfigurationBuilder
-	{
-		public QueueConfiguration Configuration { get;}
+    public class QueueConfigurationBuilder : IQueueConfigurationBuilder
+    {
+        public QueueConfiguration Configuration { get;}
 
-		public QueueConfigurationBuilder(QueueConfiguration initialQueue = null)
-		{
-			Configuration = initialQueue ?? QueueConfiguration.Default;
-		}
+        public QueueConfigurationBuilder(QueueConfiguration initialQueue = null)
+        {
+            Configuration = initialQueue ?? QueueConfiguration.Default;
+        }
 
-		public IQueueConfigurationBuilder WithName(string queueName)
-		{
-			Configuration.QueueName = queueName;
-			return this;
-		}
+        public IQueueConfigurationBuilder WithName(string queueName)
+        {
+            Configuration.QueueName = queueName;
+            return this;
+        }
 
-		public IQueueConfigurationBuilder WithNameSuffix(string suffix)
-		{
-			Configuration.NameSuffix = suffix;
-			return this;
-		}
+        public IQueueConfigurationBuilder WithNameSuffix(string suffix)
+        {
+            Configuration.NameSuffix = suffix;
+            return this;
+        }
 
-		public IQueueConfigurationBuilder WithAutoDelete(bool autoDelete = true)
-		{
-			Configuration.AutoDelete = autoDelete;
-			return this;
-		}
+        public IQueueConfigurationBuilder WithAutoDelete(bool autoDelete = true)
+        {
+            Configuration.AutoDelete = autoDelete;
+            return this;
+        }
 
-		public IQueueConfigurationBuilder WithDurability(bool durable = true)
-		{
-			Configuration.Durable = durable;
-			return this;
-		}
+        public IQueueConfigurationBuilder WithDurability(bool durable = true)
+        {
+            Configuration.Durable = durable;
+            return this;
+        }
 
-		public IQueueConfigurationBuilder WithExclusivity(bool exclusive = true)
-		{
-			Configuration.Exclusive = exclusive;
-			return this;
-		}
+        public IQueueConfigurationBuilder WithExclusivity(bool exclusive = true)
+        {
+            Configuration.Exclusive = exclusive;
+            return this;
+        }
 
-		public IQueueConfigurationBuilder WithArgument(string key, object value)
-		{
-			Configuration.Arguments.Add(key, value);
-			return this;
-		}
-	}
+        public IQueueConfigurationBuilder WithArgument(string key, object value)
+        {
+            Configuration.Arguments.Add(key, value);
+            return this;
+        }
+    }
 }

--- a/src/RawRabbit/Configuration/Queue/QueueConfigurationExtensions.cs
+++ b/src/RawRabbit/Configuration/Queue/QueueConfigurationExtensions.cs
@@ -2,13 +2,13 @@
 
 namespace RawRabbit.Configuration.Queue
 {
-	public static class QueueConfigurationExtensions
-	{
-		private static readonly string _directQueueName = "amq.rabbitmq.reply-to";
+    public static class QueueConfigurationExtensions
+    {
+        private static readonly string _directQueueName = "amq.rabbitmq.reply-to";
 
-		public static bool IsDirectReplyTo(this QueueConfiguration queue)
-		{
-			return string.Equals(queue.QueueName, _directQueueName, StringComparison.CurrentCultureIgnoreCase);
-		}
-	}
+        public static bool IsDirectReplyTo(this QueueConfiguration queue)
+        {
+            return string.Equals(queue.QueueName, _directQueueName, StringComparison.CurrentCultureIgnoreCase);
+        }
+    }
 }

--- a/src/RawRabbit/Configuration/RawRabbitConfiguration.cs
+++ b/src/RawRabbit/Configuration/RawRabbitConfiguration.cs
@@ -5,201 +5,201 @@ using ExchangeType = RawRabbit.Configuration.Exchange.ExchangeType;
 
 namespace RawRabbit.Configuration
 {
-	public class RawRabbitConfiguration
-	{
-		/// <summary>
-		/// The amount of time to wait for response to request. Defaults to 10 seconds.
-		/// </summary>
-		public TimeSpan RequestTimeout { get; set; }
+    public class RawRabbitConfiguration
+    {
+        /// <summary>
+        /// The amount of time to wait for response to request. Defaults to 10 seconds.
+        /// </summary>
+        public TimeSpan RequestTimeout { get; set; }
 
-		/// <summary>
-		/// The amount of time to wait for a publish to be confirmed. Default to 1 second.
-		/// Read more at: https://www.rabbitmq.com/confirms.html
-		/// </summary>
-		public TimeSpan PublishConfirmTimeout { get; set; }
+        /// <summary>
+        /// The amount of time to wait for a publish to be confirmed. Default to 1 second.
+        /// Read more at: https://www.rabbitmq.com/confirms.html
+        /// </summary>
+        public TimeSpan PublishConfirmTimeout { get; set; }
 
-		/// <summary>
-		/// The amount of time to wait for message handlers to process message before
-		/// shutting down.
-		/// </summary>
-		public TimeSpan GracefulShutdown { get; set; }
+        /// <summary>
+        /// The amount of time to wait for message handlers to process message before
+        /// shutting down.
+        /// </summary>
+        public TimeSpan GracefulShutdown { get; set; }
 
-		/// <summary>
-		/// Appends the message's global id to the publish routing key and wild cards (#)
-		/// to subscribers routing key.
-		/// </summary>
-		public bool RouteWithGlobalId { get; set; }
+        /// <summary>
+        /// Appends the message's global id to the publish routing key and wild cards (#)
+        /// to subscribers routing key.
+        /// </summary>
+        public bool RouteWithGlobalId { get; set; }
 
-		/// <summary>
-		/// Indicates if automatic recovery (reconnect, re-open channels, restore QoS) should be enabled
-		/// Defaults to true.
-		/// </summary>
-		public bool AutomaticRecovery { get; set; }
+        /// <summary>
+        /// Indicates if automatic recovery (reconnect, re-open channels, restore QoS) should be enabled
+        /// Defaults to true.
+        /// </summary>
+        public bool AutomaticRecovery { get; set; }
 
-		/// <summary>
-		/// Indicates if topology recovery (re-declare queues/exchanges, recover bindings and consumers) should be enabled
-		/// Defaults to true
-		/// </summary>
-		public bool TopologyRecovery { get; set;}
+        /// <summary>
+        /// Indicates if topology recovery (re-declare queues/exchanges, recover bindings and consumers) should be enabled
+        /// Defaults to true
+        /// </summary>
+        public bool TopologyRecovery { get; set;}
 
-		/// <summary>
-		/// The default values for exchnages. Can be overriden using the fluent configuration
-		/// builder that is available as an optional argument for all operations
-		/// </summary>
-		public GeneralExchangeConfiguration Exchange { get; set; }
+        /// <summary>
+        /// The default values for exchnages. Can be overriden using the fluent configuration
+        /// builder that is available as an optional argument for all operations
+        /// </summary>
+        public GeneralExchangeConfiguration Exchange { get; set; }
 
-		/// <summary>
-		/// The default values for queues. Can be overriden using the fluent configuration
-		/// builder that is available as an optional argument for all operations
-		/// </summary>
-		public GeneralQueueConfiguration Queue { get; set; }
+        /// <summary>
+        /// The default values for queues. Can be overriden using the fluent configuration
+        /// builder that is available as an optional argument for all operations
+        /// </summary>
+        public GeneralQueueConfiguration Queue { get; set; }
 
-		/// <summary>
-		/// Indicates if messages should be stored on disk or held in memory.
-		/// Set this to false if performance is more important than delivery of messages.
-		/// </summary>
-		public bool PersistentDeliveryMode { get; set; }
+        /// <summary>
+        /// Indicates if messages should be stored on disk or held in memory.
+        /// Set this to false if performance is more important than delivery of messages.
+        /// </summary>
+        public bool PersistentDeliveryMode { get; set; }
 
-		/// <summary>
-		/// Indicates if a connection should be closed when the last channel disconnects
-		/// from the connection. Read more: https://www.rabbitmq.com/dotnet-api-guide.html
-		/// </summary>
-		public bool AutoCloseConnection { get; set; }
+        /// <summary>
+        /// Indicates if a connection should be closed when the last channel disconnects
+        /// from the connection. Read more: https://www.rabbitmq.com/dotnet-api-guide.html
+        /// </summary>
+        public bool AutoCloseConnection { get; set; }
 
-		/// <summary>
-		/// Used for configure Ssl connection to the broker(s).
-		/// </summary>
-		public SslOption Ssl { get; set; }
+        /// <summary>
+        /// Used for configure Ssl connection to the broker(s).
+        /// </summary>
+        public SslOption Ssl { get; set; }
 
-	    public string VirtualHost { get; set; }
-		public string Username { get; set; }
-		public string Password { get; set; }
-		public int Port { get; set; }
-		public List<string> Hostnames { get; set; }
-		public TimeSpan RecoveryInterval { get; set; }
+        public string VirtualHost { get; set; }
+        public string Username { get; set; }
+        public string Password { get; set; }
+        public int Port { get; set; }
+        public List<string> Hostnames { get; set; }
+        public TimeSpan RecoveryInterval { get; set; }
 
-		public RawRabbitConfiguration()
-		{
-			RequestTimeout = TimeSpan.FromSeconds(10);
-			PublishConfirmTimeout = TimeSpan.FromSeconds(1);
-			PersistentDeliveryMode = true;
-			AutoCloseConnection = true;
-			AutomaticRecovery = true;
-			TopologyRecovery = true;
-			RouteWithGlobalId = true;
-			RecoveryInterval = TimeSpan.FromSeconds(10);
-			GracefulShutdown = TimeSpan.FromSeconds(10);
-			Ssl = new SslOption {Enabled = false};
-			Hostnames = new List<string>();
-			Exchange = new GeneralExchangeConfiguration
-			{
-				AutoDelete = false,
-				Durable = true,
-				Type = ExchangeType.Topic
-			};
-			Queue = new GeneralQueueConfiguration
-			{
-				Exclusive = false,
-				AutoDelete = false,
-				Durable = true
-			};
-		    VirtualHost = "/";
-		    Username = "guest";
-		    Password = "guest";
-		    Port = 5672;
-		    Hostnames = new List<string> {"localhost"};
-		}
+        public RawRabbitConfiguration()
+        {
+            RequestTimeout = TimeSpan.FromSeconds(10);
+            PublishConfirmTimeout = TimeSpan.FromSeconds(1);
+            PersistentDeliveryMode = true;
+            AutoCloseConnection = true;
+            AutomaticRecovery = true;
+            TopologyRecovery = true;
+            RouteWithGlobalId = true;
+            RecoveryInterval = TimeSpan.FromSeconds(10);
+            GracefulShutdown = TimeSpan.FromSeconds(10);
+            Ssl = new SslOption {Enabled = false};
+            Hostnames = new List<string>();
+            Exchange = new GeneralExchangeConfiguration
+            {
+                AutoDelete = false,
+                Durable = true,
+                Type = ExchangeType.Topic
+            };
+            Queue = new GeneralQueueConfiguration
+            {
+                Exclusive = false,
+                AutoDelete = false,
+                Durable = true
+            };
+            VirtualHost = "/";
+            Username = "guest";
+            Password = "guest";
+            Port = 5672;
+            Hostnames = new List<string> {"localhost"};
+        }
 
-		public static RawRabbitConfiguration Local => new RawRabbitConfiguration
-		{
-			VirtualHost = "/",
-			Username = "guest",
-			Password = "guest",
-			Port = 5672,
-			Hostnames = new List<string> { "localhost" }
-		};
-		
-	}
+        public static RawRabbitConfiguration Local => new RawRabbitConfiguration
+        {
+            VirtualHost = "/",
+            Username = "guest",
+            Password = "guest",
+            Port = 5672,
+            Hostnames = new List<string> { "localhost" }
+        };
+        
+    }
 
-	public class GeneralQueueConfiguration
-	{
-		/// <summary>
-		/// <para>
-		/// If set, the queue is deleted when all consumers have finished using it. The last consumer can be cancelled<br/>
-		/// either explicitly or because its channel is closed. If there was no consumer ever on the queue, it won't be<br/>
-		/// deleted. Applications can explicitly delete auto-delete queues using the Delete method as normal.
-		/// </para>
-		/// </summary>
-		public bool AutoDelete { get; set; }
+    public class GeneralQueueConfiguration
+    {
+        /// <summary>
+        /// <para>
+        /// If set, the queue is deleted when all consumers have finished using it. The last consumer can be cancelled<br/>
+        /// either explicitly or because its channel is closed. If there was no consumer ever on the queue, it won't be<br/>
+        /// deleted. Applications can explicitly delete auto-delete queues using the Delete method as normal.
+        /// </para>
+        /// </summary>
+        public bool AutoDelete { get; set; }
 
-		/// <summary>
-		/// <para>
-		/// Durable queues are persisted to disk and thus survive broker restarts. Queues that are not durable are called transient.<br/>
-		/// Not all scenarios and use cases mandate queues to be durable.
-		/// </para>
-		///<para>
-		/// Durability of a queue does not make messages that are routed to that queue durable.If broker is taken down and then brought<br/>
-		/// back up, durable queue will be re-declared during broker startup, however, only persistent messages will be recovered.
-		/// </para>
-		/// </summary>
-		public bool Durable { get; set; }
+        /// <summary>
+        /// <para>
+        /// Durable queues are persisted to disk and thus survive broker restarts. Queues that are not durable are called transient.<br/>
+        /// Not all scenarios and use cases mandate queues to be durable.
+        /// </para>
+        ///<para>
+        /// Durability of a queue does not make messages that are routed to that queue durable.If broker is taken down and then brought<br/>
+        /// back up, durable queue will be re-declared during broker startup, however, only persistent messages will be recovered.
+        /// </para>
+        /// </summary>
+        public bool Durable { get; set; }
 
-		/// <summary>
-		/// Exclusive queues are used by only one connection and the queue will be deleted when that connection closes.
-		/// </summary>
-		public bool Exclusive { get; set; }
-	}
+        /// <summary>
+        /// Exclusive queues are used by only one connection and the queue will be deleted when that connection closes.
+        /// </summary>
+        public bool Exclusive { get; set; }
+    }
 
-	public class GeneralExchangeConfiguration
-	{
-		/// <summary>
-		/// Exchanges can be durable or transient. Durable exchanges survive broker restart whereas transient <br />
-		/// exchanges do not (they have to be redeclared when broker comes back online). Not all scenarios <br />
-		/// and use cases require exchanges to be durable.
-		/// <a href="https://www.rabbitmq.com/tutorials/amqp-concepts.html">https://www.rabbitmq.com/tutorials/amqp-concepts.html</a>
-		/// </summary>
-		public bool Durable { get; set; }
+    public class GeneralExchangeConfiguration
+    {
+        /// <summary>
+        /// Exchanges can be durable or transient. Durable exchanges survive broker restart whereas transient <br />
+        /// exchanges do not (they have to be redeclared when broker comes back online). Not all scenarios <br />
+        /// and use cases require exchanges to be durable.
+        /// <a href="https://www.rabbitmq.com/tutorials/amqp-concepts.html">https://www.rabbitmq.com/tutorials/amqp-concepts.html</a>
+        /// </summary>
+        public bool Durable { get; set; }
 
-		/// <summary>
-		/// If set, the exchange is deleted when all queues have finished using it.
-		/// <a href="https://www.rabbitmq.com/amqp-0-9-1-reference.html">https://www.rabbitmq.com/amqp-0-9-1-reference.html</a>
-		/// </summary>
-		public bool AutoDelete { get; set; }
+        /// <summary>
+        /// If set, the exchange is deleted when all queues have finished using it.
+        /// <a href="https://www.rabbitmq.com/amqp-0-9-1-reference.html">https://www.rabbitmq.com/amqp-0-9-1-reference.html</a>
+        /// </summary>
+        public bool AutoDelete { get; set; }
 
-		/// <summary>
-		/// There are four different types of exchanges see <see cref="RawRabbit.Configuration.Exchange"/> for more info.
-		/// </summary>
-		public ExchangeType Type { get; set; }
-	}
+        /// <summary>
+        /// There are four different types of exchanges see <see cref="RawRabbit.Configuration.Exchange"/> for more info.
+        /// </summary>
+        public ExchangeType Type { get; set; }
+    }
 
-	public static class RawRabbitConfigurationExtensions
-	{
-		/// <summary>
-		/// Changes the configuration so that it does not use PersistentDeliveryMode. Also,
-		/// it sets the exchange type to Direct to increase performance, however that
-		/// disables the ability to use the MessageSequence extension.
-		/// </summary>
-		/// <param name="config">The RawRabbit configuration object</param>
-		/// <returns></returns>
-		public static RawRabbitConfiguration AsHighPerformance(this RawRabbitConfiguration config)
-		{
-			config.PersistentDeliveryMode = false;
-			config.RouteWithGlobalId = false;
-			config.Exchange.Type = ExchangeType.Direct;
-			return config;
-		}
+    public static class RawRabbitConfigurationExtensions
+    {
+        /// <summary>
+        /// Changes the configuration so that it does not use PersistentDeliveryMode. Also,
+        /// it sets the exchange type to Direct to increase performance, however that
+        /// disables the ability to use the MessageSequence extension.
+        /// </summary>
+        /// <param name="config">The RawRabbit configuration object</param>
+        /// <returns></returns>
+        public static RawRabbitConfiguration AsHighPerformance(this RawRabbitConfiguration config)
+        {
+            config.PersistentDeliveryMode = false;
+            config.RouteWithGlobalId = false;
+            config.Exchange.Type = ExchangeType.Direct;
+            return config;
+        }
 
-		/// <summary>
-		/// Disables RouteWithGlobalId to keep routing keys intact with older versions of
-		/// RawRabbit and sets exchange type to Direct.
-		/// </summary>
-		/// <param name="config"></param>
-		/// <returns></returns>
-		public static RawRabbitConfiguration AsLegacy(this RawRabbitConfiguration config)
-		{
-			config.Exchange.Type = ExchangeType.Direct;
-			config.RouteWithGlobalId = false;
-			return config;
-		}
-	}
+        /// <summary>
+        /// Disables RouteWithGlobalId to keep routing keys intact with older versions of
+        /// RawRabbit and sets exchange type to Direct.
+        /// </summary>
+        /// <param name="config"></param>
+        /// <returns></returns>
+        public static RawRabbitConfiguration AsLegacy(this RawRabbitConfiguration config)
+        {
+            config.Exchange.Type = ExchangeType.Direct;
+            config.RouteWithGlobalId = false;
+            return config;
+        }
+    }
 }

--- a/src/RawRabbit/Configuration/Request/IRequestConfigurationBuilder.cs
+++ b/src/RawRabbit/Configuration/Request/IRequestConfigurationBuilder.cs
@@ -4,11 +4,11 @@ using RawRabbit.Configuration.Queue;
 
 namespace RawRabbit.Configuration.Request
 {
-	public interface IRequestConfigurationBuilder
-	{
-		IRequestConfigurationBuilder WithExchange(Action<IExchangeConfigurationBuilder> exchange);
-		IRequestConfigurationBuilder WithRoutingKey(string routingKey);
-		IRequestConfigurationBuilder WithReplyQueue(Action<IQueueConfigurationBuilder> replyTo);
-		IRequestConfigurationBuilder WithNoAck(bool noAck);
-	}
+    public interface IRequestConfigurationBuilder
+    {
+        IRequestConfigurationBuilder WithExchange(Action<IExchangeConfigurationBuilder> exchange);
+        IRequestConfigurationBuilder WithRoutingKey(string routingKey);
+        IRequestConfigurationBuilder WithReplyQueue(Action<IQueueConfigurationBuilder> replyTo);
+        IRequestConfigurationBuilder WithNoAck(bool noAck);
+    }
 }

--- a/src/RawRabbit/Configuration/Request/RequestConfiguration.cs
+++ b/src/RawRabbit/Configuration/Request/RequestConfiguration.cs
@@ -4,23 +4,23 @@ using RawRabbit.Configuration.Respond;
 
 namespace RawRabbit.Configuration.Request
 {
-	public class RequestConfiguration : IConsumerConfiguration
-	{
-		public ExchangeConfiguration Exchange { get; set; }
-		public string RoutingKey { get; set; }
+    public class RequestConfiguration : IConsumerConfiguration
+    {
+        public ExchangeConfiguration Exchange { get; set; }
+        public string RoutingKey { get; set; }
 
-		/* Response Queue Configuration*/
-		public bool NoAck { get; set; }
-		public ushort PrefetchCount => 1; // Only expect one response
-		public QueueConfiguration Queue => ReplyQueue;
-		public QueueConfiguration ReplyQueue { get; set; }
-		public string ReplyQueueRoutingKey { get; set; }
+        /* Response Queue Configuration*/
+        public bool NoAck { get; set; }
+        public ushort PrefetchCount => 1; // Only expect one response
+        public QueueConfiguration Queue => ReplyQueue;
+        public QueueConfiguration ReplyQueue { get; set; }
+        public string ReplyQueueRoutingKey { get; set; }
 
-		public RequestConfiguration()
-		{
-			Exchange = new ExchangeConfiguration();
-			ReplyQueue = new QueueConfiguration();
-			NoAck = true;
-		}
-	}
+        public RequestConfiguration()
+        {
+            Exchange = new ExchangeConfiguration();
+            ReplyQueue = new QueueConfiguration();
+            NoAck = true;
+        }
+    }
 }

--- a/src/RawRabbit/Configuration/Request/RequestConfigurationBuilder.cs
+++ b/src/RawRabbit/Configuration/Request/RequestConfigurationBuilder.cs
@@ -4,43 +4,43 @@ using RawRabbit.Configuration.Queue;
 
 namespace RawRabbit.Configuration.Request
 {
-	public class RequestConfigurationBuilder : IRequestConfigurationBuilder
-	{
-		private readonly QueueConfigurationBuilder _replyQueue;
-		private readonly ExchangeConfigurationBuilder _exchange;
-		public RequestConfiguration Configuration { get; }
+    public class RequestConfigurationBuilder : IRequestConfigurationBuilder
+    {
+        private readonly QueueConfigurationBuilder _replyQueue;
+        private readonly ExchangeConfigurationBuilder _exchange;
+        public RequestConfiguration Configuration { get; }
 
-		public RequestConfigurationBuilder(RequestConfiguration defaultConfig)
-		{
-			_replyQueue = new QueueConfigurationBuilder(defaultConfig.ReplyQueue);
-			_exchange = new ExchangeConfigurationBuilder(defaultConfig.Exchange);
-			Configuration = defaultConfig ?? new RequestConfiguration();
-		}
+        public RequestConfigurationBuilder(RequestConfiguration defaultConfig)
+        {
+            _replyQueue = new QueueConfigurationBuilder(defaultConfig.ReplyQueue);
+            _exchange = new ExchangeConfigurationBuilder(defaultConfig.Exchange);
+            Configuration = defaultConfig ?? new RequestConfiguration();
+        }
 
-		public IRequestConfigurationBuilder WithExchange(Action<IExchangeConfigurationBuilder> exchange)
-		{
-			exchange(_exchange);
-			Configuration.Exchange = _exchange.Configuration;
-			return this;
-		}
+        public IRequestConfigurationBuilder WithExchange(Action<IExchangeConfigurationBuilder> exchange)
+        {
+            exchange(_exchange);
+            Configuration.Exchange = _exchange.Configuration;
+            return this;
+        }
 
-		public IRequestConfigurationBuilder WithRoutingKey(string routingKey)
-		{
-			Configuration.RoutingKey = routingKey;
-			return this;
-		}
+        public IRequestConfigurationBuilder WithRoutingKey(string routingKey)
+        {
+            Configuration.RoutingKey = routingKey;
+            return this;
+        }
 
-		public IRequestConfigurationBuilder WithReplyQueue(Action<IQueueConfigurationBuilder> replyTo)
-		{
-			replyTo(_replyQueue);
-			Configuration.ReplyQueue = _replyQueue.Configuration;
-			return this;
-		}
+        public IRequestConfigurationBuilder WithReplyQueue(Action<IQueueConfigurationBuilder> replyTo)
+        {
+            replyTo(_replyQueue);
+            Configuration.ReplyQueue = _replyQueue.Configuration;
+            return this;
+        }
 
-		public IRequestConfigurationBuilder WithNoAck(bool noAck)
-		{
-			Configuration.NoAck = noAck;
-			return this;
-		}
-	}
+        public IRequestConfigurationBuilder WithNoAck(bool noAck)
+        {
+            Configuration.NoAck = noAck;
+            return this;
+        }
+    }
 }

--- a/src/RawRabbit/Configuration/Respond/IResponderConfigurationBuilder.cs
+++ b/src/RawRabbit/Configuration/Respond/IResponderConfigurationBuilder.cs
@@ -4,12 +4,12 @@ using RawRabbit.Configuration.Queue;
 
 namespace RawRabbit.Configuration.Respond
 {
-	public interface IResponderConfigurationBuilder
-	{
-		IResponderConfigurationBuilder WithPrefetchCount(ushort count);
-		IResponderConfigurationBuilder WithExchange(Action<IExchangeConfigurationBuilder> exchange);
-		IResponderConfigurationBuilder WithQueue(Action<IQueueConfigurationBuilder> queue);
-		IResponderConfigurationBuilder WithRoutingKey(string routingKey);
-		IResponderConfigurationBuilder WithNoAck(bool noAck);
-	}
+    public interface IResponderConfigurationBuilder
+    {
+        IResponderConfigurationBuilder WithPrefetchCount(ushort count);
+        IResponderConfigurationBuilder WithExchange(Action<IExchangeConfigurationBuilder> exchange);
+        IResponderConfigurationBuilder WithQueue(Action<IQueueConfigurationBuilder> queue);
+        IResponderConfigurationBuilder WithRoutingKey(string routingKey);
+        IResponderConfigurationBuilder WithNoAck(bool noAck);
+    }
 }

--- a/src/RawRabbit/Configuration/Respond/ResponderConfiguration.cs
+++ b/src/RawRabbit/Configuration/Respond/ResponderConfiguration.cs
@@ -3,32 +3,32 @@ using RawRabbit.Configuration.Queue;
 
 namespace RawRabbit.Configuration.Respond
 {
-	public class ResponderConfiguration : IConsumerConfiguration
-	{
-		public bool NoAck { get; set; }
-		public ushort PrefetchCount { get; set; }
-		public ExchangeConfiguration Exchange { get; set; }
-		public QueueConfiguration Queue { get; set; }
-		public string RoutingKey { get; set; }
+    public class ResponderConfiguration : IConsumerConfiguration
+    {
+        public bool NoAck { get; set; }
+        public ushort PrefetchCount { get; set; }
+        public ExchangeConfiguration Exchange { get; set; }
+        public QueueConfiguration Queue { get; set; }
+        public string RoutingKey { get; set; }
 
-		public ResponderConfiguration()
-		{
-			Exchange = new ExchangeConfiguration();
-			Queue = new QueueConfiguration();
-			NoAck = true;
-		}
-	}
+        public ResponderConfiguration()
+        {
+            Exchange = new ExchangeConfiguration();
+            Queue = new QueueConfiguration();
+            NoAck = true;
+        }
+    }
 
-	public interface IConsumerConfiguration : IOperationConfiguration
-	{
-		bool NoAck { get; }
-		ushort PrefetchCount { get; }
-	}
+    public interface IConsumerConfiguration : IOperationConfiguration
+    {
+        bool NoAck { get; }
+        ushort PrefetchCount { get; }
+    }
 
-	public interface IOperationConfiguration
-	{
-		ExchangeConfiguration Exchange { get; }
-		QueueConfiguration Queue { get; }
-		string RoutingKey { get; }
-	}
+    public interface IOperationConfiguration
+    {
+        ExchangeConfiguration Exchange { get; }
+        QueueConfiguration Queue { get; }
+        string RoutingKey { get; }
+    }
 }

--- a/src/RawRabbit/Configuration/Respond/ResponderConfigurationBuilder.cs
+++ b/src/RawRabbit/Configuration/Respond/ResponderConfigurationBuilder.cs
@@ -4,59 +4,59 @@ using RawRabbit.Configuration.Queue;
 
 namespace RawRabbit.Configuration.Respond
 {
-	class ResponderConfigurationBuilder : IResponderConfigurationBuilder
-	{
-		private readonly ExchangeConfigurationBuilder _exchangeBuilder;
-		private readonly QueueConfigurationBuilder _queueBuilder;
+    class ResponderConfigurationBuilder : IResponderConfigurationBuilder
+    {
+        private readonly ExchangeConfigurationBuilder _exchangeBuilder;
+        private readonly QueueConfigurationBuilder _queueBuilder;
 
-		public ResponderConfiguration Configuration { get; }
+        public ResponderConfiguration Configuration { get; }
 
-		public ResponderConfigurationBuilder(QueueConfiguration defaultQueue = null, ExchangeConfiguration defaultExchange = null)
-		{
-			_exchangeBuilder = new ExchangeConfigurationBuilder(defaultExchange);
-			_queueBuilder = new QueueConfigurationBuilder(defaultQueue);
-			Configuration = new ResponderConfiguration
-			{
-				Queue = _queueBuilder.Configuration,
-				Exchange = _exchangeBuilder.Configuration,
-				RoutingKey = _queueBuilder.Configuration.QueueName
-			};
-		}
+        public ResponderConfigurationBuilder(QueueConfiguration defaultQueue = null, ExchangeConfiguration defaultExchange = null)
+        {
+            _exchangeBuilder = new ExchangeConfigurationBuilder(defaultExchange);
+            _queueBuilder = new QueueConfigurationBuilder(defaultQueue);
+            Configuration = new ResponderConfiguration
+            {
+                Queue = _queueBuilder.Configuration,
+                Exchange = _exchangeBuilder.Configuration,
+                RoutingKey = _queueBuilder.Configuration.QueueName
+            };
+        }
 
-		public IResponderConfigurationBuilder WithExchange(Action<IExchangeConfigurationBuilder> exchange)
-		{
-			exchange(_exchangeBuilder);
-			Configuration.Exchange = _exchangeBuilder.Configuration;
-			return this;
-		}
+        public IResponderConfigurationBuilder WithExchange(Action<IExchangeConfigurationBuilder> exchange)
+        {
+            exchange(_exchangeBuilder);
+            Configuration.Exchange = _exchangeBuilder.Configuration;
+            return this;
+        }
 
-		public IResponderConfigurationBuilder WithPrefetchCount(ushort count)
-		{
-			Configuration.PrefetchCount = count;
-			return this;
-		}
+        public IResponderConfigurationBuilder WithPrefetchCount(ushort count)
+        {
+            Configuration.PrefetchCount = count;
+            return this;
+        }
 
-		public IResponderConfigurationBuilder WithQueue(Action<IQueueConfigurationBuilder> queue)
-		{
-			queue(_queueBuilder);
-			Configuration.Queue = _queueBuilder.Configuration;
-			if (string.IsNullOrEmpty(Configuration.RoutingKey))
-			{
-				Configuration.RoutingKey = _queueBuilder.Configuration.QueueName;
-			}
-			return this;
-		}
+        public IResponderConfigurationBuilder WithQueue(Action<IQueueConfigurationBuilder> queue)
+        {
+            queue(_queueBuilder);
+            Configuration.Queue = _queueBuilder.Configuration;
+            if (string.IsNullOrEmpty(Configuration.RoutingKey))
+            {
+                Configuration.RoutingKey = _queueBuilder.Configuration.QueueName;
+            }
+            return this;
+        }
 
-		public IResponderConfigurationBuilder WithRoutingKey(string routingKey)
-		{
-			Configuration.RoutingKey = routingKey;
-			return this;
-		}
+        public IResponderConfigurationBuilder WithRoutingKey(string routingKey)
+        {
+            Configuration.RoutingKey = routingKey;
+            return this;
+        }
 
-		public IResponderConfigurationBuilder WithNoAck(bool noAck)
-		{
-			Configuration.NoAck = noAck;
-			return this;
-		}
-	}
+        public IResponderConfigurationBuilder WithNoAck(bool noAck)
+        {
+            Configuration.NoAck = noAck;
+            return this;
+        }
+    }
 }

--- a/src/RawRabbit/Configuration/Subscribe/ISubscriptionConfigurationBuilder.cs
+++ b/src/RawRabbit/Configuration/Subscribe/ISubscriptionConfigurationBuilder.cs
@@ -4,21 +4,21 @@ using RawRabbit.Configuration.Queue;
 
 namespace RawRabbit.Configuration.Subscribe
 {
-	public interface ISubscriptionConfigurationBuilder
-	{
-		ISubscriptionConfigurationBuilder WithRoutingKey(string routingKey);
-		ISubscriptionConfigurationBuilder WithPrefetchCount(ushort prefetchCount);
-		ISubscriptionConfigurationBuilder WithNoAck(bool noAck = true);
-		ISubscriptionConfigurationBuilder WithExchange(Action<IExchangeConfigurationBuilder> exchange);
-		ISubscriptionConfigurationBuilder WithQueue(Action<IQueueConfigurationBuilder> queue);
+    public interface ISubscriptionConfigurationBuilder
+    {
+        ISubscriptionConfigurationBuilder WithRoutingKey(string routingKey);
+        ISubscriptionConfigurationBuilder WithPrefetchCount(ushort prefetchCount);
+        ISubscriptionConfigurationBuilder WithNoAck(bool noAck = true);
+        ISubscriptionConfigurationBuilder WithExchange(Action<IExchangeConfigurationBuilder> exchange);
+        ISubscriptionConfigurationBuilder WithQueue(Action<IQueueConfigurationBuilder> queue);
 
-		/// <summary>
-		/// The unique identifier for the subscriber. Note that the subscriber id must be
-		/// unique for each routing key in order to get true topic behaviour on exchanges
-		/// that supports that.
-		/// </summary>
-		/// <param name="subscriberId">The unique indeiindetifier for the subscriber.</param>
-		/// <returns></returns>
-		ISubscriptionConfigurationBuilder WithSubscriberId(string subscriberId);
-	}
+        /// <summary>
+        /// The unique identifier for the subscriber. Note that the subscriber id must be
+        /// unique for each routing key in order to get true topic behaviour on exchanges
+        /// that supports that.
+        /// </summary>
+        /// <param name="subscriberId">The unique indeiindetifier for the subscriber.</param>
+        /// <returns></returns>
+        ISubscriptionConfigurationBuilder WithSubscriberId(string subscriberId);
+    }
 }

--- a/src/RawRabbit/Configuration/Subscribe/SubscriptionConfiguration.cs
+++ b/src/RawRabbit/Configuration/Subscribe/SubscriptionConfiguration.cs
@@ -4,18 +4,18 @@ using RawRabbit.Configuration.Respond;
 
 namespace RawRabbit.Configuration.Subscribe
 {
-	public class SubscriptionConfiguration : IConsumerConfiguration
-	{
-		public bool NoAck { get; set; }
-		public ushort PrefetchCount { get; set; }
-		public ExchangeConfiguration Exchange { get; set; }
-		public QueueConfiguration Queue { get; set; }
-		public string RoutingKey { get; set; }
+    public class SubscriptionConfiguration : IConsumerConfiguration
+    {
+        public bool NoAck { get; set; }
+        public ushort PrefetchCount { get; set; }
+        public ExchangeConfiguration Exchange { get; set; }
+        public QueueConfiguration Queue { get; set; }
+        public string RoutingKey { get; set; }
 
-		public SubscriptionConfiguration()
-		{
-			Exchange = new ExchangeConfiguration();
-			Queue = new QueueConfiguration();
-		}
-	}
+        public SubscriptionConfiguration()
+        {
+            Exchange = new ExchangeConfiguration();
+            Queue = new QueueConfiguration();
+        }
+    }
 }

--- a/src/RawRabbit/Configuration/Subscribe/SubscriptionConfigurationBuilder.cs
+++ b/src/RawRabbit/Configuration/Subscribe/SubscriptionConfigurationBuilder.cs
@@ -4,67 +4,67 @@ using RawRabbit.Configuration.Queue;
 
 namespace RawRabbit.Configuration.Subscribe
 {
-	public class SubscriptionConfigurationBuilder : ISubscriptionConfigurationBuilder
-	{
-		public SubscriptionConfiguration Configuration => new SubscriptionConfiguration
-		{
-			Queue = _queueBuilder.Configuration,
-			Exchange = _exchangeBuilder.Configuration,
-			RoutingKey = _routingKey ?? _queueBuilder.Configuration.QueueName,
-			NoAck = _noAck,
-			PrefetchCount = _prefetchCount == 0 ? (ushort)50 : _prefetchCount
-		};
+    public class SubscriptionConfigurationBuilder : ISubscriptionConfigurationBuilder
+    {
+        public SubscriptionConfiguration Configuration => new SubscriptionConfiguration
+        {
+            Queue = _queueBuilder.Configuration,
+            Exchange = _exchangeBuilder.Configuration,
+            RoutingKey = _routingKey ?? _queueBuilder.Configuration.QueueName,
+            NoAck = _noAck,
+            PrefetchCount = _prefetchCount == 0 ? (ushort)50 : _prefetchCount
+        };
 
-		private readonly ExchangeConfigurationBuilder _exchangeBuilder;
-		private readonly QueueConfigurationBuilder _queueBuilder;
-		private string _routingKey;
-		private ushort _prefetchCount;
-		private bool _noAck;
+        private readonly ExchangeConfigurationBuilder _exchangeBuilder;
+        private readonly QueueConfigurationBuilder _queueBuilder;
+        private string _routingKey;
+        private ushort _prefetchCount;
+        private bool _noAck;
 
-		public SubscriptionConfigurationBuilder() : this(null, null, null)
-		{ }
+        public SubscriptionConfigurationBuilder() : this(null, null, null)
+        { }
 
-		public SubscriptionConfigurationBuilder(QueueConfiguration initialQueue, ExchangeConfiguration initialExchange, string routingKey)
-		{
-			_exchangeBuilder = new ExchangeConfigurationBuilder(initialExchange);
-			_queueBuilder = new QueueConfigurationBuilder(initialQueue);
-			_routingKey = routingKey;
-		}
+        public SubscriptionConfigurationBuilder(QueueConfiguration initialQueue, ExchangeConfiguration initialExchange, string routingKey)
+        {
+            _exchangeBuilder = new ExchangeConfigurationBuilder(initialExchange);
+            _queueBuilder = new QueueConfigurationBuilder(initialQueue);
+            _routingKey = routingKey;
+        }
 
-		public ISubscriptionConfigurationBuilder WithRoutingKey(string routingKey)
-		{
-			_routingKey = routingKey;
-			return this;
-		}
+        public ISubscriptionConfigurationBuilder WithRoutingKey(string routingKey)
+        {
+            _routingKey = routingKey;
+            return this;
+        }
 
-		public ISubscriptionConfigurationBuilder WithPrefetchCount(ushort prefetchCount)
-		{
-			_prefetchCount = prefetchCount;
-			return this;
-		}
+        public ISubscriptionConfigurationBuilder WithPrefetchCount(ushort prefetchCount)
+        {
+            _prefetchCount = prefetchCount;
+            return this;
+        }
 
-		public ISubscriptionConfigurationBuilder WithNoAck(bool noAck = true)
-		{
-			_noAck = noAck;
-			return this;
-		}
+        public ISubscriptionConfigurationBuilder WithNoAck(bool noAck = true)
+        {
+            _noAck = noAck;
+            return this;
+        }
 
-		public ISubscriptionConfigurationBuilder WithExchange(Action<IExchangeConfigurationBuilder> exchange)
-		{
-			exchange(_exchangeBuilder);
-			return this;
-		}
+        public ISubscriptionConfigurationBuilder WithExchange(Action<IExchangeConfigurationBuilder> exchange)
+        {
+            exchange(_exchangeBuilder);
+            return this;
+        }
 
-		public ISubscriptionConfigurationBuilder WithQueue(Action<IQueueConfigurationBuilder> queue)
-		{
-			queue(_queueBuilder);
-			return this;
-		}
+        public ISubscriptionConfigurationBuilder WithQueue(Action<IQueueConfigurationBuilder> queue)
+        {
+            queue(_queueBuilder);
+            return this;
+        }
 
-		public ISubscriptionConfigurationBuilder WithSubscriberId(string subscriberId)
-		{
-			_queueBuilder.WithNameSuffix(subscriberId);
-			return this;
-		}
-	}
+        public ISubscriptionConfigurationBuilder WithSubscriberId(string subscriberId)
+        {
+            _queueBuilder.WithNameSuffix(subscriberId);
+            return this;
+        }
+    }
 }

--- a/src/RawRabbit/Consumer/Abstraction/IConsumerFactory.cs
+++ b/src/RawRabbit/Consumer/Abstraction/IConsumerFactory.cs
@@ -3,8 +3,8 @@ using RawRabbit.Configuration.Respond;
 
 namespace RawRabbit.Consumer.Abstraction
 {
-	public interface IConsumerFactory
-	{
-		IRawConsumer CreateConsumer(IConsumerConfiguration cfg, IModel channel);
-	}
+    public interface IConsumerFactory
+    {
+        IRawConsumer CreateConsumer(IConsumerConfiguration cfg, IModel channel);
+    }
 }

--- a/src/RawRabbit/Consumer/Abstraction/IRawConsumer.cs
+++ b/src/RawRabbit/Consumer/Abstraction/IRawConsumer.cs
@@ -6,10 +6,10 @@ using RabbitMQ.Client.Events;
 
 namespace RawRabbit.Consumer.Abstraction
 {
-	public interface IRawConsumer : IBasicConsumer
-	{
-		Func<object, BasicDeliverEventArgs, Task> OnMessageAsync { get; set; }
-		List<ulong> AcknowledgedTags { get; }
-		void Disconnect();
-	}
+    public interface IRawConsumer : IBasicConsumer
+    {
+        Func<object, BasicDeliverEventArgs, Task> OnMessageAsync { get; set; }
+        List<ulong> AcknowledgedTags { get; }
+        void Disconnect();
+    }
 }

--- a/src/RawRabbit/Consumer/Eventing/EventingBasicConsumerFactory.cs
+++ b/src/RawRabbit/Consumer/Eventing/EventingBasicConsumerFactory.cs
@@ -10,77 +10,77 @@ using RawRabbit.Logging;
 
 namespace RawRabbit.Consumer.Eventing
 {
-	public class EventingBasicConsumerFactory : IConsumerFactory
-	{
-		private readonly ConcurrentBag<string> _processedButNotAcked;
-		private readonly ILogger _logger = LogManager.GetLogger<EventingBasicConsumerFactory>();
+    public class EventingBasicConsumerFactory : IConsumerFactory
+    {
+        private readonly ConcurrentBag<string> _processedButNotAcked;
+        private readonly ILogger _logger = LogManager.GetLogger<EventingBasicConsumerFactory>();
 
-		public EventingBasicConsumerFactory()
-		{
-			_processedButNotAcked = new ConcurrentBag<string>();
-		}
+        public EventingBasicConsumerFactory()
+        {
+            _processedButNotAcked = new ConcurrentBag<string>();
+        }
 
-		public IRawConsumer CreateConsumer(IConsumerConfiguration cfg, IModel channel)
-		{
-			ConfigureQos(channel, cfg.PrefetchCount);
-			var rawConsumer = new EventingRawConsumer(channel);
+        public IRawConsumer CreateConsumer(IConsumerConfiguration cfg, IModel channel)
+        {
+            ConfigureQos(channel, cfg.PrefetchCount);
+            var rawConsumer = new EventingRawConsumer(channel);
 
-			rawConsumer.Received += (sender, args) =>
-			{
-				Task.Run(() =>
-				{
-					if (_processedButNotAcked.Contains(args.BasicProperties.MessageId))
-					{
-						/*
-							This instance of the consumer has allready handled this message,
-							but something went wrong when 'ack'-ing the message, therefore
-							and the message was resent.
-						*/
-						BasicAck(channel, args);
-						return;
-					}
-					_logger.LogInformation($"Message recived: MessageId: {args.BasicProperties.MessageId}");
-					rawConsumer
-						.OnMessageAsync(sender, args)
-						.ContinueWith(t =>
-						{
-							if (cfg.NoAck || rawConsumer.AcknowledgedTags.Contains(args.DeliveryTag))
-							{
-								return;
-							}
-							BasicAck(channel, args);
-						});
-				});
-			};
+            rawConsumer.Received += (sender, args) =>
+            {
+                Task.Run(() =>
+                {
+                    if (_processedButNotAcked.Contains(args.BasicProperties.MessageId))
+                    {
+                        /*
+                            This instance of the consumer has allready handled this message,
+                            but something went wrong when 'ack'-ing the message, therefore
+                            and the message was resent.
+                        */
+                        BasicAck(channel, args);
+                        return;
+                    }
+                    _logger.LogInformation($"Message recived: MessageId: {args.BasicProperties.MessageId}");
+                    rawConsumer
+                        .OnMessageAsync(sender, args)
+                        .ContinueWith(t =>
+                        {
+                            if (cfg.NoAck || rawConsumer.AcknowledgedTags.Contains(args.DeliveryTag))
+                            {
+                                return;
+                            }
+                            BasicAck(channel, args);
+                        });
+                });
+            };
 
-			return rawConsumer;
-		}
+            return rawConsumer;
+        }
 
-		protected void ConfigureQos(IModel channel, ushort prefetchCount)
-		{
-			_logger.LogDebug($"Setting QoS\n  Prefetch Size: 0\n  Prefetch Count: {prefetchCount}\n  global: false");
-			channel.BasicQos(
-				prefetchSize: 0,
-				prefetchCount: prefetchCount,
-				global: false
-			);
-		}
+        protected void ConfigureQos(IModel channel, ushort prefetchCount)
+        {
+            _logger.LogDebug($"Setting QoS\n  Prefetch Size: 0\n  Prefetch Count: {prefetchCount}\n  global: false");
+            channel.BasicQos(
+                prefetchSize: 0,
+                prefetchCount: prefetchCount,
+                global: false
+            );
+        }
 
-		protected void BasicAck(IModel channel, BasicDeliverEventArgs args)
-		{
-			try
-			{
-				_logger.LogDebug($"Ack:ing message with id {args.DeliveryTag}.");
-				channel.BasicAck(
-					deliveryTag: args.DeliveryTag,
-					multiple: false
-				);
-			}
-			catch (AlreadyClosedException)
-			{
-				_logger.LogWarning("Unable to ack message, channel is allready closed.");
-				_processedButNotAcked.Add(args.BasicProperties.MessageId);
-			}
-		}
-	}
+        protected void BasicAck(IModel channel, BasicDeliverEventArgs args)
+        {
+            try
+            {
+                _logger.LogDebug($"Ack:ing message with id {args.DeliveryTag}.");
+                channel.BasicAck(
+                    deliveryTag: args.DeliveryTag,
+                    multiple: false
+                );
+            }
+            catch (AlreadyClosedException)
+            {
+                _logger.LogWarning("Unable to ack message, channel is allready closed.");
+                _processedButNotAcked.Add(args.BasicProperties.MessageId);
+            }
+        }
+    }
 }

--- a/src/RawRabbit/Consumer/Eventing/EventingRawConsumer.cs
+++ b/src/RawRabbit/Consumer/Eventing/EventingRawConsumer.cs
@@ -9,46 +9,46 @@ using RawRabbit.Logging;
 
 namespace RawRabbit.Consumer.Eventing
 {
-	public class EventingRawConsumer : EventingBasicConsumer, IRawConsumer
-	{
-		private readonly ILogger _logger = LogManager.GetLogger<EventingRawConsumer>();
-		public List<ulong> AcknowledgedTags { get; }
+    public class EventingRawConsumer : EventingBasicConsumer, IRawConsumer
+    {
+        private readonly ILogger _logger = LogManager.GetLogger<EventingRawConsumer>();
+        public List<ulong> AcknowledgedTags { get; }
 
-		public EventingRawConsumer(IModel channel) : base(channel)
-		{
-			AcknowledgedTags = new List<ulong>();
-			SetupLogging(this);
-		}
+        public EventingRawConsumer(IModel channel) : base(channel)
+        {
+            AcknowledgedTags = new List<ulong>();
+            SetupLogging(this);
+        }
 
-		private void SetupLogging(EventingBasicConsumer rawConsumer)
-		{
-			rawConsumer.Shutdown += (sender, args) =>
-			{
-				_logger.LogInformation($"Consumer {rawConsumer.ConsumerTag} has been shut down.\n  Reason: {args.Cause}\n  Initiator: {args.Initiator}\n  Reply Text: {args.ReplyText}");
-			};
-			rawConsumer.ConsumerCancelled +=
-				(sender, args) => _logger.LogDebug($"The consumer with tag '{args.ConsumerTag}' has been cancelled.");
-			rawConsumer.Unregistered +=
-				(sender, args) => _logger.LogDebug($"The consumer with tag '{args.ConsumerTag}' has been unregistered.");
-		}
+        private void SetupLogging(EventingBasicConsumer rawConsumer)
+        {
+            rawConsumer.Shutdown += (sender, args) =>
+            {
+                _logger.LogInformation($"Consumer {rawConsumer.ConsumerTag} has been shut down.\n  Reason: {args.Cause}\n  Initiator: {args.Initiator}\n  Reply Text: {args.ReplyText}");
+            };
+            rawConsumer.ConsumerCancelled +=
+                (sender, args) => _logger.LogDebug($"The consumer with tag '{args.ConsumerTag}' has been cancelled.");
+            rawConsumer.Unregistered +=
+                (sender, args) => _logger.LogDebug($"The consumer with tag '{args.ConsumerTag}' has been unregistered.");
+        }
 
-		public Func<object, BasicDeliverEventArgs, Task> OnMessageAsync { get; set; }
+        public Func<object, BasicDeliverEventArgs, Task> OnMessageAsync { get; set; }
 
-		public void Disconnect()
-		{
-			if (string.IsNullOrEmpty(ConsumerTag))
-			{
-				// broker has not given a tag yet.
-				return;
-			}
-			try
-			{
-				Model.BasicCancel(ConsumerTag);
-			}
-			catch (AlreadyClosedException)
-			{
-				// Perfect, someone allready closed this.
-			}
-		}
-	}
+        public void Disconnect()
+        {
+            if (string.IsNullOrEmpty(ConsumerTag))
+            {
+                // broker has not given a tag yet.
+                return;
+            }
+            try
+            {
+                Model.BasicCancel(ConsumerTag);
+            }
+            catch (AlreadyClosedException)
+            {
+                // Perfect, someone allready closed this.
+            }
+        }
+    }
 }

--- a/src/RawRabbit/Context/AdvancedMessageContext.cs
+++ b/src/RawRabbit/Context/AdvancedMessageContext.cs
@@ -2,16 +2,16 @@
 
 namespace RawRabbit.Context
 {
-	public class AdvancedMessageContext : MessageContext, IAdvancedMessageContext
-	{
-		public Action Nack { get; set; }
-		public Action<TimeSpan> RetryLater { get; set; }
-		public RetryInformation RetryInfo { get; set; }
-	}
+    public class AdvancedMessageContext : MessageContext, IAdvancedMessageContext
+    {
+        public Action Nack { get; set; }
+        public Action<TimeSpan> RetryLater { get; set; }
+        public RetryInformation RetryInfo { get; set; }
+    }
 
-	public class RetryInformation
-	{
-		public long NumberOfRetries { get; set; }
-		public DateTime OriginalSent { get; set; }
-	}
+    public class RetryInformation
+    {
+        public long NumberOfRetries { get; set; }
+        public DateTime OriginalSent { get; set; }
+    }
 }

--- a/src/RawRabbit/Context/Enhancer/ContextEnhancer.cs
+++ b/src/RawRabbit/Context/Enhancer/ContextEnhancer.cs
@@ -10,106 +10,106 @@ using RawRabbit.Consumer.Abstraction;
 
 namespace RawRabbit.Context.Enhancer
 {
-	public class ContextEnhancer : IContextEnhancer
-	{
-		private readonly IChannelFactory _channelFactory;
-		private readonly INamingConventions _conventions;
+    public class ContextEnhancer : IContextEnhancer
+    {
+        private readonly IChannelFactory _channelFactory;
+        private readonly INamingConventions _conventions;
 
-		public ContextEnhancer(IChannelFactory channelFactory, INamingConventions conventions)
-		{
-			_channelFactory = channelFactory;
-			_conventions = conventions;
-		}
+        public ContextEnhancer(IChannelFactory channelFactory, INamingConventions conventions)
+        {
+            _channelFactory = channelFactory;
+            _conventions = conventions;
+        }
 
-		public void WireUpContextFeatures<TMessageContext>(TMessageContext context, IRawConsumer consumer, BasicDeliverEventArgs args) where TMessageContext : IMessageContext
-		{
-			var advancedCtx = context as IAdvancedMessageContext;
-			if (advancedCtx == null)
-			{
-				return;
-			}
+        public void WireUpContextFeatures<TMessageContext>(TMessageContext context, IRawConsumer consumer, BasicDeliverEventArgs args) where TMessageContext : IMessageContext
+        {
+            var advancedCtx = context as IAdvancedMessageContext;
+            if (advancedCtx == null)
+            {
+                return;
+            }
 
-			advancedCtx.Nack = () =>
-			{
-				consumer.AcknowledgedTags.Add(args.DeliveryTag);
-				consumer.Model.BasicNack(args.DeliveryTag, false, true);
-			};
+            advancedCtx.Nack = () =>
+            {
+                consumer.AcknowledgedTags.Add(args.DeliveryTag);
+                consumer.Model.BasicNack(args.DeliveryTag, false, true);
+            };
 
-			advancedCtx.RetryLater = timespan =>
-			{
-				var dlxName = _conventions.RetryLaterExchangeConvention(timespan);
-				var dlQueueName = _conventions.RetryLaterExchangeConvention(timespan);
-				var channel = _channelFactory.CreateChannel();
-				channel.ExchangeDeclare(dlxName, ExchangeType.Direct, true, true, null);
-				channel.QueueDeclare(dlQueueName, true, false, true, new Dictionary<string, object>
-				{
-						{QueueArgument.DeadLetterExchange, args.Exchange},
-						{QueueArgument.Expires, Convert.ToInt32(timespan.Add(TimeSpan.FromSeconds(1)).TotalMilliseconds)},
-						{QueueArgument.MessageTtl, Convert.ToInt32(timespan.TotalMilliseconds)}
-				});
-				channel.QueueBind(dlQueueName, dlxName, args.RoutingKey, null);
-				UpdateHeaders(args.BasicProperties);
-				channel.BasicPublish(dlxName, args.RoutingKey, args.BasicProperties, args.Body);
-				channel.QueueUnbind(dlQueueName, dlxName, args.RoutingKey, null);
-			};
+            advancedCtx.RetryLater = timespan =>
+            {
+                var dlxName = _conventions.RetryLaterExchangeConvention(timespan);
+                var dlQueueName = _conventions.RetryLaterExchangeConvention(timespan);
+                var channel = _channelFactory.CreateChannel();
+                channel.ExchangeDeclare(dlxName, ExchangeType.Direct, true, true, null);
+                channel.QueueDeclare(dlQueueName, true, false, true, new Dictionary<string, object>
+                {
+                        {QueueArgument.DeadLetterExchange, args.Exchange},
+                        {QueueArgument.Expires, Convert.ToInt32(timespan.Add(TimeSpan.FromSeconds(1)).TotalMilliseconds)},
+                        {QueueArgument.MessageTtl, Convert.ToInt32(timespan.TotalMilliseconds)}
+                });
+                channel.QueueBind(dlQueueName, dlxName, args.RoutingKey, null);
+                UpdateHeaders(args.BasicProperties);
+                channel.BasicPublish(dlxName, args.RoutingKey, args.BasicProperties, args.Body);
+                channel.QueueUnbind(dlQueueName, dlxName, args.RoutingKey, null);
+            };
 
-			advancedCtx.RetryInfo = GetRetryInformatino(args.BasicProperties);
-		}
+            advancedCtx.RetryInfo = GetRetryInformatino(args.BasicProperties);
+        }
 
-		private static void UpdateHeaders(IBasicProperties basicProperties)
-		{
-			if (basicProperties.Headers.ContainsKey(PropertyHeaders.EstimatedRetry))
-			{
-				basicProperties.Headers.Remove(PropertyHeaders.EstimatedRetry);
-			}
-			basicProperties.Headers.Add(PropertyHeaders.EstimatedRetry, DateTime.UtcNow.ToString("u"));
+        private static void UpdateHeaders(IBasicProperties basicProperties)
+        {
+            if (basicProperties.Headers.ContainsKey(PropertyHeaders.EstimatedRetry))
+            {
+                basicProperties.Headers.Remove(PropertyHeaders.EstimatedRetry);
+            }
+            basicProperties.Headers.Add(PropertyHeaders.EstimatedRetry, DateTime.UtcNow.ToString("u"));
 
-			var currentRetry = 0;
-			if (basicProperties.Headers.ContainsKey(PropertyHeaders.RetryCount))
-			{
-				var valueStr = GetHeaderString(basicProperties.Headers, PropertyHeaders.RetryCount);
-				currentRetry = int.Parse(valueStr);
-				basicProperties.Headers.Remove(PropertyHeaders.RetryCount);
-			}
-			var nextRetry = (++currentRetry).ToString();
-			basicProperties.Headers.Add(PropertyHeaders.RetryCount, nextRetry);
-		}
+            var currentRetry = 0;
+            if (basicProperties.Headers.ContainsKey(PropertyHeaders.RetryCount))
+            {
+                var valueStr = GetHeaderString(basicProperties.Headers, PropertyHeaders.RetryCount);
+                currentRetry = int.Parse(valueStr);
+                basicProperties.Headers.Remove(PropertyHeaders.RetryCount);
+            }
+            var nextRetry = (++currentRetry).ToString();
+            basicProperties.Headers.Add(PropertyHeaders.RetryCount, nextRetry);
+        }
 
-		private static string GetHeaderString(IDictionary<string, object> headers, string key)
-		{
-			var headerBytes = headers[key] as byte[] ?? new byte[0];
-			var headerStr = System.Text.Encoding.UTF8.GetString(headerBytes);
-			return headerStr;
-		}
+        private static string GetHeaderString(IDictionary<string, object> headers, string key)
+        {
+            var headerBytes = headers[key] as byte[] ?? new byte[0];
+            var headerStr = System.Text.Encoding.UTF8.GetString(headerBytes);
+            return headerStr;
+        }
 
-		private static RetryInformation GetRetryInformatino(IBasicProperties basicProperties)
-		{
-			return new RetryInformation
-			{
-				OriginalSent = GetOriginalSentDate(basicProperties),
-				NumberOfRetries = GetCurentRetryCount(basicProperties)
-			};
-		}
+        private static RetryInformation GetRetryInformatino(IBasicProperties basicProperties)
+        {
+            return new RetryInformation
+            {
+                OriginalSent = GetOriginalSentDate(basicProperties),
+                NumberOfRetries = GetCurentRetryCount(basicProperties)
+            };
+        }
 
-		private static DateTime GetOriginalSentDate(IBasicProperties basicProperties)
-		{
-			if (!basicProperties.Headers.ContainsKey(PropertyHeaders.Sent))
-			{
-				return DateTime.MinValue;
-			}
-			var sentBytes = basicProperties?.Headers[PropertyHeaders.Sent] as byte[] ?? new byte[0];
-			var sentStr = System.Text.Encoding.UTF8.GetString(sentBytes);
-			return DateTime.Parse(sentStr);
-		}
+        private static DateTime GetOriginalSentDate(IBasicProperties basicProperties)
+        {
+            if (!basicProperties.Headers.ContainsKey(PropertyHeaders.Sent))
+            {
+                return DateTime.MinValue;
+            }
+            var sentBytes = basicProperties?.Headers[PropertyHeaders.Sent] as byte[] ?? new byte[0];
+            var sentStr = System.Text.Encoding.UTF8.GetString(sentBytes);
+            return DateTime.Parse(sentStr);
+        }
 
-		private static long GetCurentRetryCount(IBasicProperties basicProperties)
-		{
-			if (basicProperties.Headers.ContainsKey(PropertyHeaders.RetryCount))
-			{
-				var countStr = GetHeaderString(basicProperties.Headers, PropertyHeaders.RetryCount);
-				return int.Parse(countStr);
-			}
-			return 0;
-		}
-	}
+        private static long GetCurentRetryCount(IBasicProperties basicProperties)
+        {
+            if (basicProperties.Headers.ContainsKey(PropertyHeaders.RetryCount))
+            {
+                var countStr = GetHeaderString(basicProperties.Headers, PropertyHeaders.RetryCount);
+                return int.Parse(countStr);
+            }
+            return 0;
+        }
+    }
 }

--- a/src/RawRabbit/Context/Enhancer/IContextEnhancer.cs
+++ b/src/RawRabbit/Context/Enhancer/IContextEnhancer.cs
@@ -3,8 +3,8 @@ using RawRabbit.Consumer.Abstraction;
 
 namespace RawRabbit.Context.Enhancer
 {
-	public interface IContextEnhancer
-	{
-		void WireUpContextFeatures<TMessageContext >(TMessageContext context, IRawConsumer consumer, BasicDeliverEventArgs args) where TMessageContext : IMessageContext;
-	}
+    public interface IContextEnhancer
+    {
+        void WireUpContextFeatures<TMessageContext >(TMessageContext context, IRawConsumer consumer, BasicDeliverEventArgs args) where TMessageContext : IMessageContext;
+    }
 }

--- a/src/RawRabbit/Context/IAdvancedMessageContext.cs
+++ b/src/RawRabbit/Context/IAdvancedMessageContext.cs
@@ -2,10 +2,10 @@
 
 namespace RawRabbit.Context
 {
-	public interface IAdvancedMessageContext : IMessageContext
-	{
-		Action Nack { get; set; }
-		Action<TimeSpan> RetryLater { get; set; }
-		RetryInformation RetryInfo { get; set; }
-	}
+    public interface IAdvancedMessageContext : IMessageContext
+    {
+        Action Nack { get; set; }
+        Action<TimeSpan> RetryLater { get; set; }
+        RetryInformation RetryInfo { get; set; }
+    }
 }

--- a/src/RawRabbit/Context/IMessageContext.cs
+++ b/src/RawRabbit/Context/IMessageContext.cs
@@ -2,8 +2,8 @@
 
 namespace RawRabbit.Context
 {
-	public interface IMessageContext
-	{
-		Guid GlobalRequestId { get; set; }
-	}
+    public interface IMessageContext
+    {
+        Guid GlobalRequestId { get; set; }
+    }
 }

--- a/src/RawRabbit/Context/MessageContext.cs
+++ b/src/RawRabbit/Context/MessageContext.cs
@@ -2,8 +2,8 @@
 
 namespace RawRabbit.Context
 {
-	public class MessageContext : IMessageContext
-	{
-		public Guid GlobalRequestId { get; set; }
-	}
+    public class MessageContext : IMessageContext
+    {
+        public Guid GlobalRequestId { get; set; }
+    }
 }

--- a/src/RawRabbit/Context/Provider/IMessageContextProvider.cs
+++ b/src/RawRabbit/Context/Provider/IMessageContextProvider.cs
@@ -3,11 +3,11 @@ using System.Threading.Tasks;
 
 namespace RawRabbit.Context.Provider
 {
-	public interface IMessageContextProvider<TMessageContext> where TMessageContext : IMessageContext
-	{
-		Task<object> GetMessageContextAsync(Guid globalMessageId);
-		Task<TMessageContext> ExtractContextAsync(object o);
-		TMessageContext ExtractContext(object o);
-		object GetMessageContext(ref Guid globalMessageId);
-	}
+    public interface IMessageContextProvider<TMessageContext> where TMessageContext : IMessageContext
+    {
+        Task<object> GetMessageContextAsync(Guid globalMessageId);
+        Task<TMessageContext> ExtractContextAsync(object o);
+        TMessageContext ExtractContext(object o);
+        object GetMessageContext(ref Guid globalMessageId);
+    }
 }

--- a/src/RawRabbit/Context/Provider/MessageContextProvider.cs
+++ b/src/RawRabbit/Context/Provider/MessageContextProvider.cs
@@ -4,55 +4,55 @@ using Newtonsoft.Json;
 
 namespace RawRabbit.Context.Provider
 {
-	public class MessageContextProvider<TContext> : MessageContextProviderBase<TContext> where TContext : IMessageContext
-	{
-		private readonly Func<Task<TContext>> _createContextAsync;
-		private readonly Func<TContext> _createContext;
+    public class MessageContextProvider<TContext> : MessageContextProviderBase<TContext> where TContext : IMessageContext
+    {
+        private readonly Func<Task<TContext>> _createContextAsync;
+        private readonly Func<TContext> _createContext;
 
-		public MessageContextProvider(JsonSerializer serializer, Func<Task<TContext>> createContextAsync = null)
-			: base(serializer)
-		{
-			_createContextAsync = createContextAsync;
-		}
+        public MessageContextProvider(JsonSerializer serializer, Func<Task<TContext>> createContextAsync = null)
+            : base(serializer)
+        {
+            _createContextAsync = createContextAsync;
+        }
 
-		public MessageContextProvider(JsonSerializer serializer, Func<TContext> createContext)
-		: base(serializer)
-		{
-			_createContext = createContext;
-		}
+        public MessageContextProvider(JsonSerializer serializer, Func<TContext> createContext)
+        : base(serializer)
+        {
+            _createContext = createContext;
+        }
 
-		protected override Task<TContext> CreateMessageContextAsync()
-		{
-			return _createContextAsync != null
-				? _createContextAsync()
-				: Task.FromResult(ActivateOrDefault());
-		}
+        protected override Task<TContext> CreateMessageContextAsync()
+        {
+            return _createContextAsync != null
+                ? _createContextAsync()
+                : Task.FromResult(ActivateOrDefault());
+        }
 
-		protected override TContext CreateMessageContext(Guid globalRequestId = default(Guid))
-		{
-			var context = _createContext != null
-						? _createContext()
-						: ActivateOrDefault();
-			if (globalRequestId != Guid.Empty)
-			{
-				context.GlobalRequestId = globalRequestId;
-			}
-			return context;
-		}
+        protected override TContext CreateMessageContext(Guid globalRequestId = default(Guid))
+        {
+            var context = _createContext != null
+                        ? _createContext()
+                        : ActivateOrDefault();
+            if (globalRequestId != Guid.Empty)
+            {
+                context.GlobalRequestId = globalRequestId;
+            }
+            return context;
+        }
 
-		private static TContext ActivateOrDefault()
-		{
-			TContext context;
-			try
-			{
-				context = (TContext)Activator.CreateInstance(typeof(TContext), new object[] { });
-				context.GlobalRequestId = Guid.NewGuid();
-			}
-			catch (Exception)
-			{
-				context = default(TContext);
-			}
-			return context;
-		}
-	}
+        private static TContext ActivateOrDefault()
+        {
+            TContext context;
+            try
+            {
+                context = (TContext)Activator.CreateInstance(typeof(TContext), new object[] { });
+                context.GlobalRequestId = Guid.NewGuid();
+            }
+            catch (Exception)
+            {
+                context = default(TContext);
+            }
+            return context;
+        }
+    }
 }

--- a/src/RawRabbit/Context/Provider/MessageContextProviderBase.cs
+++ b/src/RawRabbit/Context/Provider/MessageContextProviderBase.cs
@@ -11,100 +11,100 @@ using System.Runtime.Remoting.Messaging;
 
 namespace RawRabbit.Context.Provider
 {
-	public abstract class MessageContextProviderBase<TMessageContext> : IMessageContextProvider<TMessageContext> where TMessageContext : IMessageContext
-	{
-		private readonly JsonSerializer _serializer;
-		protected ConcurrentDictionary<Guid, TMessageContext> ContextDictionary;
+    public abstract class MessageContextProviderBase<TMessageContext> : IMessageContextProvider<TMessageContext> where TMessageContext : IMessageContext
+    {
+        private readonly JsonSerializer _serializer;
+        protected ConcurrentDictionary<Guid, TMessageContext> ContextDictionary;
 #if NETSTANDARD1_5
-		private readonly AsyncLocal<Guid> _globalMsgId;
+        private readonly AsyncLocal<Guid> _globalMsgId;
 #elif NET451
-		private const string GlobalMsgId = "RawRabbit:GlobalMessageId";
+        private const string GlobalMsgId = "RawRabbit:GlobalMessageId";
 #endif
-		protected MessageContextProviderBase(JsonSerializer serializer)
-		{
-			_serializer = serializer;
-			ContextDictionary = new ConcurrentDictionary<Guid, TMessageContext>();
+        protected MessageContextProviderBase(JsonSerializer serializer)
+        {
+            _serializer = serializer;
+            ContextDictionary = new ConcurrentDictionary<Guid, TMessageContext>();
 #if NETSTANDARD1_5
-			_globalMsgId = new AsyncLocal<Guid>();
+            _globalMsgId = new AsyncLocal<Guid>();
 #endif
-		}
+        }
 
-		public TMessageContext ExtractContext(object o)
-		{
-			if (o == null)
-			{
-				return default(TMessageContext);
-			}
-			var bytes = (byte[])o;
-			var jsonHeader = Encoding.UTF8.GetString(bytes);
-			TMessageContext context;
-			using (var jsonReader = new JsonTextReader(new StringReader(jsonHeader)))
-			{
-				context = _serializer.Deserialize<TMessageContext>(jsonReader);
-			}
+        public TMessageContext ExtractContext(object o)
+        {
+            if (o == null)
+            {
+                return default(TMessageContext);
+            }
+            var bytes = (byte[])o;
+            var jsonHeader = Encoding.UTF8.GetString(bytes);
+            TMessageContext context;
+            using (var jsonReader = new JsonTextReader(new StringReader(jsonHeader)))
+            {
+                context = _serializer.Deserialize<TMessageContext>(jsonReader);
+            }
 
 #if NETSTANDARD1_5
-			_globalMsgId.Value = context.GlobalRequestId;
+            _globalMsgId.Value = context.GlobalRequestId;
 #elif NET451
-			CallContext.LogicalSetData(GlobalMsgId, context.GlobalRequestId);
+            CallContext.LogicalSetData(GlobalMsgId, context.GlobalRequestId);
 #endif
-			ContextDictionary.TryAdd(context.GlobalRequestId, context);
-			return context;
-		}
+            ContextDictionary.TryAdd(context.GlobalRequestId, context);
+            return context;
+        }
 
-		public Task<TMessageContext> ExtractContextAsync(object o)
-		{
-			var context = ExtractContext(o);
-			return Task.FromResult(context);
-		}
+        public Task<TMessageContext> ExtractContextAsync(object o)
+        {
+            var context = ExtractContext(o);
+            return Task.FromResult(context);
+        }
 
-		public object GetMessageContext(ref Guid globalMessageId)
-		{
+        public object GetMessageContext(ref Guid globalMessageId)
+        {
 
 #if NETSTANDARD1_5
-			if (globalMessageId == Guid.Empty)
-			{
-				globalMessageId = _globalMsgId?.Value ?? globalMessageId;
-			}
+            if (globalMessageId == Guid.Empty)
+            {
+                globalMessageId = _globalMsgId?.Value ?? globalMessageId;
+            }
 #elif NET451
-			if (globalMessageId == Guid.Empty)
-			{
-				globalMessageId = (Guid?)CallContext.LogicalGetData(GlobalMsgId) ?? globalMessageId;
-			}	
+            if (globalMessageId == Guid.Empty)
+            {
+                globalMessageId = (Guid?)CallContext.LogicalGetData(GlobalMsgId) ?? globalMessageId;
+            }    
 #endif
-			var context = globalMessageId != Guid.Empty && ContextDictionary.ContainsKey(globalMessageId)
-				? ContextDictionary[globalMessageId]
-				: CreateMessageContext(globalMessageId);
-			var contextAsJson = SerializeContext(context);
-			var contextAsBytes = (object) Encoding.UTF8.GetBytes(contextAsJson);
-			return contextAsBytes;
-		}
+            var context = globalMessageId != Guid.Empty && ContextDictionary.ContainsKey(globalMessageId)
+                ? ContextDictionary[globalMessageId]
+                : CreateMessageContext(globalMessageId);
+            var contextAsJson = SerializeContext(context);
+            var contextAsBytes = (object) Encoding.UTF8.GetBytes(contextAsJson);
+            return contextAsBytes;
+        }
 
-		public Task<object> GetMessageContextAsync(Guid globalMessageId)
-		{
-			var ctxTask = globalMessageId != Guid.Empty && ContextDictionary.ContainsKey(globalMessageId)
-				? Task.FromResult(ContextDictionary[globalMessageId])
-				: CreateMessageContextAsync();
+        public Task<object> GetMessageContextAsync(Guid globalMessageId)
+        {
+            var ctxTask = globalMessageId != Guid.Empty && ContextDictionary.ContainsKey(globalMessageId)
+                ? Task.FromResult(ContextDictionary[globalMessageId])
+                : CreateMessageContextAsync();
 
-			return ctxTask
-				.ContinueWith(contextTask => SerializeContext(contextTask.Result))
-				.ContinueWith(jsonTask => (object)Encoding.UTF8.GetBytes(jsonTask.Result));
-		}
+            return ctxTask
+                .ContinueWith(contextTask => SerializeContext(contextTask.Result))
+                .ContinueWith(jsonTask => (object)Encoding.UTF8.GetBytes(jsonTask.Result));
+        }
 
-		private string SerializeContext(TMessageContext messageContext)
-		{
-			using (var sw = new StringWriter())
-			{
-				_serializer.Serialize(sw, messageContext);
-				return sw.GetStringBuilder().ToString();
-			}
-		}
+        private string SerializeContext(TMessageContext messageContext)
+        {
+            using (var sw = new StringWriter())
+            {
+                _serializer.Serialize(sw, messageContext);
+                return sw.GetStringBuilder().ToString();
+            }
+        }
 
-		protected virtual Task<TMessageContext> CreateMessageContextAsync()
-		{
-			return Task.FromResult(CreateMessageContext());
-		}
+        protected virtual Task<TMessageContext> CreateMessageContextAsync()
+        {
+            return Task.FromResult(CreateMessageContext());
+        }
 
-		protected abstract TMessageContext CreateMessageContext(Guid globalRequestId = default(Guid));
-	}
+        protected abstract TMessageContext CreateMessageContext(Guid globalRequestId = default(Guid));
+    }
 }

--- a/src/RawRabbit/ErrorHandling/DefaultStrategy.cs
+++ b/src/RawRabbit/ErrorHandling/DefaultStrategy.cs
@@ -15,143 +15,143 @@ using RawRabbit.Serialization;
 
 namespace RawRabbit.ErrorHandling
 {
-	public class DefaultStrategy : IErrorHandlingStrategy
-	{
-		private readonly IMessageSerializer _serializer;
-		private readonly IBasicPropertiesProvider _propertiesProvider;
-		private readonly ITopologyProvider _topologyProvider;
-		private readonly IChannelFactory _channelFactory;
-		private readonly ILogger _logger = LogManager.GetLogger<DefaultStrategy>();
-		private readonly string _messageExceptionName = typeof(MessageHandlerException).Name;
-		private readonly ExchangeConfiguration _errorExchangeCfg;
+    public class DefaultStrategy : IErrorHandlingStrategy
+    {
+        private readonly IMessageSerializer _serializer;
+        private readonly IBasicPropertiesProvider _propertiesProvider;
+        private readonly ITopologyProvider _topologyProvider;
+        private readonly IChannelFactory _channelFactory;
+        private readonly ILogger _logger = LogManager.GetLogger<DefaultStrategy>();
+        private readonly string _messageExceptionName = typeof(MessageHandlerException).Name;
+        private readonly ExchangeConfiguration _errorExchangeCfg;
 
-		public DefaultStrategy(IMessageSerializer serializer, INamingConventions conventions, IBasicPropertiesProvider propertiesProvider, ITopologyProvider topologyProvider, IChannelFactory channelFactory)
-		{
-			_serializer = serializer;
-			_propertiesProvider = propertiesProvider;
-			_topologyProvider = topologyProvider;
-			_channelFactory = channelFactory;
-			_errorExchangeCfg = ExchangeConfiguration.Default;
-			_errorExchangeCfg.ExchangeName = conventions.ErrorExchangeNamingConvention();
-		}
+        public DefaultStrategy(IMessageSerializer serializer, INamingConventions conventions, IBasicPropertiesProvider propertiesProvider, ITopologyProvider topologyProvider, IChannelFactory channelFactory)
+        {
+            _serializer = serializer;
+            _propertiesProvider = propertiesProvider;
+            _topologyProvider = topologyProvider;
+            _channelFactory = channelFactory;
+            _errorExchangeCfg = ExchangeConfiguration.Default;
+            _errorExchangeCfg.ExchangeName = conventions.ErrorExchangeNamingConvention();
+        }
 
-		public virtual Task OnResponseHandlerExceptionAsync(IRawConsumer rawConsumer, IConsumerConfiguration cfg, BasicDeliverEventArgs args, Exception exception)
-		{
-			_logger.LogError($"An unhandled exception was thrown in the response handler for message '{args.BasicProperties.MessageId}'.", exception);
-			var innerException = UnwrapInnerException(exception);
-			var exceptionInfo = new MessageHandlerExceptionInformation
-			{
-				Message = $"An unhandled exception was thrown when consuming a message\n  MessageId: {args.BasicProperties.MessageId}\n  Queue: '{cfg.Queue.FullQueueName}'\n  Exchange: '{cfg.Exchange.ExchangeName}'\nSee inner exception for more details.",
-				ExceptionType = innerException.GetType().FullName,
-				StackTrace = innerException.StackTrace,
-				InnerMessage = innerException.Message
-			};
-			_logger.LogInformation($"Sending MessageHandlerException with CorrelationId '{args.BasicProperties.CorrelationId}'");
-			rawConsumer.Model.BasicPublish(
-				exchange: string.Empty,
-				routingKey: args.BasicProperties?.ReplyTo ?? string.Empty,
-				basicProperties: _propertiesProvider.GetProperties<MessageHandlerExceptionInformation>(p =>
-				{
-					p.CorrelationId = args.BasicProperties?.CorrelationId ?? string.Empty;
-					p.Headers.Add(PropertyHeaders.ExceptionHeader, _messageExceptionName);
-				}),
-				body: _serializer.Serialize(exceptionInfo)
-			);
+        public virtual Task OnResponseHandlerExceptionAsync(IRawConsumer rawConsumer, IConsumerConfiguration cfg, BasicDeliverEventArgs args, Exception exception)
+        {
+            _logger.LogError($"An unhandled exception was thrown in the response handler for message '{args.BasicProperties.MessageId}'.", exception);
+            var innerException = UnwrapInnerException(exception);
+            var exceptionInfo = new MessageHandlerExceptionInformation
+            {
+                Message = $"An unhandled exception was thrown when consuming a message\n  MessageId: {args.BasicProperties.MessageId}\n  Queue: '{cfg.Queue.FullQueueName}'\n  Exchange: '{cfg.Exchange.ExchangeName}'\nSee inner exception for more details.",
+                ExceptionType = innerException.GetType().FullName,
+                StackTrace = innerException.StackTrace,
+                InnerMessage = innerException.Message
+            };
+            _logger.LogInformation($"Sending MessageHandlerException with CorrelationId '{args.BasicProperties.CorrelationId}'");
+            rawConsumer.Model.BasicPublish(
+                exchange: string.Empty,
+                routingKey: args.BasicProperties?.ReplyTo ?? string.Empty,
+                basicProperties: _propertiesProvider.GetProperties<MessageHandlerExceptionInformation>(p =>
+                {
+                    p.CorrelationId = args.BasicProperties?.CorrelationId ?? string.Empty;
+                    p.Headers.Add(PropertyHeaders.ExceptionHeader, _messageExceptionName);
+                }),
+                body: _serializer.Serialize(exceptionInfo)
+            );
 
-			if (!cfg.NoAck)
-			{
-				_logger.LogDebug($"Nack'ing message with delivery tag '{args.DeliveryTag}'.");
-				rawConsumer.Model.BasicNack(args.DeliveryTag, false, false);
-			}
-			return Task.FromResult(true);
-		}
+            if (!cfg.NoAck)
+            {
+                _logger.LogDebug($"Nack'ing message with delivery tag '{args.DeliveryTag}'.");
+                rawConsumer.Model.BasicNack(args.DeliveryTag, false, false);
+            }
+            return Task.FromResult(true);
+        }
 
-		private static Exception UnwrapInnerException(Exception exception)
-		{
-			if (exception is AggregateException && exception.InnerException != null)
-			{
-				return UnwrapInnerException(exception.InnerException);
-			}
-			return exception;
-		}
+        private static Exception UnwrapInnerException(Exception exception)
+        {
+            if (exception is AggregateException && exception.InnerException != null)
+            {
+                return UnwrapInnerException(exception.InnerException);
+            }
+            return exception;
+        }
 
-		public virtual Task OnResponseRecievedAsync(BasicDeliverEventArgs args, TaskCompletionSource<object> responseTcs)
-		{
-			var containsException = args?.BasicProperties?.Headers?.ContainsKey(PropertyHeaders.ExceptionHeader) ?? false;
+        public virtual Task OnResponseRecievedAsync(BasicDeliverEventArgs args, TaskCompletionSource<object> responseTcs)
+        {
+            var containsException = args?.BasicProperties?.Headers?.ContainsKey(PropertyHeaders.ExceptionHeader) ?? false;
 
-			if (containsException)
-			{
-				_logger.LogInformation($"Message '{args.BasicProperties.MessageId}' withh CorrelationId '{args.BasicProperties.CorrelationId}' contains exception. Deserialize and re-throw.");
-				var exceptionInfo = _serializer.Deserialize<MessageHandlerExceptionInformation>(args.Body);
-				var exception = new MessageHandlerException(exceptionInfo.Message)
-				{
-					InnerExceptionType = exceptionInfo.ExceptionType,
-					InnerStackTrace = exceptionInfo.StackTrace,
-					InnerMessage = exceptionInfo.InnerMessage
-				};
-				responseTcs.TrySetException(exception);
-			}
+            if (containsException)
+            {
+                _logger.LogInformation($"Message '{args.BasicProperties.MessageId}' withh CorrelationId '{args.BasicProperties.CorrelationId}' contains exception. Deserialize and re-throw.");
+                var exceptionInfo = _serializer.Deserialize<MessageHandlerExceptionInformation>(args.Body);
+                var exception = new MessageHandlerException(exceptionInfo.Message)
+                {
+                    InnerExceptionType = exceptionInfo.ExceptionType,
+                    InnerStackTrace = exceptionInfo.StackTrace,
+                    InnerMessage = exceptionInfo.InnerMessage
+                };
+                responseTcs.TrySetException(exception);
+            }
 
-			return Task.FromResult(true);
-		}
+            return Task.FromResult(true);
+        }
 
-		public virtual Task OnResponseRecievedException(IRawConsumer rawConsumer, IConsumerConfiguration cfg, BasicDeliverEventArgs args, TaskCompletionSource<object> responseTcs, Exception exception)
-		{
-			_logger.LogError($"An exception was thrown when recieving response to messaeg '{args.BasicProperties.MessageId}' with CorrelationId '{args.BasicProperties.CorrelationId}'.", exception);
-			responseTcs.TrySetException(exception);
-			return Task.FromResult(true);
-		}
+        public virtual Task OnResponseRecievedException(IRawConsumer rawConsumer, IConsumerConfiguration cfg, BasicDeliverEventArgs args, TaskCompletionSource<object> responseTcs, Exception exception)
+        {
+            _logger.LogError($"An exception was thrown when recieving response to messaeg '{args.BasicProperties.MessageId}' with CorrelationId '{args.BasicProperties.CorrelationId}'.", exception);
+            responseTcs.TrySetException(exception);
+            return Task.FromResult(true);
+        }
 
-		public virtual Task ExecuteAsync(Func<Task> messageHandler, Func<Exception, Task> errorHandler)
-		{
-			try
-			{
-				return messageHandler()
-					.ContinueWith(tHandler => tHandler.IsFaulted
-							? errorHandler(tHandler.Exception)
-							: tHandler
-						);
-			}
-			catch (Exception e)
-			{
-				return errorHandler(e);
-			}
-		}
+        public virtual Task ExecuteAsync(Func<Task> messageHandler, Func<Exception, Task> errorHandler)
+        {
+            try
+            {
+                return messageHandler()
+                    .ContinueWith(tHandler => tHandler.IsFaulted
+                            ? errorHandler(tHandler.Exception)
+                            : tHandler
+                        );
+            }
+            catch (Exception e)
+            {
+                return errorHandler(e);
+            }
+        }
 
-		public virtual async Task OnSubscriberExceptionAsync(IRawConsumer consumer, SubscriptionConfiguration config, BasicDeliverEventArgs args, Exception exception)
-		{
-			if (!config.NoAck)
-			{
-				consumer.Model.BasicAck(args.DeliveryTag, false);
-				consumer.AcknowledgedTags.Add(args.DeliveryTag);
-			}
-			try
-			{
-				_logger.LogError($"Error thrown in Subscriber: ", exception);
-				_logger.LogDebug($"Attempting to publish message '{args.BasicProperties.MessageId}' to error exchange.");
+        public virtual async Task OnSubscriberExceptionAsync(IRawConsumer consumer, SubscriptionConfiguration config, BasicDeliverEventArgs args, Exception exception)
+        {
+            if (!config.NoAck)
+            {
+                consumer.Model.BasicAck(args.DeliveryTag, false);
+                consumer.AcknowledgedTags.Add(args.DeliveryTag);
+            }
+            try
+            {
+                _logger.LogError($"Error thrown in Subscriber: ", exception);
+                _logger.LogDebug($"Attempting to publish message '{args.BasicProperties.MessageId}' to error exchange.");
 
-				await _topologyProvider.DeclareExchangeAsync(_errorExchangeCfg);
-				var channel = await _channelFactory.GetChannelAsync();
-				var msg = _serializer.Deserialize(args);
-				var errorMsg = new HandlerExceptionMessage
-				{
-					Exception = exception,
-					Time = DateTime.Now,
-					Host = Environment.MachineName,
-					Message = msg,
-				};
-				channel.BasicPublish(
-					exchange: _errorExchangeCfg.ExchangeName,
-					routingKey: args.RoutingKey,
-					basicProperties: args.BasicProperties,
-					body: _serializer.Serialize(errorMsg)
-					);
-				channel.Close();
-			}
-			catch (Exception e)
-			{
-				_logger.LogWarning($"Unable to publish message '{args.BasicProperties.MessageId}' to default error exchange.", e);
-			}
-		}
-	}
+                await _topologyProvider.DeclareExchangeAsync(_errorExchangeCfg);
+                var channel = await _channelFactory.GetChannelAsync();
+                var msg = _serializer.Deserialize(args);
+                var errorMsg = new HandlerExceptionMessage
+                {
+                    Exception = exception,
+                    Time = DateTime.Now,
+                    Host = Environment.MachineName,
+                    Message = msg,
+                };
+                channel.BasicPublish(
+                    exchange: _errorExchangeCfg.ExchangeName,
+                    routingKey: args.RoutingKey,
+                    basicProperties: args.BasicProperties,
+                    body: _serializer.Serialize(errorMsg)
+                    );
+                channel.Close();
+            }
+            catch (Exception e)
+            {
+                _logger.LogWarning($"Unable to publish message '{args.BasicProperties.MessageId}' to default error exchange.", e);
+            }
+        }
+    }
 }

--- a/src/RawRabbit/ErrorHandling/IErrorHandlingStrategy.cs
+++ b/src/RawRabbit/ErrorHandling/IErrorHandlingStrategy.cs
@@ -7,53 +7,53 @@ using RawRabbit.Consumer.Abstraction;
 
 namespace RawRabbit.ErrorHandling
 {
-	public interface IErrorHandlingStrategy
-	{
-		/// <summary>
-		/// Executes the message handler with exception handling for sync and async calls.
-		/// </summary>
-		/// <param name="messageHandler"> The message handler</param>
-		/// <param name="exceptionHandler">The exception handler to be called if message handler throws exception</param>
-		/// <returns></returns>
-		Task ExecuteAsync(Func<Task> messageHandler, Func<Exception, Task> exceptionHandler);
+    public interface IErrorHandlingStrategy
+    {
+        /// <summary>
+        /// Executes the message handler with exception handling for sync and async calls.
+        /// </summary>
+        /// <param name="messageHandler"> The message handler</param>
+        /// <param name="exceptionHandler">The exception handler to be called if message handler throws exception</param>
+        /// <returns></returns>
+        Task ExecuteAsync(Func<Task> messageHandler, Func<Exception, Task> exceptionHandler);
 
-		/// <summary>
-		/// Error strategy for unhandled exceptions thrown within RespondAsync message handler
-		/// </summary>
-		/// <param name="consumer">The consumer that was used for the message handler</param>
-		/// <param name="config"> The configuration for the consumer</param>
-		/// <param name="args">The recieved args</param>
-		/// <param name="exception">The thrown exception</param>
-		/// <returns></returns>
-		Task OnResponseHandlerExceptionAsync(IRawConsumer consumer, IConsumerConfiguration config, BasicDeliverEventArgs args,  Exception exception);
+        /// <summary>
+        /// Error strategy for unhandled exceptions thrown within RespondAsync message handler
+        /// </summary>
+        /// <param name="consumer">The consumer that was used for the message handler</param>
+        /// <param name="config"> The configuration for the consumer</param>
+        /// <param name="args">The recieved args</param>
+        /// <param name="exception">The thrown exception</param>
+        /// <returns></returns>
+        Task OnResponseHandlerExceptionAsync(IRawConsumer consumer, IConsumerConfiguration config, BasicDeliverEventArgs args,  Exception exception);
 
-		/// <summary>
-		/// Error strategy for unhandled exceptions thrown within SubscribeAsync message handler
-		/// </summary>
-		/// <param name="consumer">The consumer that was used for the message handler</param>
-		/// <param name="config"> The configuration for the consumer</param>
-		/// <param name="args">The recieved args</param>
-		/// <param name="exception">The thrown exception</param>
-		/// <returns></returns>
-		Task OnSubscriberExceptionAsync(IRawConsumer consumer, SubscriptionConfiguration config, BasicDeliverEventArgs args, Exception exception);
+        /// <summary>
+        /// Error strategy for unhandled exceptions thrown within SubscribeAsync message handler
+        /// </summary>
+        /// <param name="consumer">The consumer that was used for the message handler</param>
+        /// <param name="config"> The configuration for the consumer</param>
+        /// <param name="args">The recieved args</param>
+        /// <param name="exception">The thrown exception</param>
+        /// <returns></returns>
+        Task OnSubscriberExceptionAsync(IRawConsumer consumer, SubscriptionConfiguration config, BasicDeliverEventArgs args, Exception exception);
 
-		/// <summary>
-		/// Method called when response is recieved. This method can be used to re-throw exceptions from the responder.
-		/// </summary>
-		/// <param name="args">The recieved args</param>
-		/// <param name="responseTcs">The TaskCompletionSource to the return task from RequestAsync</param>
-		/// <returns></returns>
-		Task OnResponseRecievedAsync(BasicDeliverEventArgs args, TaskCompletionSource<object> responseTcs);
+        /// <summary>
+        /// Method called when response is recieved. This method can be used to re-throw exceptions from the responder.
+        /// </summary>
+        /// <param name="args">The recieved args</param>
+        /// <param name="responseTcs">The TaskCompletionSource to the return task from RequestAsync</param>
+        /// <returns></returns>
+        Task OnResponseRecievedAsync(BasicDeliverEventArgs args, TaskCompletionSource<object> responseTcs);
 
-		/// <summary>
-		/// Method called when an unhandled exception is thrown when handling the recieved response
-		/// </summary>
-		/// <param name="consumer">The consumer that was used for the message handler</param>
-		/// <param name="config"> The configuration for the consumer</param>
-		/// <param name="args">The recieved args</param>
-		/// <param name="responseTcs">The TaskCompletionSource to the return task from RequestAsync</param>
-		/// <param name="exception">The thrown exception</param>
-		/// <returns></returns>
-		Task OnResponseRecievedException(IRawConsumer consumer, IConsumerConfiguration config, BasicDeliverEventArgs args, TaskCompletionSource<object> responseTcs, Exception exception);
-	}
+        /// <summary>
+        /// Method called when an unhandled exception is thrown when handling the recieved response
+        /// </summary>
+        /// <param name="consumer">The consumer that was used for the message handler</param>
+        /// <param name="config"> The configuration for the consumer</param>
+        /// <param name="args">The recieved args</param>
+        /// <param name="responseTcs">The TaskCompletionSource to the return task from RequestAsync</param>
+        /// <param name="exception">The thrown exception</param>
+        /// <returns></returns>
+        Task OnResponseRecievedException(IRawConsumer consumer, IConsumerConfiguration config, BasicDeliverEventArgs args, TaskCompletionSource<object> responseTcs, Exception exception);
+    }
 }

--- a/src/RawRabbit/ErrorHandling/MessageHandlerExceptionMessage.cs
+++ b/src/RawRabbit/ErrorHandling/MessageHandlerExceptionMessage.cs
@@ -2,11 +2,11 @@
 
 namespace RawRabbit.ErrorHandling
 {
-	public class HandlerExceptionMessage
-	{
-		public string Host { get; set; }
-		public DateTime Time { get; set; }
-		public object Message { get; set; }
-		public Exception Exception { get; set; }
-	}
+    public class HandlerExceptionMessage
+    {
+        public string Host { get; set; }
+        public DateTime Time { get; set; }
+        public object Message { get; set; }
+        public Exception Exception { get; set; }
+    }
 }

--- a/src/RawRabbit/Exceptions/ChannelAvailabilityException.cs
+++ b/src/RawRabbit/Exceptions/ChannelAvailabilityException.cs
@@ -2,9 +2,9 @@
 
 namespace RawRabbit.Exceptions
 {
-	public class ChannelAvailabilityException : Exception
-	{
-		public ChannelAvailabilityException(string message) : base(message)
-		{ }
-	}
+    public class ChannelAvailabilityException : Exception
+    {
+        public ChannelAvailabilityException(string message) : base(message)
+        { }
+    }
 }

--- a/src/RawRabbit/Exceptions/MessageHandlerException.cs
+++ b/src/RawRabbit/Exceptions/MessageHandlerException.cs
@@ -2,25 +2,25 @@
 
 namespace RawRabbit.Exceptions
 {
-	/// <summary>
-	/// Exception is thrown if the message handler in a IResponder throws
-	/// a unhandled exception.
-	/// </summary>
-	public class MessageHandlerException : Exception
-	{
-		public string InnerExceptionType { get; set; }
-		public string InnerStackTrace { get; set; }
-		public string InnerMessage { get; set; }
+    /// <summary>
+    /// Exception is thrown if the message handler in a IResponder throws
+    /// a unhandled exception.
+    /// </summary>
+    public class MessageHandlerException : Exception
+    {
+        public string InnerExceptionType { get; set; }
+        public string InnerStackTrace { get; set; }
+        public string InnerMessage { get; set; }
 
-		public MessageHandlerException()
-		{ }
+        public MessageHandlerException()
+        { }
 
-		public MessageHandlerException(string message) :base(message)
-		{ }
+        public MessageHandlerException(string message) :base(message)
+        { }
 
-		public MessageHandlerException(string message, Exception inner)
-			: base(message, inner)
-		{ }
+        public MessageHandlerException(string message, Exception inner)
+            : base(message, inner)
+        { }
 
-	}
+    }
 }

--- a/src/RawRabbit/Exceptions/MessageHandlerExceptionInformation.cs
+++ b/src/RawRabbit/Exceptions/MessageHandlerExceptionInformation.cs
@@ -1,13 +1,13 @@
 ﻿namespace RawRabbit.Exceptions
 {
-	/// <summary>
-	/// Holds information about exception thrown in a remote message handler. 
-	/// </summary>
-	public class MessageHandlerExceptionInformation
-	{
-		public string Message { get; set; }
-		public string ExceptionType { get; set; }
-		public string StackTrace { get; set; }
-		public string InnerMessage { get; set; }
-	}
+    /// <summary>
+    /// Holds information about exception thrown in a remote message handler. 
+    /// </summary>
+    public class MessageHandlerExceptionInformation
+    {
+        public string Message { get; set; }
+        public string ExceptionType { get; set; }
+        public string StackTrace { get; set; }
+        public string InnerMessage { get; set; }
+    }
 }

--- a/src/RawRabbit/Exceptions/PublishConfirmException.cs
+++ b/src/RawRabbit/Exceptions/PublishConfirmException.cs
@@ -2,16 +2,16 @@
 
 namespace RawRabbit.Exceptions
 {
-	public class PublishConfirmException : Exception
-	{
-		public PublishConfirmException()
-		{ }
+    public class PublishConfirmException : Exception
+    {
+        public PublishConfirmException()
+        { }
 
-		public PublishConfirmException(string message) :base(message)
-		{ }
+        public PublishConfirmException(string message) :base(message)
+        { }
 
-		public PublishConfirmException(string message, Exception inner)
-			: base(message, inner)
-		{ }
-	}
+        public PublishConfirmException(string message, Exception inner)
+            : base(message, inner)
+        { }
+    }
 }

--- a/src/RawRabbit/IBusClient.cs
+++ b/src/RawRabbit/IBusClient.cs
@@ -9,14 +9,14 @@ using RawRabbit.Context;
 
 namespace RawRabbit
 {
-	public interface IBusClient<out TMessageContext> : IShutdown where TMessageContext : IMessageContext
-	{
-		ISubscription SubscribeAsync<T>(Func<T, TMessageContext, Task> subscribeMethod, Action<ISubscriptionConfigurationBuilder> configuration = null);
+    public interface IBusClient<out TMessageContext> : IShutdown where TMessageContext : IMessageContext
+    {
+        ISubscription SubscribeAsync<T>(Func<T, TMessageContext, Task> subscribeMethod, Action<ISubscriptionConfigurationBuilder> configuration = null);
 
-		Task PublishAsync<T>(T message = default(T), Guid globalMessageId = new Guid(), Action<IPublishConfigurationBuilder> configuration = null);
+        Task PublishAsync<T>(T message = default(T), Guid globalMessageId = new Guid(), Action<IPublishConfigurationBuilder> configuration = null);
 
-		ISubscription RespondAsync<TRequest, TResponse>(Func<TRequest, TMessageContext, Task<TResponse>> onMessage, Action<IResponderConfigurationBuilder> configuration = null);
+        ISubscription RespondAsync<TRequest, TResponse>(Func<TRequest, TMessageContext, Task<TResponse>> onMessage, Action<IResponderConfigurationBuilder> configuration = null);
 
-		Task<TResponse> RequestAsync<TRequest, TResponse>(TRequest message = default(TRequest), Guid globalMessageId = new Guid(), Action<IRequestConfigurationBuilder> configuration = null);
-	}
+        Task<TResponse> RequestAsync<TRequest, TResponse>(TRequest message = default(TRequest), Guid globalMessageId = new Guid(), Action<IRequestConfigurationBuilder> configuration = null);
+    }
 }

--- a/src/RawRabbit/Logging/ConsoleLogger.cs
+++ b/src/RawRabbit/Logging/ConsoleLogger.cs
@@ -4,72 +4,72 @@ using Newtonsoft.Json;
 
 namespace RawRabbit.Logging
 {
-	public class ConsoleLogger : ILogger
-	{
-		private readonly LogLevel _minLevel;
-		private readonly string _category;
+    public class ConsoleLogger : ILogger
+    {
+        private readonly LogLevel _minLevel;
+        private readonly string _category;
 
-		public ConsoleLogger(LogLevel minLevel, string category)
-		{
-			_minLevel = minLevel;
-			_category = category;
-		}
+        public ConsoleLogger(LogLevel minLevel, string category)
+        {
+            _minLevel = minLevel;
+            _category = category;
+        }
 
-		public void LogDebug(string format, params object[] args)
-		{
-			if (LogLevel.Debug < _minLevel)
-			{
-				return;
-			}
-			var message = FormatEntry(format, args);
-			Console.ForegroundColor = ConsoleColor.DarkGray;
-			Console.WriteLine($"[{DateTime.Now.ToString("HH:mm:ss")}] [${Thread.CurrentThread.ManagedThreadId}] [DEBUG] [{_category}]: {message}");
-		}
+        public void LogDebug(string format, params object[] args)
+        {
+            if (LogLevel.Debug < _minLevel)
+            {
+                return;
+            }
+            var message = FormatEntry(format, args);
+            Console.ForegroundColor = ConsoleColor.DarkGray;
+            Console.WriteLine($"[{DateTime.Now.ToString("HH:mm:ss")}] [${Thread.CurrentThread.ManagedThreadId}] [DEBUG] [{_category}]: {message}");
+        }
 
-		public void LogInformation(string format, params object[] args)
-		{
-			if (LogLevel.Information < _minLevel)
-			{
-				return;
-			}
-			var message = FormatEntry(format, args);
-			Console.ForegroundColor = ConsoleColor.Green;
-			Console.WriteLine($"[{DateTime.Now.ToString("HH:mm:ss")}] [${Thread.CurrentThread.ManagedThreadId}] [INFO] [{_category}]: {message}");
-		}
+        public void LogInformation(string format, params object[] args)
+        {
+            if (LogLevel.Information < _minLevel)
+            {
+                return;
+            }
+            var message = FormatEntry(format, args);
+            Console.ForegroundColor = ConsoleColor.Green;
+            Console.WriteLine($"[{DateTime.Now.ToString("HH:mm:ss")}] [${Thread.CurrentThread.ManagedThreadId}] [INFO] [{_category}]: {message}");
+        }
 
-		public void LogWarning(string format, params object[] args)
-		{
-			if (LogLevel.Warning < _minLevel)
-			{
-				return;
-			}
-			var message = FormatEntry(format, args);
-			Console.ForegroundColor = ConsoleColor.DarkRed;
-			Console.WriteLine($"[{DateTime.Now.ToString("HH:mm:ss")}] [${Thread.CurrentThread.ManagedThreadId}] [WARN] [{_category}]: {message}");
-		}
+        public void LogWarning(string format, params object[] args)
+        {
+            if (LogLevel.Warning < _minLevel)
+            {
+                return;
+            }
+            var message = FormatEntry(format, args);
+            Console.ForegroundColor = ConsoleColor.DarkRed;
+            Console.WriteLine($"[{DateTime.Now.ToString("HH:mm:ss")}] [${Thread.CurrentThread.ManagedThreadId}] [WARN] [{_category}]: {message}");
+        }
 
-		public void LogError(string message, Exception exception)
-		{
-			if (LogLevel.Error < _minLevel)
-			{
-				return;
-			}
-			Console.ForegroundColor = ConsoleColor.DarkRed;
-			Console.WriteLine($"[{DateTime.Now.ToString("HH:mm:ss")}] [${Thread.CurrentThread.ManagedThreadId}] [ERROR] [{_category}]: {message}, Exception: {Environment.NewLine} {exception}");
-		}
+        public void LogError(string message, Exception exception)
+        {
+            if (LogLevel.Error < _minLevel)
+            {
+                return;
+            }
+            Console.ForegroundColor = ConsoleColor.DarkRed;
+            Console.WriteLine($"[{DateTime.Now.ToString("HH:mm:ss")}] [${Thread.CurrentThread.ManagedThreadId}] [ERROR] [{_category}]: {message}, Exception: {Environment.NewLine} {exception}");
+        }
 
-		private static string FormatEntry(string format, object[] args)
-		{
-			args = args ?? new object[0];
-			for (var i = 0; i < args.Length; i++)
-			{
-				if (args[i] is string)
-				{
-					continue;
-				}
-				args[i] = JsonConvert.SerializeObject(args[i]);
-			}
-			return string.Format(format, args);
-		}
-	}
+        private static string FormatEntry(string format, object[] args)
+        {
+            args = args ?? new object[0];
+            for (var i = 0; i < args.Length; i++)
+            {
+                if (args[i] is string)
+                {
+                    continue;
+                }
+                args[i] = JsonConvert.SerializeObject(args[i]);
+            }
+            return string.Format(format, args);
+        }
+    }
 }

--- a/src/RawRabbit/Logging/ILogger.cs
+++ b/src/RawRabbit/Logging/ILogger.cs
@@ -2,14 +2,14 @@
 
 namespace RawRabbit.Logging
 {
-	/*
-		This interface is an abstract of signatures for Microsoft.Extensions.Logging's ILogger and its extensionmethods.
-	*/
-	public interface ILogger
-	{
-		void LogDebug(string format, params object[] args);
-		void LogInformation(string format, params object[] args);
-		void LogWarning(string format, params object[] args);
-		void LogError(string message, Exception exception);
-	}
+    /*
+        This interface is an abstract of signatures for Microsoft.Extensions.Logging's ILogger and its extensionmethods.
+    */
+    public interface ILogger
+    {
+        void LogDebug(string format, params object[] args);
+        void LogInformation(string format, params object[] args);
+        void LogWarning(string format, params object[] args);
+        void LogError(string message, Exception exception);
+    }
 }

--- a/src/RawRabbit/Logging/LogLevel.cs
+++ b/src/RawRabbit/Logging/LogLevel.cs
@@ -1,43 +1,43 @@
 ﻿namespace RawRabbit.Logging
 {
-	/// <summary>
-	/// A temporary copy of https://github.com/aspnet/Logging/blob/dev/src/Microsoft.Extensions.Logging.Abstractions/LogLevel.cs
-	/// </summary>
-	public enum LogLevel
-	{
-		/// <summary>
-		/// Logs that contain the most detailed messages. These messages may contain sensitive application data.
-		/// These messages are disabled by default and should never be enabled in a production environment.
-		/// </summary>
-		Debug = 1,
+    /// <summary>
+    /// A temporary copy of https://github.com/aspnet/Logging/blob/dev/src/Microsoft.Extensions.Logging.Abstractions/LogLevel.cs
+    /// </summary>
+    public enum LogLevel
+    {
+        /// <summary>
+        /// Logs that contain the most detailed messages. These messages may contain sensitive application data.
+        /// These messages are disabled by default and should never be enabled in a production environment.
+        /// </summary>
+        Debug = 1,
 
-		/// <summary>
-		/// Logs that are used for interactive investigation during development.  These logs should primarily contain
-		/// information useful for debugging and have no long-term value.
-		/// </summary>
-		Verbose = 2,
+        /// <summary>
+        /// Logs that are used for interactive investigation during development.  These logs should primarily contain
+        /// information useful for debugging and have no long-term value.
+        /// </summary>
+        Verbose = 2,
 
-		/// <summary>
-		/// Logs that track the general flow of the application. These logs should have long-term value.
-		/// </summary>
-		Information = 3,
+        /// <summary>
+        /// Logs that track the general flow of the application. These logs should have long-term value.
+        /// </summary>
+        Information = 3,
 
-		/// <summary>
-		/// Logs that highlight an abnormal or unexpected event in the application flow, but do not otherwise cause the
-		/// application execution to stop.
-		/// </summary>
-		Warning = 4,
+        /// <summary>
+        /// Logs that highlight an abnormal or unexpected event in the application flow, but do not otherwise cause the
+        /// application execution to stop.
+        /// </summary>
+        Warning = 4,
 
-		/// <summary>
-		/// Logs that highlight when the current flow of execution is stopped due to a failure. These should indicate a
-		/// failure in the current activity, not an application-wide failure.
-		/// </summary>
-		Error = 5,
+        /// <summary>
+        /// Logs that highlight when the current flow of execution is stopped due to a failure. These should indicate a
+        /// failure in the current activity, not an application-wide failure.
+        /// </summary>
+        Error = 5,
 
-		/// <summary>
-		/// Logs that describe an unrecoverable application or system crash, or a catastrophic failure that requires
-		/// immediate attention.
-		/// </summary>
-		Critical = 6,
-	}
+        /// <summary>
+        /// Logs that describe an unrecoverable application or system crash, or a catastrophic failure that requires
+        /// immediate attention.
+        /// </summary>
+        Critical = 6,
+    }
 }

--- a/src/RawRabbit/Logging/LogManager.cs
+++ b/src/RawRabbit/Logging/LogManager.cs
@@ -1,18 +1,18 @@
 ﻿
 namespace RawRabbit.Logging
 {
-	public class LogManager
-	{
-		private static ILoggerFactory _current;
-		public static ILoggerFactory CurrentFactory
-		{
-			get { return _current ?? (_current = new LoggerFactory()); }
-			set { _current = value; }
-		}
+    public class LogManager
+    {
+        private static ILoggerFactory _current;
+        public static ILoggerFactory CurrentFactory
+        {
+            get { return _current ?? (_current = new LoggerFactory()); }
+            set { _current = value; }
+        }
 
-		public static ILogger GetLogger<TType>()
-		{
-			return CurrentFactory.CreateLogger<TType>();
-		}
-	}
+        public static ILogger GetLogger<TType>()
+        {
+            return CurrentFactory.CreateLogger<TType>();
+        }
+    }
 }

--- a/src/RawRabbit/Logging/LoggerFactory.cs
+++ b/src/RawRabbit/Logging/LoggerFactory.cs
@@ -3,49 +3,49 @@ using System.Collections.Concurrent;
 
 namespace RawRabbit.Logging
 {
-	public interface ILoggerFactory : IDisposable
-	{
-		/// <summary>
-		/// Creates a new <see cref="ILogger"/> instance.
-		/// </summary>
-		/// <param name="categoryName">The category name for messages produced by the logger.</param>
-		/// <returns>The <see cref="ILogger"/>.</returns>
-		ILogger CreateLogger(string categoryName);
-	}
+    public interface ILoggerFactory : IDisposable
+    {
+        /// <summary>
+        /// Creates a new <see cref="ILogger"/> instance.
+        /// </summary>
+        /// <param name="categoryName">The category name for messages produced by the logger.</param>
+        /// <returns>The <see cref="ILogger"/>.</returns>
+        ILogger CreateLogger(string categoryName);
+    }
 
-	public class LoggerFactory : ILoggerFactory
-	{
-		private readonly Func<string, ILogger> _createFn;
-		private readonly ConcurrentDictionary<string, ILogger> _categoryToLogger;
+    public class LoggerFactory : ILoggerFactory
+    {
+        private readonly Func<string, ILogger> _createFn;
+        private readonly ConcurrentDictionary<string, ILogger> _categoryToLogger;
 
-		public LoggerFactory() : this(s => new ConsoleLogger(LogLevel.Debug, s))
-		{
-			
-		}
-		public LoggerFactory(Func<string, ILogger> createFn)
-		{
-			_createFn = createFn;
-			_categoryToLogger = new ConcurrentDictionary<string, ILogger>();
-		}
+        public LoggerFactory() : this(s => new ConsoleLogger(LogLevel.Debug, s))
+        {
+            
+        }
+        public LoggerFactory(Func<string, ILogger> createFn)
+        {
+            _createFn = createFn;
+            _categoryToLogger = new ConcurrentDictionary<string, ILogger>();
+        }
 
-		public void Dispose() { }
+        public void Dispose() { }
 
-		public ILogger CreateLogger(string categoryName)
-		{
-			ILogger logger;
-			if (!_categoryToLogger.TryGetValue(categoryName, out logger))
-			{
-				logger = _categoryToLogger.GetOrAdd(categoryName, _createFn);
-			}
-			return logger;
-		}
-	}
+        public ILogger CreateLogger(string categoryName)
+        {
+            ILogger logger;
+            if (!_categoryToLogger.TryGetValue(categoryName, out logger))
+            {
+                logger = _categoryToLogger.GetOrAdd(categoryName, _createFn);
+            }
+            return logger;
+        }
+    }
 
-	public static class LoggerFactoryExtensions
-	{
-		public static ILogger CreateLogger<TType>(this ILoggerFactory factory)
-		{
-			return factory.CreateLogger(typeof(TType).Name);
-		}
-	}
+    public static class LoggerFactoryExtensions
+    {
+        public static ILogger CreateLogger<TType>(this ILoggerFactory factory)
+        {
+            return factory.CreateLogger(typeof(TType).Name);
+        }
+    }
 }

--- a/src/RawRabbit/Logging/VoidLogger.cs
+++ b/src/RawRabbit/Logging/VoidLogger.cs
@@ -2,40 +2,40 @@
 
 namespace RawRabbit.Logging
 {
-	public class VoidLogger : ILogger
-	{
-		public void LogDebug(string format, params object[] args)
-		{
-		}
+    public class VoidLogger : ILogger
+    {
+        public void LogDebug(string format, params object[] args)
+        {
+        }
 
-		public void LogInformation(string format, params object[] args)
-		{
-		}
+        public void LogInformation(string format, params object[] args)
+        {
+        }
 
-		public void LogWarning(string format, params object[] args)
-		{
-		}
+        public void LogWarning(string format, params object[] args)
+        {
+        }
 
-		public void LogError(string message, Exception exception)
-		{
-		}
-	}
+        public void LogError(string message, Exception exception)
+        {
+        }
+    }
 
-	public class VoidLoggerFactory : ILoggerFactory
-	{
-		private readonly VoidLogger _logger;
+    public class VoidLoggerFactory : ILoggerFactory
+    {
+        private readonly VoidLogger _logger;
 
-		public VoidLoggerFactory()
-		{
-			_logger = new VoidLogger();
-		}
-		public void Dispose()
-		{
-		}
+        public VoidLoggerFactory()
+        {
+            _logger = new VoidLogger();
+        }
+        public void Dispose()
+        {
+        }
 
-		public ILogger CreateLogger(string categoryName)
-		{
-			return _logger;
-		}
-	}
+        public ILogger CreateLogger(string categoryName)
+        {
+            return _logger;
+        }
+    }
 }

--- a/src/RawRabbit/Operations/Abstraction/IPublisher.cs
+++ b/src/RawRabbit/Operations/Abstraction/IPublisher.cs
@@ -4,8 +4,8 @@ using RawRabbit.Configuration.Publish;
 
 namespace RawRabbit.Operations.Abstraction
 {
-	public interface IPublisher
-	{
-		Task PublishAsync<TMessage>(TMessage message, Guid globalMessageId, PublishConfiguration config);
-	}
+    public interface IPublisher
+    {
+        Task PublishAsync<TMessage>(TMessage message, Guid globalMessageId, PublishConfiguration config);
+    }
 }

--- a/src/RawRabbit/Operations/Abstraction/IRequester.cs
+++ b/src/RawRabbit/Operations/Abstraction/IRequester.cs
@@ -4,8 +4,8 @@ using RawRabbit.Configuration.Request;
 
 namespace RawRabbit.Operations.Abstraction
 {
-	public interface IRequester
-	{
-		Task<TResponse> RequestAsync<TRequest, TResponse>(TRequest message, Guid globalMessageId, RequestConfiguration config);
-	}
+    public interface IRequester
+    {
+        Task<TResponse> RequestAsync<TRequest, TResponse>(TRequest message, Guid globalMessageId, RequestConfiguration config);
+    }
 }

--- a/src/RawRabbit/Operations/Abstraction/IResponder.cs
+++ b/src/RawRabbit/Operations/Abstraction/IResponder.cs
@@ -6,8 +6,8 @@ using RawRabbit.Context;
 
 namespace RawRabbit.Operations.Abstraction
 {
-	public interface IResponder<out TMessageContext> where TMessageContext : IMessageContext
-	{
-		ISubscription RespondAsync<TRequest, TResponse>(Func<TRequest, TMessageContext, Task<TResponse>> onMessage, ResponderConfiguration cfg);
-	}
+    public interface IResponder<out TMessageContext> where TMessageContext : IMessageContext
+    {
+        ISubscription RespondAsync<TRequest, TResponse>(Func<TRequest, TMessageContext, Task<TResponse>> onMessage, ResponderConfiguration cfg);
+    }
 }

--- a/src/RawRabbit/Operations/Abstraction/ISubscriber.cs
+++ b/src/RawRabbit/Operations/Abstraction/ISubscriber.cs
@@ -6,8 +6,8 @@ using RawRabbit.Context;
 
 namespace RawRabbit.Operations.Abstraction
 {
-	public interface ISubscriber<out TMessageContext> where TMessageContext : IMessageContext
-	{
-		ISubscription SubscribeAsync<T>(Func<T, TMessageContext, Task> subscribeMethod, SubscriptionConfiguration config);
-	}
+    public interface ISubscriber<out TMessageContext> where TMessageContext : IMessageContext
+    {
+        ISubscription SubscribeAsync<T>(Func<T, TMessageContext, Task> subscribeMethod, SubscriptionConfiguration config);
+    }
 }

--- a/src/RawRabbit/Operations/Publisher.cs
+++ b/src/RawRabbit/Operations/Publisher.cs
@@ -12,70 +12,70 @@ using RawRabbit.Serialization;
 
 namespace RawRabbit.Operations
 {
-	public class Publisher<TMessageContext> : IPublisher where TMessageContext : IMessageContext
-	{
-		private readonly IChannelFactory _channelFactory;
-		private readonly ITopologyProvider _topologyProvider;
-		private readonly IMessageSerializer _serializer;
-		private readonly IMessageContextProvider<TMessageContext> _contextProvider;
-		private readonly IPublishAcknowledger _acknowledger;
-		private readonly IBasicPropertiesProvider _propertiesProvider;
-		private readonly RawRabbitConfiguration _config;
-		private readonly ILogger _logger = LogManager.GetLogger<Publisher<TMessageContext>>();
-		private readonly object _publishLock = new object();
-		private readonly object _topologyLock = new object();
+    public class Publisher<TMessageContext> : IPublisher where TMessageContext : IMessageContext
+    {
+        private readonly IChannelFactory _channelFactory;
+        private readonly ITopologyProvider _topologyProvider;
+        private readonly IMessageSerializer _serializer;
+        private readonly IMessageContextProvider<TMessageContext> _contextProvider;
+        private readonly IPublishAcknowledger _acknowledger;
+        private readonly IBasicPropertiesProvider _propertiesProvider;
+        private readonly RawRabbitConfiguration _config;
+        private readonly ILogger _logger = LogManager.GetLogger<Publisher<TMessageContext>>();
+        private readonly object _publishLock = new object();
+        private readonly object _topologyLock = new object();
 
-		public Publisher(IChannelFactory channelFactory, ITopologyProvider topologyProvider, IMessageSerializer serializer, IMessageContextProvider<TMessageContext> contextProvider, IPublishAcknowledger acknowledger, IBasicPropertiesProvider propertiesProvider, RawRabbitConfiguration config)
-		{
-			_channelFactory = channelFactory;
-			_topologyProvider = topologyProvider;
-			_serializer = serializer;
-			_contextProvider = contextProvider;
-			_acknowledger = acknowledger;
-			_propertiesProvider = propertiesProvider;
-			_config = config;
-		}
+        public Publisher(IChannelFactory channelFactory, ITopologyProvider topologyProvider, IMessageSerializer serializer, IMessageContextProvider<TMessageContext> contextProvider, IPublishAcknowledger acknowledger, IBasicPropertiesProvider propertiesProvider, RawRabbitConfiguration config)
+        {
+            _channelFactory = channelFactory;
+            _topologyProvider = topologyProvider;
+            _serializer = serializer;
+            _contextProvider = contextProvider;
+            _acknowledger = acknowledger;
+            _propertiesProvider = propertiesProvider;
+            _config = config;
+        }
 
-		public Task PublishAsync<TMessage>(TMessage message, Guid globalMessageId, PublishConfiguration config)
-		{
-			var context = _contextProvider.GetMessageContext(ref globalMessageId);
-			var props = _propertiesProvider.GetProperties<TMessage>(config.PropertyModifier + (p => p.Headers.Add(PropertyHeaders.Context, context)));
+        public Task PublishAsync<TMessage>(TMessage message, Guid globalMessageId, PublishConfiguration config)
+        {
+            var context = _contextProvider.GetMessageContext(ref globalMessageId);
+            var props = _propertiesProvider.GetProperties<TMessage>(config.PropertyModifier + (p => p.Headers.Add(PropertyHeaders.Context, context)));
 
-			Task exchangeTask;
-			lock (_topologyLock)
-			{
-				exchangeTask = _topologyProvider.DeclareExchangeAsync(config.Exchange);
-			}
-			var channelTask = _channelFactory.GetChannelAsync();
+            Task exchangeTask;
+            lock (_topologyLock)
+            {
+                exchangeTask = _topologyProvider.DeclareExchangeAsync(config.Exchange);
+            }
+            var channelTask = _channelFactory.GetChannelAsync();
 
-			return Task
-				.WhenAll(exchangeTask, channelTask)
-				.ContinueWith(t =>
-				{
-					if (t.IsFaulted)
-					{
-						throw t.Exception;
-					}
+            return Task
+                .WhenAll(exchangeTask, channelTask)
+                .ContinueWith(t =>
+                {
+                    if (t.IsFaulted)
+                    {
+                        throw t.Exception;
+                    }
 
-					channelTask.Result.BasicReturn += config.BasicReturn;
+                    channelTask.Result.BasicReturn += config.BasicReturn;
 
-					lock (_publishLock)
-					{
-						var ackTask = _acknowledger.GetAckTask(channelTask.Result);
-						channelTask.Result.BasicPublish(
-							exchange: config.Exchange.ExchangeName,
-							routingKey: _config.RouteWithGlobalId ? $"{config.RoutingKey}.{globalMessageId}" : config.RoutingKey,
-							basicProperties: props,
-							body: _serializer.Serialize(message),
-							mandatory: (config.BasicReturn != null)
-						);
-						return ackTask
-						.ContinueWith(a => {
-							channelTask.Result.BasicReturn -= config.BasicReturn;
-						});
-					}
-				})
-				.Unwrap();
-		}
-	}
+                    lock (_publishLock)
+                    {
+                        var ackTask = _acknowledger.GetAckTask(channelTask.Result);
+                        channelTask.Result.BasicPublish(
+                            exchange: config.Exchange.ExchangeName,
+                            routingKey: _config.RouteWithGlobalId ? $"{config.RoutingKey}.{globalMessageId}" : config.RoutingKey,
+                            basicProperties: props,
+                            body: _serializer.Serialize(message),
+                            mandatory: (config.BasicReturn != null)
+                        );
+                        return ackTask
+                        .ContinueWith(a => {
+                            channelTask.Result.BasicReturn -= config.BasicReturn;
+                        });
+                    }
+                })
+                .Unwrap();
+        }
+    }
 }

--- a/src/RawRabbit/Operations/Requester.cs
+++ b/src/RawRabbit/Operations/Requester.cs
@@ -18,216 +18,216 @@ using RawRabbit.Serialization;
 
 namespace RawRabbit.Operations
 {
-	public class Requester<TMessageContext> : IShutdown, IRequester where TMessageContext : IMessageContext
-	{
-		private readonly IChannelFactory _channelFactory;
-		private readonly IConsumerFactory _consumerFactory;
-		private readonly IMessageSerializer _serializer;
-		private readonly IMessageContextProvider<TMessageContext> _contextProvider;
-		private readonly IErrorHandlingStrategy _errorStrategy;
-		private readonly IBasicPropertiesProvider _propertiesProvider;
-		private readonly ITopologyProvider _topologyProvider;
-		private readonly RawRabbitConfiguration _config;
-		private readonly ConcurrentDictionary<string, ResponseCompletionSource> _responseDictionary;
-		private readonly ConcurrentDictionary<IModel, ConsumerCompletionSource> _consumerCompletionSources;
-		private readonly ILogger _logger = LogManager.GetLogger<Requester<TMessageContext>>();
-		private ConsumerCompletionSource _currentConsumer;
-		private readonly Task _completed = Task.FromResult(true);
+    public class Requester<TMessageContext> : IShutdown, IRequester where TMessageContext : IMessageContext
+    {
+        private readonly IChannelFactory _channelFactory;
+        private readonly IConsumerFactory _consumerFactory;
+        private readonly IMessageSerializer _serializer;
+        private readonly IMessageContextProvider<TMessageContext> _contextProvider;
+        private readonly IErrorHandlingStrategy _errorStrategy;
+        private readonly IBasicPropertiesProvider _propertiesProvider;
+        private readonly ITopologyProvider _topologyProvider;
+        private readonly RawRabbitConfiguration _config;
+        private readonly ConcurrentDictionary<string, ResponseCompletionSource> _responseDictionary;
+        private readonly ConcurrentDictionary<IModel, ConsumerCompletionSource> _consumerCompletionSources;
+        private readonly ILogger _logger = LogManager.GetLogger<Requester<TMessageContext>>();
+        private ConsumerCompletionSource _currentConsumer;
+        private readonly Task _completed = Task.FromResult(true);
 
-		public Requester(
-			IChannelFactory channelFactory,
-			IConsumerFactory consumerFactory,
-			IMessageSerializer serializer,
-			IMessageContextProvider<TMessageContext> contextProvider,
-			IErrorHandlingStrategy errorStrategy,
-			IBasicPropertiesProvider propertiesProvider,
-			ITopologyProvider topologyProvider,
-			RawRabbitConfiguration config)
-		{
-			_channelFactory = channelFactory;
-			_consumerFactory = consumerFactory;
-			_serializer = serializer;
-			_contextProvider = contextProvider;
-			_errorStrategy = errorStrategy;
-			_propertiesProvider = propertiesProvider;
-			_topologyProvider = topologyProvider;
-			_config = config;
-			_responseDictionary = new ConcurrentDictionary<string, ResponseCompletionSource>();
-			_consumerCompletionSources = new ConcurrentDictionary<IModel, ConsumerCompletionSource>();
-		}
+        public Requester(
+            IChannelFactory channelFactory,
+            IConsumerFactory consumerFactory,
+            IMessageSerializer serializer,
+            IMessageContextProvider<TMessageContext> contextProvider,
+            IErrorHandlingStrategy errorStrategy,
+            IBasicPropertiesProvider propertiesProvider,
+            ITopologyProvider topologyProvider,
+            RawRabbitConfiguration config)
+        {
+            _channelFactory = channelFactory;
+            _consumerFactory = consumerFactory;
+            _serializer = serializer;
+            _contextProvider = contextProvider;
+            _errorStrategy = errorStrategy;
+            _propertiesProvider = propertiesProvider;
+            _topologyProvider = topologyProvider;
+            _config = config;
+            _responseDictionary = new ConcurrentDictionary<string, ResponseCompletionSource>();
+            _consumerCompletionSources = new ConcurrentDictionary<IModel, ConsumerCompletionSource>();
+        }
 
-		public Task<TResponse> RequestAsync<TRequest, TResponse>(TRequest message, Guid globalMessageId, RequestConfiguration cfg)
-		{
-			if (!_topologyProvider.IsInitialized(cfg.Queue) || !_topologyProvider.IsInitialized(cfg.Exchange))
-			{
-				var queueTask = _topologyProvider.DeclareQueueAsync(cfg.Queue);
-				var exchangeTask = _topologyProvider.DeclareExchangeAsync(cfg.Exchange);
-				Task.WaitAll(queueTask, exchangeTask);
-			}
+        public Task<TResponse> RequestAsync<TRequest, TResponse>(TRequest message, Guid globalMessageId, RequestConfiguration cfg)
+        {
+            if (!_topologyProvider.IsInitialized(cfg.Queue) || !_topologyProvider.IsInitialized(cfg.Exchange))
+            {
+                var queueTask = _topologyProvider.DeclareQueueAsync(cfg.Queue);
+                var exchangeTask = _topologyProvider.DeclareExchangeAsync(cfg.Exchange);
+                Task.WaitAll(queueTask, exchangeTask);
+            }
 
-			if (_currentConsumer != null && _currentConsumer.ConsumerQueues.ContainsKey(cfg.Queue.FullQueueName) && _currentConsumer.IsCompletedAndOpen())
-			{
-				return SendRequestAsync<TRequest, TResponse>(message, globalMessageId, cfg, _currentConsumer.Consumer);
-			}
+            if (_currentConsumer != null && _currentConsumer.ConsumerQueues.ContainsKey(cfg.Queue.FullQueueName) && _currentConsumer.IsCompletedAndOpen())
+            {
+                return SendRequestAsync<TRequest, TResponse>(message, globalMessageId, cfg, _currentConsumer.Consumer);
+            }
 
-			return GetOrCreateConsumerAsync(cfg)
-				.ContinueWith(tConsumer => SendRequestAsync<TRequest, TResponse>(message, globalMessageId, cfg, tConsumer.Result))
-				.Unwrap();
-		}
+            return GetOrCreateConsumerAsync(cfg)
+                .ContinueWith(tConsumer => SendRequestAsync<TRequest, TResponse>(message, globalMessageId, cfg, tConsumer.Result))
+                .Unwrap();
+        }
 
-		private Task<TResponse> SendRequestAsync<TRequest, TResponse>(TRequest message, Guid globalMessageId, RequestConfiguration cfg, IRawConsumer consumer)
-		{
-			var correlationId = Guid.NewGuid().ToString();
-			var responseSource = new ResponseCompletionSource
-			{
-				RequestTimer = new Timer(state =>
-				{
-					ResponseCompletionSource rcs;
-					if (!_responseDictionary.TryRemove(correlationId, out rcs))
-					{
-						_logger.LogWarning($"Unable to find request timer for {correlationId}.");
-						return;
-					}
-					rcs.RequestTimer?.Dispose();
-					rcs.TrySetException(
-						new TimeoutException($"The request '{correlationId}' timed out after {_config.RequestTimeout.ToString("g")}."));
-				}, null, _config.RequestTimeout, new TimeSpan(-1))
-			};
+        private Task<TResponse> SendRequestAsync<TRequest, TResponse>(TRequest message, Guid globalMessageId, RequestConfiguration cfg, IRawConsumer consumer)
+        {
+            var correlationId = Guid.NewGuid().ToString();
+            var responseSource = new ResponseCompletionSource
+            {
+                RequestTimer = new Timer(state =>
+                {
+                    ResponseCompletionSource rcs;
+                    if (!_responseDictionary.TryRemove(correlationId, out rcs))
+                    {
+                        _logger.LogWarning($"Unable to find request timer for {correlationId}.");
+                        return;
+                    }
+                    rcs.RequestTimer?.Dispose();
+                    rcs.TrySetException(
+                        new TimeoutException($"The request '{correlationId}' timed out after {_config.RequestTimeout.ToString("g")}."));
+                }, null, _config.RequestTimeout, new TimeSpan(-1))
+            };
 
-			_responseDictionary.TryAdd(correlationId, responseSource);
+            _responseDictionary.TryAdd(correlationId, responseSource);
 
-			consumer.Model.BasicPublish(
-				exchange: cfg.Exchange.ExchangeName,
-				routingKey: _config.RouteWithGlobalId ? $"{cfg.RoutingKey}.{globalMessageId}" : cfg.RoutingKey,
-				basicProperties: _propertiesProvider.GetProperties<TResponse>(p =>
-					{
-						p.ReplyTo = cfg.ReplyQueue.QueueName;
-						p.CorrelationId = correlationId;
-						p.Expiration = _config.RequestTimeout.TotalMilliseconds.ToString();
-						p.Headers.Add(PropertyHeaders.Context, _contextProvider.GetMessageContext(ref globalMessageId));
-					}),
-				body: _serializer.Serialize(message)
-			);
-			return responseSource.Task.ContinueWith(tResponse =>
-			{
-				if (tResponse.IsFaulted)
-				{
-					throw tResponse.Exception?.InnerException ?? new Exception("Failed to recieve response");
-				}
-				return (TResponse)tResponse.Result;
-			});
-		}
+            consumer.Model.BasicPublish(
+                exchange: cfg.Exchange.ExchangeName,
+                routingKey: _config.RouteWithGlobalId ? $"{cfg.RoutingKey}.{globalMessageId}" : cfg.RoutingKey,
+                basicProperties: _propertiesProvider.GetProperties<TResponse>(p =>
+                    {
+                        p.ReplyTo = cfg.ReplyQueue.QueueName;
+                        p.CorrelationId = correlationId;
+                        p.Expiration = _config.RequestTimeout.TotalMilliseconds.ToString();
+                        p.Headers.Add(PropertyHeaders.Context, _contextProvider.GetMessageContext(ref globalMessageId));
+                    }),
+                body: _serializer.Serialize(message)
+            );
+            return responseSource.Task.ContinueWith(tResponse =>
+            {
+                if (tResponse.IsFaulted)
+                {
+                    throw tResponse.Exception?.InnerException ?? new Exception("Failed to recieve response");
+                }
+                return (TResponse)tResponse.Result;
+            });
+        }
 
-		private Task<IRawConsumer> GetOrCreateConsumerAsync(IConsumerConfiguration cfg)
-		{
-			return _channelFactory
-				.GetChannelAsync()
-				.ContinueWith(tChannel =>
-					{
-						var consumerCs = new ConsumerCompletionSource();
-						if (_consumerCompletionSources.TryAdd(tChannel.Result, consumerCs))
-						{
-							var newConsumer = _consumerFactory.CreateConsumer(cfg, tChannel.Result);
-							WireUpConsumer(newConsumer, cfg);
-							consumerCs.ConsumerQueues.TryAdd(
-								key: cfg.Queue.FullQueueName,
-								value: newConsumer.Model.BasicConsume(cfg.Queue.FullQueueName, cfg.NoAck, newConsumer)
-							);
-							_currentConsumer = consumerCs;
-							_logger.LogInformation($"Created consumer on channel '{tChannel.Result.ChannelNumber}' that consumes messages from '{cfg.Queue.FullQueueName}'.");
-							consumerCs.TrySetResult(newConsumer);
-							return consumerCs.Task;
-						}
-						_logger.LogDebug($"Consumer for channel '{tChannel.Result.ChannelNumber}' exists. Using it.");
-						consumerCs = _consumerCompletionSources[tChannel.Result];
-						if (consumerCs.ConsumerQueues.ContainsKey(cfg.Queue.FullQueueName))
-						{
-							return consumerCs.Task;
-						}
-						return consumerCs.Task.ContinueWith(t =>
-						{
-							lock (consumerCs.Consumer)
-							{
-								if (consumerCs.ConsumerQueues.ContainsKey(cfg.Queue.FullQueueName))
-								{
-									return t.Result;
-								}
-								consumerCs.ConsumerQueues.TryAdd(
-									key: cfg.Queue.FullQueueName,
-									value: consumerCs.Consumer.Model.BasicConsume(cfg.Queue.FullQueueName, cfg.NoAck, consumerCs.Consumer)
-								);
-								_logger.LogDebug($"Existign consumer for channel '{tChannel.Result.ChannelNumber}' consumes '{cfg.Queue.FullQueueName}'.");
-								return t.Result;
-							}
-						});
-					})
-				.Unwrap();
-		}
+        private Task<IRawConsumer> GetOrCreateConsumerAsync(IConsumerConfiguration cfg)
+        {
+            return _channelFactory
+                .GetChannelAsync()
+                .ContinueWith(tChannel =>
+                    {
+                        var consumerCs = new ConsumerCompletionSource();
+                        if (_consumerCompletionSources.TryAdd(tChannel.Result, consumerCs))
+                        {
+                            var newConsumer = _consumerFactory.CreateConsumer(cfg, tChannel.Result);
+                            WireUpConsumer(newConsumer, cfg);
+                            consumerCs.ConsumerQueues.TryAdd(
+                                key: cfg.Queue.FullQueueName,
+                                value: newConsumer.Model.BasicConsume(cfg.Queue.FullQueueName, cfg.NoAck, newConsumer)
+                            );
+                            _currentConsumer = consumerCs;
+                            _logger.LogInformation($"Created consumer on channel '{tChannel.Result.ChannelNumber}' that consumes messages from '{cfg.Queue.FullQueueName}'.");
+                            consumerCs.TrySetResult(newConsumer);
+                            return consumerCs.Task;
+                        }
+                        _logger.LogDebug($"Consumer for channel '{tChannel.Result.ChannelNumber}' exists. Using it.");
+                        consumerCs = _consumerCompletionSources[tChannel.Result];
+                        if (consumerCs.ConsumerQueues.ContainsKey(cfg.Queue.FullQueueName))
+                        {
+                            return consumerCs.Task;
+                        }
+                        return consumerCs.Task.ContinueWith(t =>
+                        {
+                            lock (consumerCs.Consumer)
+                            {
+                                if (consumerCs.ConsumerQueues.ContainsKey(cfg.Queue.FullQueueName))
+                                {
+                                    return t.Result;
+                                }
+                                consumerCs.ConsumerQueues.TryAdd(
+                                    key: cfg.Queue.FullQueueName,
+                                    value: consumerCs.Consumer.Model.BasicConsume(cfg.Queue.FullQueueName, cfg.NoAck, consumerCs.Consumer)
+                                );
+                                _logger.LogDebug($"Existign consumer for channel '{tChannel.Result.ChannelNumber}' consumes '{cfg.Queue.FullQueueName}'.");
+                                return t.Result;
+                            }
+                        });
+                    })
+                .Unwrap();
+        }
 
-		private void WireUpConsumer(IRawConsumer consumer, IConsumerConfiguration cfg)
-		{
-			consumer.OnMessageAsync = (o, args) =>
-			{
-				ResponseCompletionSource responseTcs = null;
-				return _errorStrategy.ExecuteAsync(() =>
-				{
-					if (_responseDictionary.TryRemove(args.BasicProperties.CorrelationId, out responseTcs))
-					{
-						_logger.LogDebug($"Recived response with correlationId {args.BasicProperties.CorrelationId}.");
-						responseTcs.RequestTimer.Dispose();
+        private void WireUpConsumer(IRawConsumer consumer, IConsumerConfiguration cfg)
+        {
+            consumer.OnMessageAsync = (o, args) =>
+            {
+                ResponseCompletionSource responseTcs = null;
+                return _errorStrategy.ExecuteAsync(() =>
+                {
+                    if (_responseDictionary.TryRemove(args.BasicProperties.CorrelationId, out responseTcs))
+                    {
+                        _logger.LogDebug($"Recived response with correlationId {args.BasicProperties.CorrelationId}.");
+                        responseTcs.RequestTimer.Dispose();
 
-						_errorStrategy.OnResponseRecievedAsync(args, responseTcs);
-						if (responseTcs.Task.IsFaulted)
-						{
-							return _completed;
-						}
-						var response = _serializer.Deserialize(args);
-						responseTcs.TrySetResult(response);
-						return _completed;
-					}
-					_logger.LogWarning($"Unable to find callback for {args.BasicProperties.CorrelationId}.");
-					return _completed;
-				}, exception => _errorStrategy.OnResponseRecievedException(consumer, cfg, args, responseTcs, exception));
-			};
-		}
+                        _errorStrategy.OnResponseRecievedAsync(args, responseTcs);
+                        if (responseTcs.Task.IsFaulted)
+                        {
+                            return _completed;
+                        }
+                        var response = _serializer.Deserialize(args);
+                        responseTcs.TrySetResult(response);
+                        return _completed;
+                    }
+                    _logger.LogWarning($"Unable to find callback for {args.BasicProperties.CorrelationId}.");
+                    return _completed;
+                }, exception => _errorStrategy.OnResponseRecievedException(consumer, cfg, args, responseTcs, exception));
+            };
+        }
 
-		private class ResponseCompletionSource : TaskCompletionSource<object>
-		{
-			public Timer RequestTimer { get; set; }
-		}
+        private class ResponseCompletionSource : TaskCompletionSource<object>
+        {
+            public Timer RequestTimer { get; set; }
+        }
 
-		private class ConsumerCompletionSource : TaskCompletionSource<IRawConsumer>
-		{
-			public ConcurrentDictionary<string, string> ConsumerQueues { get; }
-			public IRawConsumer Consumer => Task.IsCompleted ? Task.Result : null;
+        private class ConsumerCompletionSource : TaskCompletionSource<IRawConsumer>
+        {
+            public ConcurrentDictionary<string, string> ConsumerQueues { get; }
+            public IRawConsumer Consumer => Task.IsCompleted ? Task.Result : null;
 
-			public ConsumerCompletionSource()
-			{
-				ConsumerQueues = new ConcurrentDictionary<string, string>();
-			}
+            public ConsumerCompletionSource()
+            {
+                ConsumerQueues = new ConcurrentDictionary<string, string>();
+            }
 
-			public bool IsCompletedAndOpen()
-			{
-				return Task.IsCompleted && Task.Result.Model.IsOpen;
-			}
-		}
+            public bool IsCompletedAndOpen()
+            {
+                return Task.IsCompleted && Task.Result.Model.IsOpen;
+            }
+        }
 
-		public async Task ShutdownAsync(TimeSpan? graceful = null)
-		{
-			_logger.LogDebug("Shutting down Requester.");
-			foreach (var ccS in _consumerCompletionSources)
-			{
-				if (!ccS.Value.IsCompletedAndOpen())
-				{
-					continue;
-				}
-				ccS.Value.Consumer.Disconnect();
-			}
-			if (!_responseDictionary.IsEmpty)
-			{
-				await Task.Delay(_config.RequestTimeout);
-			}
-			(_channelFactory as IDisposable)?.Dispose();
-		}
-	}
+        public async Task ShutdownAsync(TimeSpan? graceful = null)
+        {
+            _logger.LogDebug("Shutting down Requester.");
+            foreach (var ccS in _consumerCompletionSources)
+            {
+                if (!ccS.Value.IsCompletedAndOpen())
+                {
+                    continue;
+                }
+                ccS.Value.Consumer.Disconnect();
+            }
+            if (!_responseDictionary.IsEmpty)
+            {
+                await Task.Delay(_config.RequestTimeout);
+            }
+            (_channelFactory as IDisposable)?.Dispose();
+        }
+    }
 }

--- a/src/RawRabbit/Operations/Responder.cs
+++ b/src/RawRabbit/Operations/Responder.cs
@@ -17,105 +17,105 @@ using RawRabbit.Operations.Abstraction;
 
 namespace RawRabbit.Operations
 {
-	public class Responder<TMessageContext> : IShutdown, IResponder<TMessageContext> where TMessageContext : IMessageContext
-	{
-		private readonly IChannelFactory _channelFactory;
-		private readonly ITopologyProvider _topologyProvider;
-		private readonly IConsumerFactory _consumerFactory;
-		private readonly IMessageSerializer _serializer;
-		private readonly IMessageContextProvider<TMessageContext> _contextProvider;
-		private readonly IContextEnhancer _contextEnhancer;
-		private readonly IBasicPropertiesProvider _propertyProvider;
-		private readonly IErrorHandlingStrategy _errorHandling;
-		private readonly RawRabbitConfiguration _config;
-		private readonly ILogger _logger = LogManager.GetLogger<Responder<TMessageContext>>();
-		private readonly List<ISubscription> _subscriptions;
+    public class Responder<TMessageContext> : IShutdown, IResponder<TMessageContext> where TMessageContext : IMessageContext
+    {
+        private readonly IChannelFactory _channelFactory;
+        private readonly ITopologyProvider _topologyProvider;
+        private readonly IConsumerFactory _consumerFactory;
+        private readonly IMessageSerializer _serializer;
+        private readonly IMessageContextProvider<TMessageContext> _contextProvider;
+        private readonly IContextEnhancer _contextEnhancer;
+        private readonly IBasicPropertiesProvider _propertyProvider;
+        private readonly IErrorHandlingStrategy _errorHandling;
+        private readonly RawRabbitConfiguration _config;
+        private readonly ILogger _logger = LogManager.GetLogger<Responder<TMessageContext>>();
+        private readonly List<ISubscription> _subscriptions;
 
-		public Responder(
-			IChannelFactory channelFactory,
-			ITopologyProvider topologyProvider,
-			IConsumerFactory consumerFactory,
-			IMessageSerializer serializer,
-			IMessageContextProvider<TMessageContext> contextProvider,
-			IContextEnhancer contextEnhancer,
-			IBasicPropertiesProvider propertyProvider,
-			IErrorHandlingStrategy errorHandling,
-			RawRabbitConfiguration config)
-		{
-			_channelFactory = channelFactory;
-			_topologyProvider = topologyProvider;
-			_consumerFactory = consumerFactory;
-			_serializer = serializer;
-			_contextProvider = contextProvider;
-			_contextEnhancer = contextEnhancer;
-			_propertyProvider = propertyProvider;
-			_errorHandling = errorHandling;
-			_config = config;
-			_subscriptions = new List<ISubscription>();
-		}
+        public Responder(
+            IChannelFactory channelFactory,
+            ITopologyProvider topologyProvider,
+            IConsumerFactory consumerFactory,
+            IMessageSerializer serializer,
+            IMessageContextProvider<TMessageContext> contextProvider,
+            IContextEnhancer contextEnhancer,
+            IBasicPropertiesProvider propertyProvider,
+            IErrorHandlingStrategy errorHandling,
+            RawRabbitConfiguration config)
+        {
+            _channelFactory = channelFactory;
+            _topologyProvider = topologyProvider;
+            _consumerFactory = consumerFactory;
+            _serializer = serializer;
+            _contextProvider = contextProvider;
+            _contextEnhancer = contextEnhancer;
+            _propertyProvider = propertyProvider;
+            _errorHandling = errorHandling;
+            _config = config;
+            _subscriptions = new List<ISubscription>();
+        }
 
-		public ISubscription RespondAsync<TRequest, TResponse>(Func<TRequest, TMessageContext, Task<TResponse>> onMessage, ResponderConfiguration cfg)
-		{
-			var routingKey = _config.RouteWithGlobalId ? $"{cfg.RoutingKey}.#" : cfg.RoutingKey;
-			var topologyTask = _topologyProvider.BindQueueAsync(cfg.Queue, cfg.Exchange, routingKey);
-			var channelTask = _channelFactory.CreateChannelAsync();
+        public ISubscription RespondAsync<TRequest, TResponse>(Func<TRequest, TMessageContext, Task<TResponse>> onMessage, ResponderConfiguration cfg)
+        {
+            var routingKey = _config.RouteWithGlobalId ? $"{cfg.RoutingKey}.#" : cfg.RoutingKey;
+            var topologyTask = _topologyProvider.BindQueueAsync(cfg.Queue, cfg.Exchange, routingKey);
+            var channelTask = _channelFactory.CreateChannelAsync();
 
-			var respondTask = Task.WhenAll(topologyTask, channelTask)
-				.ContinueWith(t =>
-				{
-					if (topologyTask.IsFaulted)
-					{
-						throw topologyTask.Exception ?? new Exception("Topology Task Fauled");
-					}
-					var consumer = _consumerFactory.CreateConsumer(cfg, channelTask.Result);
-					consumer.OnMessageAsync = (o, args) => _errorHandling.ExecuteAsync(() =>
-					{
-						var body = _serializer.Deserialize<TRequest>(args.Body);
-						var context = _contextProvider.ExtractContext(args.BasicProperties.Headers[PropertyHeaders.Context]);
-						_contextEnhancer.WireUpContextFeatures(context, consumer, args);
+            var respondTask = Task.WhenAll(topologyTask, channelTask)
+                .ContinueWith(t =>
+                {
+                    if (topologyTask.IsFaulted)
+                    {
+                        throw topologyTask.Exception ?? new Exception("Topology Task Fauled");
+                    }
+                    var consumer = _consumerFactory.CreateConsumer(cfg, channelTask.Result);
+                    consumer.OnMessageAsync = (o, args) => _errorHandling.ExecuteAsync(() =>
+                    {
+                        var body = _serializer.Deserialize<TRequest>(args.Body);
+                        var context = _contextProvider.ExtractContext(args.BasicProperties.Headers[PropertyHeaders.Context]);
+                        _contextEnhancer.WireUpContextFeatures(context, consumer, args);
 
-						return onMessage(body, context)
-							.ContinueWith(tResponse =>
-							{
-								if (tResponse.IsFaulted)
-								{
-									throw tResponse.Exception ?? new Exception();
-								}
-								if (consumer.AcknowledgedTags.Contains(args.DeliveryTag))
-								{
-									return;
-								}
-								if (tResponse.Result == null)
-								{
-									return;
-								}
-								_logger.LogDebug($"Sending response to request with correlation '{args.BasicProperties.CorrelationId}'.");
-								consumer.Model.BasicPublish(
-									exchange: string.Empty,
-									routingKey: args.BasicProperties.ReplyTo,
-									basicProperties: _propertyProvider.GetProperties<TResponse>(p => p.CorrelationId = args.BasicProperties.CorrelationId),
-									body: _serializer.Serialize(tResponse.Result)
-								);
-							});
-					}, exception => _errorHandling.OnResponseHandlerExceptionAsync(consumer, cfg, args, exception)); 
-					consumer.Model.BasicConsume(cfg.Queue.QueueName, cfg.NoAck, consumer);
-					return new Subscription(consumer, cfg.Queue.QueueName);
-				});
-			Task.WaitAll(respondTask);
-			_subscriptions.Add(respondTask.Result);
-			return respondTask.Result;
-		}
+                        return onMessage(body, context)
+                            .ContinueWith(tResponse =>
+                            {
+                                if (tResponse.IsFaulted)
+                                {
+                                    throw tResponse.Exception ?? new Exception();
+                                }
+                                if (consumer.AcknowledgedTags.Contains(args.DeliveryTag))
+                                {
+                                    return;
+                                }
+                                if (tResponse.Result == null)
+                                {
+                                    return;
+                                }
+                                _logger.LogDebug($"Sending response to request with correlation '{args.BasicProperties.CorrelationId}'.");
+                                consumer.Model.BasicPublish(
+                                    exchange: string.Empty,
+                                    routingKey: args.BasicProperties.ReplyTo,
+                                    basicProperties: _propertyProvider.GetProperties<TResponse>(p => p.CorrelationId = args.BasicProperties.CorrelationId),
+                                    body: _serializer.Serialize(tResponse.Result)
+                                );
+                            });
+                    }, exception => _errorHandling.OnResponseHandlerExceptionAsync(consumer, cfg, args, exception)); 
+                    consumer.Model.BasicConsume(cfg.Queue.QueueName, cfg.NoAck, consumer);
+                    return new Subscription(consumer, cfg.Queue.QueueName);
+                });
+            Task.WaitAll(respondTask);
+            _subscriptions.Add(respondTask.Result);
+            return respondTask.Result;
+        }
 
-		public async Task ShutdownAsync(TimeSpan? graceful = null)
-		{
-			_logger.LogDebug("Shutting down Responder.");
-			foreach (var subscription in _subscriptions)
-			{
-				subscription.Dispose();
-			}
-			graceful = graceful ?? _config.GracefulShutdown;
-			await Task.Delay(graceful.Value);
-			(_consumerFactory as IDisposable)?.Dispose();
-		}
-	}
+        public async Task ShutdownAsync(TimeSpan? graceful = null)
+        {
+            _logger.LogDebug("Shutting down Responder.");
+            foreach (var subscription in _subscriptions)
+            {
+                subscription.Dispose();
+            }
+            graceful = graceful ?? _config.GracefulShutdown;
+            await Task.Delay(graceful.Value);
+            (_consumerFactory as IDisposable)?.Dispose();
+        }
+    }
 }

--- a/src/RawRabbit/Operations/Subscriber.cs
+++ b/src/RawRabbit/Operations/Subscriber.cs
@@ -18,86 +18,86 @@ using RawRabbit.Serialization;
 
 namespace RawRabbit.Operations
 {
-	public class Subscriber<TMessageContext> : IShutdown, ISubscriber<TMessageContext> where TMessageContext : IMessageContext
-	{
-		private readonly IChannelFactory _channelFactory;
-		private readonly IConsumerFactory _consumerFactory;
-		private readonly ITopologyProvider _topologyProvider;
-		private readonly IMessageSerializer _serializer;
-		private readonly IMessageContextProvider<TMessageContext> _contextProvider;
-		private readonly IContextEnhancer _contextEnhancer;
-		private readonly IErrorHandlingStrategy _errorHandling;
-		private readonly RawRabbitConfiguration _config;
-		private readonly List<ISubscription> _subscriptions;
-		private readonly ILogger _logger = LogManager.GetLogger<Subscriber<TMessageContext>>();
+    public class Subscriber<TMessageContext> : IShutdown, ISubscriber<TMessageContext> where TMessageContext : IMessageContext
+    {
+        private readonly IChannelFactory _channelFactory;
+        private readonly IConsumerFactory _consumerFactory;
+        private readonly ITopologyProvider _topologyProvider;
+        private readonly IMessageSerializer _serializer;
+        private readonly IMessageContextProvider<TMessageContext> _contextProvider;
+        private readonly IContextEnhancer _contextEnhancer;
+        private readonly IErrorHandlingStrategy _errorHandling;
+        private readonly RawRabbitConfiguration _config;
+        private readonly List<ISubscription> _subscriptions;
+        private readonly ILogger _logger = LogManager.GetLogger<Subscriber<TMessageContext>>();
 
-		public Subscriber(
-			IChannelFactory channelFactory,
-			IConsumerFactory consumerFactory,
-			ITopologyProvider topologyProvider,
-			IMessageSerializer serializer,
-			IMessageContextProvider<TMessageContext> contextProvider,
-			IContextEnhancer contextEnhancer,
-			IErrorHandlingStrategy errorHandling,
-			RawRabbitConfiguration config)
-		{
-			_channelFactory = channelFactory;
-			_consumerFactory = consumerFactory;
-			_topologyProvider = topologyProvider;
-			_serializer = serializer;
-			_contextProvider = contextProvider;
-			_contextEnhancer = contextEnhancer;
-			_errorHandling = errorHandling;
-			_config = config;
-			_subscriptions = new List<ISubscription>();
-		}
+        public Subscriber(
+            IChannelFactory channelFactory,
+            IConsumerFactory consumerFactory,
+            ITopologyProvider topologyProvider,
+            IMessageSerializer serializer,
+            IMessageContextProvider<TMessageContext> contextProvider,
+            IContextEnhancer contextEnhancer,
+            IErrorHandlingStrategy errorHandling,
+            RawRabbitConfiguration config)
+        {
+            _channelFactory = channelFactory;
+            _consumerFactory = consumerFactory;
+            _topologyProvider = topologyProvider;
+            _serializer = serializer;
+            _contextProvider = contextProvider;
+            _contextEnhancer = contextEnhancer;
+            _errorHandling = errorHandling;
+            _config = config;
+            _subscriptions = new List<ISubscription>();
+        }
 
-		public ISubscription SubscribeAsync<T>(Func<T, TMessageContext, Task> subscribeMethod, SubscriptionConfiguration config)
-		{
-			var routingKey = _config.RouteWithGlobalId
-				? $"{config.RoutingKey}.#"
-				: config.RoutingKey;
+        public ISubscription SubscribeAsync<T>(Func<T, TMessageContext, Task> subscribeMethod, SubscriptionConfiguration config)
+        {
+            var routingKey = _config.RouteWithGlobalId
+                ? $"{config.RoutingKey}.#"
+                : config.RoutingKey;
 
-			var topologyTask = _topologyProvider.BindQueueAsync(config.Queue, config.Exchange, routingKey);
-			var channelTask = _channelFactory.CreateChannelAsync();
+            var topologyTask = _topologyProvider.BindQueueAsync(config.Queue, config.Exchange, routingKey);
+            var channelTask = _channelFactory.CreateChannelAsync();
 
-			var subscriberTask = Task
-				.WhenAll(topologyTask, channelTask)
-				.ContinueWith(t =>
-				{
-					if (topologyTask.IsFaulted)
-					{
-						throw topologyTask.Exception ?? new Exception("Topology Task Faulted");
-					}
-					var consumer = _consumerFactory.CreateConsumer(config, channelTask.Result);
-					consumer.OnMessageAsync = (o, args) => _errorHandling.ExecuteAsync(() =>
-					{
-						var body = _serializer.Deserialize<T>(args.Body);
-						var context = _contextProvider.ExtractContext(args.BasicProperties?.Headers?.GetOrDefault(PropertyHeaders.Context));
-						_contextEnhancer.WireUpContextFeatures(context, consumer, args);
-						return subscribeMethod(body, context);
-					}, exception => _errorHandling.OnSubscriberExceptionAsync(consumer, config, args, exception));
-					consumer.Model.BasicConsume(config.Queue.FullQueueName, config.NoAck, consumer);
-					_logger.LogDebug($"Setting up a consumer on channel '{channelTask.Result.ChannelNumber}' for queue {config.Queue.QueueName} with NoAck set to {config.NoAck}.");
-					return new Subscription(consumer, config.Queue.FullQueueName);
-				});
-			Task.WaitAll(subscriberTask);
-			_subscriptions.Add(subscriberTask.Result);
-			return subscriberTask.Result;
-		}
+            var subscriberTask = Task
+                .WhenAll(topologyTask, channelTask)
+                .ContinueWith(t =>
+                {
+                    if (topologyTask.IsFaulted)
+                    {
+                        throw topologyTask.Exception ?? new Exception("Topology Task Faulted");
+                    }
+                    var consumer = _consumerFactory.CreateConsumer(config, channelTask.Result);
+                    consumer.OnMessageAsync = (o, args) => _errorHandling.ExecuteAsync(() =>
+                    {
+                        var body = _serializer.Deserialize<T>(args.Body);
+                        var context = _contextProvider.ExtractContext(args.BasicProperties?.Headers?.GetOrDefault(PropertyHeaders.Context));
+                        _contextEnhancer.WireUpContextFeatures(context, consumer, args);
+                        return subscribeMethod(body, context);
+                    }, exception => _errorHandling.OnSubscriberExceptionAsync(consumer, config, args, exception));
+                    consumer.Model.BasicConsume(config.Queue.FullQueueName, config.NoAck, consumer);
+                    _logger.LogDebug($"Setting up a consumer on channel '{channelTask.Result.ChannelNumber}' for queue {config.Queue.QueueName} with NoAck set to {config.NoAck}.");
+                    return new Subscription(consumer, config.Queue.FullQueueName);
+                });
+            Task.WaitAll(subscriberTask);
+            _subscriptions.Add(subscriberTask.Result);
+            return subscriberTask.Result;
+        }
 
-		public async Task ShutdownAsync(TimeSpan? graceful = null)
-		{
-			_logger.LogDebug("Shutting down Subscriber.");
-			foreach (var subscription in _subscriptions.Where(s => s.Active))
-			{
-				subscription.Dispose();
-			}
-			graceful = graceful ?? _config.GracefulShutdown;
-			await Task.Delay(graceful.Value);
-			(_consumerFactory as IDisposable)?.Dispose();
-			(_channelFactory as IDisposable)?.Dispose();
-			(_topologyProvider as IDisposable)?.Dispose();
-		}
-	}
+        public async Task ShutdownAsync(TimeSpan? graceful = null)
+        {
+            _logger.LogDebug("Shutting down Subscriber.");
+            foreach (var subscription in _subscriptions.Where(s => s.Active))
+            {
+                subscription.Dispose();
+            }
+            graceful = graceful ?? _config.GracefulShutdown;
+            await Task.Delay(graceful.Value);
+            (_consumerFactory as IDisposable)?.Dispose();
+            (_channelFactory as IDisposable)?.Dispose();
+            (_topologyProvider as IDisposable)?.Dispose();
+        }
+    }
 }

--- a/src/RawRabbit/Serialization/IMessageSerializer.cs
+++ b/src/RawRabbit/Serialization/IMessageSerializer.cs
@@ -3,11 +3,11 @@ using RabbitMQ.Client.Events;
 
 namespace RawRabbit.Serialization
 {
-	public interface IMessageSerializer
-	{
-		byte[] Serialize<T>(T obj);
-		T Deserialize<T>(byte[] bytes);
-		object Deserialize(byte[] bytes, Type messageType);
-		object Deserialize(BasicDeliverEventArgs args);
-	}
+    public interface IMessageSerializer
+    {
+        byte[] Serialize<T>(T obj);
+        T Deserialize<T>(byte[] bytes);
+        object Deserialize(byte[] bytes, Type messageType);
+        object Deserialize(BasicDeliverEventArgs args);
+    }
 }

--- a/src/RawRabbit/Serialization/JsonMessageSerializer.cs
+++ b/src/RawRabbit/Serialization/JsonMessageSerializer.cs
@@ -7,64 +7,64 @@ using RawRabbit.Common;
 
 namespace RawRabbit.Serialization
 {
-	public class JsonMessageSerializer : IMessageSerializer
-	{
-		private readonly JsonSerializer _serializer;
+    public class JsonMessageSerializer : IMessageSerializer
+    {
+        private readonly JsonSerializer _serializer;
 
-		public JsonMessageSerializer(JsonSerializer serializer, Action<JsonSerializer> config = null)
-		{
-			_serializer = serializer;
-			config?.Invoke(_serializer);
-		}
+        public JsonMessageSerializer(JsonSerializer serializer, Action<JsonSerializer> config = null)
+        {
+            _serializer = serializer;
+            config?.Invoke(_serializer);
+        }
 
-		public byte[] Serialize<T>(T obj)
-		{
-			if (obj == null)
-			{
-				return Encoding.UTF8.GetBytes(string.Empty);
-			}
-			string msgStr;
-			using (var sw = new StringWriter())
-			{
-				_serializer.Serialize(sw, obj);
-				msgStr = sw.GetStringBuilder().ToString();
-			}
-			var msgBytes = Encoding.UTF8.GetBytes(msgStr);
-			return msgBytes;
-		}
+        public byte[] Serialize<T>(T obj)
+        {
+            if (obj == null)
+            {
+                return Encoding.UTF8.GetBytes(string.Empty);
+            }
+            string msgStr;
+            using (var sw = new StringWriter())
+            {
+                _serializer.Serialize(sw, obj);
+                msgStr = sw.GetStringBuilder().ToString();
+            }
+            var msgBytes = Encoding.UTF8.GetBytes(msgStr);
+            return msgBytes;
+        }
 
-		public object Deserialize(BasicDeliverEventArgs args)
-		{
-			object typeBytes;
-			if (args.BasicProperties.Headers.TryGetValue(PropertyHeaders.MessageType, out typeBytes))
-			{
-				var typeName = Encoding.UTF8.GetString(typeBytes as byte[] ?? new byte[0]);
-				var type = Type.GetType(typeName, false);
-				return Deserialize(args.Body, type);
-			}
-			else
-			{
-				var typeName = args.BasicProperties.Type;
-				var type = Type.GetType(typeName, false);
-				return Deserialize(args.Body, type);
-			}
-		}
+        public object Deserialize(BasicDeliverEventArgs args)
+        {
+            object typeBytes;
+            if (args.BasicProperties.Headers.TryGetValue(PropertyHeaders.MessageType, out typeBytes))
+            {
+                var typeName = Encoding.UTF8.GetString(typeBytes as byte[] ?? new byte[0]);
+                var type = Type.GetType(typeName, false);
+                return Deserialize(args.Body, type);
+            }
+            else
+            {
+                var typeName = args.BasicProperties.Type;
+                var type = Type.GetType(typeName, false);
+                return Deserialize(args.Body, type);
+            }
+        }
 
-		public T Deserialize<T>(byte[] bytes)
-		{
-			var obj = (T)Deserialize(bytes, typeof(T));
-			return obj;
-		}
+        public T Deserialize<T>(byte[] bytes)
+        {
+            var obj = (T)Deserialize(bytes, typeof(T));
+            return obj;
+        }
 
-		public object Deserialize(byte[] bytes, Type messageType)
-		{
-			object obj;
-			var msgStr = Encoding.UTF8.GetString(bytes);
-			using (var jsonReader = new JsonTextReader(new StringReader(msgStr)))
-			{
-				obj = _serializer.Deserialize(jsonReader, messageType);
-			}
-			return obj;
-		}
-	}
+        public object Deserialize(byte[] bytes, Type messageType)
+        {
+            object obj;
+            var msgStr = Encoding.UTF8.GetString(bytes);
+            using (var jsonReader = new JsonTextReader(new StringReader(msgStr)))
+            {
+                obj = _serializer.Deserialize(jsonReader, messageType);
+            }
+            return obj;
+        }
+    }
 }

--- a/src/RawRabbit/project.json
+++ b/src/RawRabbit/project.json
@@ -1,24 +1,24 @@
 {
-	"title": "RawRabbit",
-	"version": "1.10.2-*",
-	"authors": [ "pardahlman", "enrique-avalon" ],
-	"description": "A modern framework for communication over RabbitMq.",
-	"packOptions": {
-		"iconUrl": "http://pardahlman.se/raw/icon.png",
-		"projectUrl": "https://github.com/pardahlman/RawRabbit",
-		"tags": [ "rabbitmq", "raw", "rawrabbit", "attributes" ],
-		"publishExclude": [ "**.xproj", "**.user", "**.vspscc" ]
-	},
+    "title": "RawRabbit",
+    "version": "1.10.2-*",
+    "authors": [ "pardahlman", "enrique-avalon" ],
+    "description": "A modern framework for communication over RabbitMq.",
+    "packOptions": {
+        "iconUrl": "http://pardahlman.se/raw/icon.png",
+        "projectUrl": "https://github.com/pardahlman/RawRabbit",
+        "tags": [ "rabbitmq", "raw", "rawrabbit", "attributes" ],
+        "publishExclude": [ "**.xproj", "**.user", "**.vspscc" ]
+    },
 
-	"dependencies": {
-			"RabbitMQ.Client": "4.1.0",
-		"Newtonsoft.Json": "9.0.1"
-	},
+    "dependencies": {
+            "RabbitMQ.Client": "4.1.0",
+        "Newtonsoft.Json": "9.0.1"
+    },
 
-	"frameworks": {
-		"netstandard1.5": {},
-			"net451": {
-				"define": [ "NET451" ]
-			}
-	}
+    "frameworks": {
+        "netstandard1.5": {},
+            "net451": {
+                "define": [ "NET451" ]
+            }
+    }
 }

--- a/test/RawRabbit.IntegrationTests/Attributes/TopologyAttributeTests.cs
+++ b/test/RawRabbit.IntegrationTests/Attributes/TopologyAttributeTests.cs
@@ -8,88 +8,88 @@ using Xunit;
 
 namespace RawRabbit.IntegrationTests.Attributes
 {
-	public class TopologyAttributeTests : IntegrationTestBase
-	{
-		[Fact]
-		public async Task Should_Work_For_Pub_Sub()
-		{
-			/* Setup */
-			using (var client = TestClientFactory.CreateNormal(ioc => ioc
-				.AddSingleton<IConfigurationEvaluator, AttributeConfigEvaluator>()
-				))
-			{
-				var tcs = new TaskCompletionSource<AttributedMessage>();
-				client.SubscribeAsync<AttributedMessage>((message, context) =>
-				{
-					tcs.TrySetResult(message);
-					return Task.FromResult(true);
-				});
+    public class TopologyAttributeTests : IntegrationTestBase
+    {
+        [Fact]
+        public async Task Should_Work_For_Pub_Sub()
+        {
+            /* Setup */
+            using (var client = TestClientFactory.CreateNormal(ioc => ioc
+                .AddSingleton<IConfigurationEvaluator, AttributeConfigEvaluator>()
+                ))
+            {
+                var tcs = new TaskCompletionSource<AttributedMessage>();
+                client.SubscribeAsync<AttributedMessage>((message, context) =>
+                {
+                    tcs.TrySetResult(message);
+                    return Task.FromResult(true);
+                });
 
-				/* Test */
-				await client.PublishAsync(new AttributedMessage());
-				await tcs.Task;
+                /* Test */
+                await client.PublishAsync(new AttributedMessage());
+                await tcs.Task;
 
-				/* Assert */
-				Assert.True(true, "Routing successful.");
-			}
-		}
+                /* Assert */
+                Assert.True(true, "Routing successful.");
+            }
+        }
 
-		[Fact]
-		public async Task Should_Work_For_Rpc()
-		{
-			/* Setup */
-			using (var client = TestClientFactory.CreateNormal(ioc => ioc.AddSingleton<IConfigurationEvaluator, AttributeConfigEvaluator>()))
-			{
-				client.RespondAsync<AttributedRequest, AttributedResponse>((message, context) =>
-					Task.FromResult(new AttributedResponse())
-				);
+        [Fact]
+        public async Task Should_Work_For_Rpc()
+        {
+            /* Setup */
+            using (var client = TestClientFactory.CreateNormal(ioc => ioc.AddSingleton<IConfigurationEvaluator, AttributeConfigEvaluator>()))
+            {
+                client.RespondAsync<AttributedRequest, AttributedResponse>((message, context) =>
+                    Task.FromResult(new AttributedResponse())
+                );
 
-				/* Test */
-				await client.RequestAsync<AttributedRequest, AttributedResponse>();
+                /* Test */
+                await client.RequestAsync<AttributedRequest, AttributedResponse>();
 
-				/* Assert */
-				Assert.True(true, "Routing successful.");
-			}
-		}
+                /* Assert */
+                Assert.True(true, "Routing successful.");
+            }
+        }
 
-		[Fact]
-		public async Task Should_Honor_Custom_Config()
-		{
-			/* Setup */
-			using (var client = TestClientFactory.CreateNormal(ioc => ioc
-				.AddSingleton<IConfigurationEvaluator, AttributeConfigEvaluator>()
-				))
-			{
-				var tcs = new TaskCompletionSource<AttributedMessage>();
-				client.SubscribeAsync<AttributedMessage>((message, context) =>
-				{
-					tcs.TrySetResult(message);
-					return Task.FromResult(true);
-				}, c => c
-					.WithRoutingKey("special")
-					.WithExchange(e => e.WithName("special")));
+        [Fact]
+        public async Task Should_Honor_Custom_Config()
+        {
+            /* Setup */
+            using (var client = TestClientFactory.CreateNormal(ioc => ioc
+                .AddSingleton<IConfigurationEvaluator, AttributeConfigEvaluator>()
+                ))
+            {
+                var tcs = new TaskCompletionSource<AttributedMessage>();
+                client.SubscribeAsync<AttributedMessage>((message, context) =>
+                {
+                    tcs.TrySetResult(message);
+                    return Task.FromResult(true);
+                }, c => c
+                    .WithRoutingKey("special")
+                    .WithExchange(e => e.WithName("special")));
 
-				/* Test */
-				await
-					client.PublishAsync(new AttributedMessage(),
-						configuration: c => c.WithRoutingKey("special").WithExchange(e => e.WithName("special")));
-				await tcs.Task;
+                /* Test */
+                await
+                    client.PublishAsync(new AttributedMessage(),
+                        configuration: c => c.WithRoutingKey("special").WithExchange(e => e.WithName("special")));
+                await tcs.Task;
 
-				/* Assert */
-				Assert.True(true, "Routing successful.");
-			}
-		}
+                /* Assert */
+                Assert.True(true, "Routing successful.");
+            }
+        }
 
-		[Queue(Name = "my_queue", MessageTtl = 300, DeadLeterExchange = "dlx", Durable = false)]
-		[Exchange(Name = "my_topic", Type = ExchangeType.Topic)]
-		[Routing(RoutingKey = "my_key", NoAck = true, PrefetchCount = 50)]
-		private class AttributedMessage { }
+        [Queue(Name = "my_queue", MessageTtl = 300, DeadLeterExchange = "dlx", Durable = false)]
+        [Exchange(Name = "my_topic", Type = ExchangeType.Topic)]
+        [Routing(RoutingKey = "my_key", NoAck = true, PrefetchCount = 50)]
+        private class AttributedMessage { }
 
-		[Queue(Name = "attributed_rpc", MessageTtl = 300, DeadLeterExchange = "dlx", Durable = false)]
-		[Exchange(Name = "my_topic", Type = ExchangeType.Topic)]
-		[Routing(RoutingKey = "my_key", NoAck = true, PrefetchCount = 50)]
-		private class AttributedRequest { }
+        [Queue(Name = "attributed_rpc", MessageTtl = 300, DeadLeterExchange = "dlx", Durable = false)]
+        [Exchange(Name = "my_topic", Type = ExchangeType.Topic)]
+        [Routing(RoutingKey = "my_key", NoAck = true, PrefetchCount = 50)]
+        private class AttributedRequest { }
 
-		private class AttributedResponse { }
-	}
+        private class AttributedResponse { }
+    }
 }

--- a/test/RawRabbit.IntegrationTests/Extensions/BulkGetTests.cs
+++ b/test/RawRabbit.IntegrationTests/Extensions/BulkGetTests.cs
@@ -11,70 +11,70 @@ using Xunit;
 
 namespace RawRabbit.IntegrationTests.Extensions
 {
-	public class BulkGetTests : IntegrationTestBase
-	{
-		private readonly string _firstBasicQueue;
-		private readonly string _secondBasicQueue;
-		private readonly string _firstSimpleQueue;
+    public class BulkGetTests : IntegrationTestBase
+    {
+        private readonly string _firstBasicQueue;
+        private readonly string _secondBasicQueue;
+        private readonly string _firstSimpleQueue;
 
-		public BulkGetTests()
-		{
-			var basicQueueBase = "basicmessage";
-			var simpleQueueBase = "simplemessage";
-			var firstSuffix = "first_subscriber";
-			var secondSuffix = "second_subscriber";
-			_firstBasicQueue = $"{basicQueueBase}_{firstSuffix}";
-			_secondBasicQueue = $"{basicQueueBase}_{secondSuffix}";
-			_firstSimpleQueue = $"{simpleQueueBase}_{firstSuffix}";
+        public BulkGetTests()
+        {
+            var basicQueueBase = "basicmessage";
+            var simpleQueueBase = "simplemessage";
+            var firstSuffix = "first_subscriber";
+            var secondSuffix = "second_subscriber";
+            _firstBasicQueue = $"{basicQueueBase}_{firstSuffix}";
+            _secondBasicQueue = $"{basicQueueBase}_{secondSuffix}";
+            _firstSimpleQueue = $"{simpleQueueBase}_{firstSuffix}";
 
-			using (var subscriber = TestClientFactory.CreateNormal())
-			{
-				subscriber.SubscribeAsync<BasicMessage>((message, context) => Task.FromResult(true), cfg => cfg.WithSubscriberId(firstSuffix).WithQueue(q => q.WithAutoDelete(false)));
-				subscriber.SubscribeAsync<BasicMessage>((message, context) => Task.FromResult(true), cfg => cfg.WithSubscriberId(secondSuffix).WithQueue(q => q.WithAutoDelete(false)));
-				subscriber.SubscribeAsync<SimpleMessage>((message, context) => Task.FromResult(true), cfg => cfg.WithSubscriberId(firstSuffix).WithQueue(q => q.WithAutoDelete(false)));
-			}
-		}
+            using (var subscriber = TestClientFactory.CreateNormal())
+            {
+                subscriber.SubscribeAsync<BasicMessage>((message, context) => Task.FromResult(true), cfg => cfg.WithSubscriberId(firstSuffix).WithQueue(q => q.WithAutoDelete(false)));
+                subscriber.SubscribeAsync<BasicMessage>((message, context) => Task.FromResult(true), cfg => cfg.WithSubscriberId(secondSuffix).WithQueue(q => q.WithAutoDelete(false)));
+                subscriber.SubscribeAsync<SimpleMessage>((message, context) => Task.FromResult(true), cfg => cfg.WithSubscriberId(firstSuffix).WithQueue(q => q.WithAutoDelete(false)));
+            }
+        }
 
-		public override void Dispose()
-		{
-			TestChannel.QueueDelete(_firstBasicQueue);
-			TestChannel.QueueDelete(_firstSimpleQueue);
-			TestChannel.QueueDelete(_secondBasicQueue);
-			base.Dispose();
-		}
+        public override void Dispose()
+        {
+            TestChannel.QueueDelete(_firstBasicQueue);
+            TestChannel.QueueDelete(_firstSimpleQueue);
+            TestChannel.QueueDelete(_secondBasicQueue);
+            base.Dispose();
+        }
 
-		[Fact]
-		public async Task Should_Be_Able_To_Bulk_Get_Messages()
-		{
-			var firstBasicMsg = new BasicMessage { Prop = "This is the first message" };
-			var secondBasicMsg = new BasicMessage { Prop = "This is the second message" };
-			var thridBasicMsg = new BasicMessage { Prop = "This is the thrid message" };
-			var firstSimpleMsg = new SimpleMessage { IsSimple = true };
+        [Fact]
+        public async Task Should_Be_Able_To_Bulk_Get_Messages()
+        {
+            var firstBasicMsg = new BasicMessage { Prop = "This is the first message" };
+            var secondBasicMsg = new BasicMessage { Prop = "This is the second message" };
+            var thridBasicMsg = new BasicMessage { Prop = "This is the thrid message" };
+            var firstSimpleMsg = new SimpleMessage { IsSimple = true };
 
-			using (var client = TestClientFactory.CreateExtendable())
-			{
-				await client.PublishAsync(secondBasicMsg);
-				await client.PublishAsync(firstBasicMsg);
-				await client.PublishAsync(thridBasicMsg);
-				await client.PublishAsync(firstSimpleMsg);
-				await Task.Delay(500);
+            using (var client = TestClientFactory.CreateExtendable())
+            {
+                await client.PublishAsync(secondBasicMsg);
+                await client.PublishAsync(firstBasicMsg);
+                await client.PublishAsync(thridBasicMsg);
+                await client.PublishAsync(firstSimpleMsg);
+                await Task.Delay(500);
 
-				var bulk = client.GetMessages(cfg => cfg
-					.ForMessage<BasicMessage>(msg => msg
-						.FromQueues(_firstBasicQueue, _secondBasicQueue)
-						.WithBatchSize(4))
-					.ForMessage<SimpleMessage>(msg => msg
-						.FromQueues(_firstSimpleQueue)
-						.GetAll()
-						.WithNoAck()
-					));
-				var basics = bulk.GetMessages<BasicMessage>().ToList();
-				var simple = bulk.GetMessages<SimpleMessage>().ToList();
-				bulk.AckAll();
+                var bulk = client.GetMessages(cfg => cfg
+                    .ForMessage<BasicMessage>(msg => msg
+                        .FromQueues(_firstBasicQueue, _secondBasicQueue)
+                        .WithBatchSize(4))
+                    .ForMessage<SimpleMessage>(msg => msg
+                        .FromQueues(_firstSimpleQueue)
+                        .GetAll()
+                        .WithNoAck()
+                    ));
+                var basics = bulk.GetMessages<BasicMessage>().ToList();
+                var simple = bulk.GetMessages<SimpleMessage>().ToList();
+                bulk.AckAll();
 
-				Assert.Equal(expected: 4, actual: basics.Count);
-				Assert.Equal(expected: 1, actual: simple.Count);
-			}
-		}
-	}
+                Assert.Equal(expected: 4, actual: basics.Count);
+                Assert.Equal(expected: 1, actual: simple.Count);
+            }
+        }
+    }
 }

--- a/test/RawRabbit.IntegrationTests/Extensions/MessageSequenceTests.cs
+++ b/test/RawRabbit.IntegrationTests/Extensions/MessageSequenceTests.cs
@@ -14,273 +14,273 @@ using Xunit;
 
 namespace RawRabbit.IntegrationTests.Extensions
 {
-	public class MessageSequenceTests : IntegrationTestBase
-	{
-		private readonly RawRabbit.Extensions.Disposable.IBusClient _client;
+    public class MessageSequenceTests : IntegrationTestBase
+    {
+        private readonly RawRabbit.Extensions.Disposable.IBusClient _client;
 
-		public MessageSequenceTests()
-		{
-			_client = TestClientFactory.CreateExtendable();
-		}
+        public MessageSequenceTests()
+        {
+            _client = TestClientFactory.CreateExtendable();
+        }
 
-		public override void Dispose()
-		{
-			base.Dispose();
-			_client.Dispose();
-		}
+        public override void Dispose()
+        {
+            base.Dispose();
+            _client.Dispose();
+        }
 
-		[Fact]
-		public async Task Should_Create_Simple_Chain_Of_One_Send_And_Final_Recieve()
-		{
-			/* Setup */
-			_client.SubscribeAsync<BasicRequest>((request, context) =>
-				_client.PublishAsync(new BasicResponse(), context.GlobalRequestId)
-			, cfg => cfg.WithQueue(q => q.WithAutoDelete()));
+        [Fact]
+        public async Task Should_Create_Simple_Chain_Of_One_Send_And_Final_Recieve()
+        {
+            /* Setup */
+            _client.SubscribeAsync<BasicRequest>((request, context) =>
+                _client.PublishAsync(new BasicResponse(), context.GlobalRequestId)
+            , cfg => cfg.WithQueue(q => q.WithAutoDelete()));
 
-			/* Test */
-			var chain = _client.ExecuteSequence(c => c
-				.PublishAsync<BasicRequest>()
-				.Complete<BasicResponse>()
-			);
-			
-			await chain.Task;
+            /* Test */
+            var chain = _client.ExecuteSequence(c => c
+                .PublishAsync<BasicRequest>()
+                .Complete<BasicResponse>()
+            );
+            
+            await chain.Task;
 
-			/* Assert */
-			Assert.True(true, "Recieed Response");
-		}
+            /* Assert */
+            Assert.True(true, "Recieed Response");
+        }
 
-		[Fact]
-		public async Task Should_Create_Chain_With_Publish_When_And_Complete()
-		{
-			/* Setup */
-			_client.SubscribeAsync<BasicRequest>(async (request, context) =>
-			{
-				await _client.PublishAsync(new BasicMessage(), context.GlobalRequestId);
-				await _client.PublishAsync(new BasicResponse(), context.GlobalRequestId);
-			}, cfg => cfg.WithQueue(q => q.WithAutoDelete()));
+        [Fact]
+        public async Task Should_Create_Chain_With_Publish_When_And_Complete()
+        {
+            /* Setup */
+            _client.SubscribeAsync<BasicRequest>(async (request, context) =>
+            {
+                await _client.PublishAsync(new BasicMessage(), context.GlobalRequestId);
+                await _client.PublishAsync(new BasicResponse(), context.GlobalRequestId);
+            }, cfg => cfg.WithQueue(q => q.WithAutoDelete()));
 
-			/* Test */
-			var chain = _client.ExecuteSequence(c => c
-				.PublishAsync<BasicRequest>()
-				.When<BasicMessage>((message, context) => Task.FromResult(true))
-				.Complete<BasicResponse>()
-			);
-			await chain.Task;
+            /* Test */
+            var chain = _client.ExecuteSequence(c => c
+                .PublishAsync<BasicRequest>()
+                .When<BasicMessage>((message, context) => Task.FromResult(true))
+                .Complete<BasicResponse>()
+            );
+            await chain.Task;
 
-			/* Assert */
-			Assert.True(true, "Recieed Response");
-		}
+            /* Assert */
+            Assert.True(true, "Recieed Response");
+        }
 
-		[Fact(Skip = "Investigation needed")]
-		public async Task Should_Call_Message_Handler_In_Correct_Order()
-		{
-			/* Setup */
-			using (var publisher = TestClientFactory.CreateExtendable())
-			{
-				publisher.SubscribeAsync<FirstMessage>((message, context) =>
-					publisher.PublishAsync(new SecondMessage(), context.GlobalRequestId));
-				publisher.SubscribeAsync<SecondMessage>((message, context) =>
-					publisher.PublishAsync(new ThirdMessage(), context.GlobalRequestId));
-				publisher.SubscribeAsync<ThirdMessage>((message, context) =>
-					publisher.PublishAsync(new ForthMessage(), context.GlobalRequestId));
-				var recieveIndex = 0;
-				var secondMsgDate = DateTime.MinValue;
-				var thirdMsgDate = DateTime.MinValue;
+        [Fact(Skip = "Investigation needed")]
+        public async Task Should_Call_Message_Handler_In_Correct_Order()
+        {
+            /* Setup */
+            using (var publisher = TestClientFactory.CreateExtendable())
+            {
+                publisher.SubscribeAsync<FirstMessage>((message, context) =>
+                    publisher.PublishAsync(new SecondMessage(), context.GlobalRequestId));
+                publisher.SubscribeAsync<SecondMessage>((message, context) =>
+                    publisher.PublishAsync(new ThirdMessage(), context.GlobalRequestId));
+                publisher.SubscribeAsync<ThirdMessage>((message, context) =>
+                    publisher.PublishAsync(new ForthMessage(), context.GlobalRequestId));
+                var recieveIndex = 0;
+                var secondMsgDate = DateTime.MinValue;
+                var thirdMsgDate = DateTime.MinValue;
 
-				/* Test */
-				var chain = _client.ExecuteSequence(c => c
-					.PublishAsync(new FirstMessage())
-					.When<SecondMessage>((message, context) =>
-					{
-						secondMsgDate = DateTime.Now;
-						return Task.FromResult(true);
-					})
-					.When<ThirdMessage>((message, context) =>
-					{
-						thirdMsgDate = DateTime.Now;
-						return Task.FromResult(true);
-					})
-					.Complete<ForthMessage>()
-				);
+                /* Test */
+                var chain = _client.ExecuteSequence(c => c
+                    .PublishAsync(new FirstMessage())
+                    .When<SecondMessage>((message, context) =>
+                    {
+                        secondMsgDate = DateTime.Now;
+                        return Task.FromResult(true);
+                    })
+                    .When<ThirdMessage>((message, context) =>
+                    {
+                        thirdMsgDate = DateTime.Now;
+                        return Task.FromResult(true);
+                    })
+                    .Complete<ForthMessage>()
+                );
 
-				await chain.Task;
+                await chain.Task;
 
-				/* Assert */
-				Assert.True(secondMsgDate < thirdMsgDate);
-			}
-		}
+                /* Assert */
+                Assert.True(secondMsgDate < thirdMsgDate);
+            }
+        }
 
-		[Fact]
-		public async Task Should_Be_Able_To_Have_Multiple_Chains_Active()
-		{
-			/* Setup */
-			var outer = 2;
-			var inner = 4;
+        [Fact]
+        public async Task Should_Be_Able_To_Have_Multiple_Chains_Active()
+        {
+            /* Setup */
+            var outer = 2;
+            var inner = 4;
 
-			_client.SubscribeAsync<BasicRequest>(async (request, context) =>
-			{
-				await _client.PublishAsync(new BasicMessage(), context.GlobalRequestId);
-			});
-			_client.SubscribeAsync<BasicMessage>(async (request, context) =>
-			{
-				await _client.PublishAsync(new BasicResponse(), context.GlobalRequestId);
-			});
+            _client.SubscribeAsync<BasicRequest>(async (request, context) =>
+            {
+                await _client.PublishAsync(new BasicMessage(), context.GlobalRequestId);
+            });
+            _client.SubscribeAsync<BasicMessage>(async (request, context) =>
+            {
+                await _client.PublishAsync(new BasicResponse(), context.GlobalRequestId);
+            });
 
-			/* Test */
-			var triggerTasks = new Task[outer];
-			var result = new ConcurrentBag<BasicResponse>();
-			for (var o = 0; o < outer; o++)
-			{
-				triggerTasks[o] = new Task(() =>
-				{
-					for (int i = 0; i < inner; i++)
-					{
-						var chain = _client.ExecuteSequence(c => c
-							.PublishAsync<BasicRequest>()
-							.When<BasicMessage>((message, context) => Task.FromResult(true))
-							.Complete<BasicResponse>()
-							);
-						result.Add(chain.Task.Result);
-					}
-				});
-			}
-			foreach (var triggerTask in triggerTasks)
-			{
-				triggerTask.Start();
-			}
-			
-			Task.WaitAll(triggerTasks);
+            /* Test */
+            var triggerTasks = new Task[outer];
+            var result = new ConcurrentBag<BasicResponse>();
+            for (var o = 0; o < outer; o++)
+            {
+                triggerTasks[o] = new Task(() =>
+                {
+                    for (int i = 0; i < inner; i++)
+                    {
+                        var chain = _client.ExecuteSequence(c => c
+                            .PublishAsync<BasicRequest>()
+                            .When<BasicMessage>((message, context) => Task.FromResult(true))
+                            .Complete<BasicResponse>()
+                            );
+                        result.Add(chain.Task.Result);
+                    }
+                });
+            }
+            foreach (var triggerTask in triggerTasks)
+            {
+                triggerTask.Start();
+            }
+            
+            Task.WaitAll(triggerTasks);
 
-			/* Assert */
-			Assert.Equal(inner*outer, result.Count);
-		}
+            /* Assert */
+            Assert.Equal(inner*outer, result.Count);
+        }
 
-		[Fact]
-		public async Task Should_Honor_Abort_Exeuction()
-		{
-			/* Setup */
-			var thirdHandlerCalled = false;
-			_client.SubscribeAsync<FirstMessage>(async (request, context) =>
-			{
-				await _client.PublishAsync(new SecondMessage(), context.GlobalRequestId);
-			});
-			_client.SubscribeAsync<SecondMessage>(async (request, context) =>
-			{
-				await _client.PublishAsync(new ThirdMessage(), context.GlobalRequestId);
-			});
+        [Fact]
+        public async Task Should_Honor_Abort_Exeuction()
+        {
+            /* Setup */
+            var thirdHandlerCalled = false;
+            _client.SubscribeAsync<FirstMessage>(async (request, context) =>
+            {
+                await _client.PublishAsync(new SecondMessage(), context.GlobalRequestId);
+            });
+            _client.SubscribeAsync<SecondMessage>(async (request, context) =>
+            {
+                await _client.PublishAsync(new ThirdMessage(), context.GlobalRequestId);
+            });
 
-			/* Test */
-			var chain = _client.ExecuteSequence(c => c
-				.PublishAsync<FirstMessage>()
-				.When<SecondMessage>(
-					(message, context) => Task.FromResult(true),
-					(option) => option.AbortsExecution())
-				.When<ThirdMessage>(
-					(message, context) =>
-					{
-						thirdHandlerCalled = true;
-						return Task.FromResult(true);
-					})
-				.Complete<ForthMessage>()
-			);
-			await chain.Task;
+            /* Test */
+            var chain = _client.ExecuteSequence(c => c
+                .PublishAsync<FirstMessage>()
+                .When<SecondMessage>(
+                    (message, context) => Task.FromResult(true),
+                    (option) => option.AbortsExecution())
+                .When<ThirdMessage>(
+                    (message, context) =>
+                    {
+                        thirdHandlerCalled = true;
+                        return Task.FromResult(true);
+                    })
+                .Complete<ForthMessage>()
+            );
+            await chain.Task;
 
-			/* Assert */
-			Assert.True(chain.Aborted, "Execution should be aborted");
-			Assert.False(thirdHandlerCalled, "Handler should not be called");
-		}
+            /* Assert */
+            Assert.True(chain.Aborted, "Execution should be aborted");
+            Assert.False(thirdHandlerCalled, "Handler should not be called");
+        }
 
-		[Fact]
-		public async Task Should_Skip_Optional_Handler_If_Not_Matched()
-		{
-			/* Setup */
-			var secondHandlerCalled = false;
-			_client.SubscribeAsync<FirstMessage>(async (request, context) =>
-			{
-				await _client.PublishAsync(new ThirdMessage(), context.GlobalRequestId);
-			});
-			_client.SubscribeAsync<ThirdMessage>(async (request, context) =>
-			{
-				await _client.PublishAsync(new ForthMessage(), context.GlobalRequestId);
-			});
+        [Fact]
+        public async Task Should_Skip_Optional_Handler_If_Not_Matched()
+        {
+            /* Setup */
+            var secondHandlerCalled = false;
+            _client.SubscribeAsync<FirstMessage>(async (request, context) =>
+            {
+                await _client.PublishAsync(new ThirdMessage(), context.GlobalRequestId);
+            });
+            _client.SubscribeAsync<ThirdMessage>(async (request, context) =>
+            {
+                await _client.PublishAsync(new ForthMessage(), context.GlobalRequestId);
+            });
 
-			/* Test */
-			var chain = _client.ExecuteSequence(c => c
-				.PublishAsync<FirstMessage>()
-				.When<SecondMessage>(
-					(message, context) =>
-					{
-						secondHandlerCalled = true;
-						return Task.FromResult(true);
-					},
-					(option) => option.IsOptional())
-				.When<ThirdMessage>(
-					(message, context) => Task.FromResult(true))
-				.Complete<ForthMessage>()
-			);
-			await chain.Task;
+            /* Test */
+            var chain = _client.ExecuteSequence(c => c
+                .PublishAsync<FirstMessage>()
+                .When<SecondMessage>(
+                    (message, context) =>
+                    {
+                        secondHandlerCalled = true;
+                        return Task.FromResult(true);
+                    },
+                    (option) => option.IsOptional())
+                .When<ThirdMessage>(
+                    (message, context) => Task.FromResult(true))
+                .Complete<ForthMessage>()
+            );
+            await chain.Task;
 
-			/* Assert */
-			Assert.Equal(1, chain.Skipped.Count);
-			Assert.False(secondHandlerCalled, "Handler should not be called");
-		}
+            /* Assert */
+            Assert.Equal(1, chain.Skipped.Count);
+            Assert.False(secondHandlerCalled, "Handler should not be called");
+        }
 
-		[Fact]
-		public async Task Should_Call_Matching_Optional_Handler()
-		{
-			/* Setup */
-			var secondHandlerCalled = false;
-			_client.SubscribeAsync<FirstMessage>(async (request, context) =>
-			{
-				await _client.PublishAsync(new SecondMessage(), context.GlobalRequestId);
-			});
-			_client.SubscribeAsync<SecondMessage>(async (request, context) =>
-			{
-				await _client.PublishAsync(new ThirdMessage(), context.GlobalRequestId);
-			});
-			_client.SubscribeAsync<ThirdMessage>(async (request, context) =>
-			{
-				await _client.PublishAsync(new ForthMessage(), context.GlobalRequestId);
-			});
+        [Fact]
+        public async Task Should_Call_Matching_Optional_Handler()
+        {
+            /* Setup */
+            var secondHandlerCalled = false;
+            _client.SubscribeAsync<FirstMessage>(async (request, context) =>
+            {
+                await _client.PublishAsync(new SecondMessage(), context.GlobalRequestId);
+            });
+            _client.SubscribeAsync<SecondMessage>(async (request, context) =>
+            {
+                await _client.PublishAsync(new ThirdMessage(), context.GlobalRequestId);
+            });
+            _client.SubscribeAsync<ThirdMessage>(async (request, context) =>
+            {
+                await _client.PublishAsync(new ForthMessage(), context.GlobalRequestId);
+            });
 
-			/* Test */
-			var chain = _client.ExecuteSequence(c => c
-				.PublishAsync<FirstMessage>()
-				.When<SecondMessage>(
-					(message, context) =>
-					{
-						secondHandlerCalled = true;
-						return Task.FromResult(true);
-					},
-					(option) => option.IsOptional())
-				.When<ThirdMessage>(
-					(message, context) => Task.FromResult(true))
-				.Complete<ForthMessage>()
-			);
-			await chain.Task;
+            /* Test */
+            var chain = _client.ExecuteSequence(c => c
+                .PublishAsync<FirstMessage>()
+                .When<SecondMessage>(
+                    (message, context) =>
+                    {
+                        secondHandlerCalled = true;
+                        return Task.FromResult(true);
+                    },
+                    (option) => option.IsOptional())
+                .When<ThirdMessage>(
+                    (message, context) => Task.FromResult(true))
+                .Complete<ForthMessage>()
+            );
+            await chain.Task;
 
-			/* Assert */
-			Assert.Equal(0, chain.Skipped.Count);
-			Assert.True(secondHandlerCalled, "Handler should be called");
-		}
+            /* Assert */
+            Assert.Equal(0, chain.Skipped.Count);
+            Assert.True(secondHandlerCalled, "Handler should be called");
+        }
 
-		[Fact]
-		public async Task Should_Honor_Timeout()
-		{
-			/* Setup */
-			var cfg = RawRabbitConfiguration.Local;
-			cfg.RequestTimeout = TimeSpan.FromMilliseconds(200);
-			using (var client = TestClientFactory.CreateExtendable(ioc => ioc.AddSingleton(c => cfg)))
-			{
-				/* Test */
-				var chain = client.ExecuteSequence(c => c
-					.PublishAsync<FirstMessage>()
-					.Complete<SecondMessage>()
-				);
+        [Fact]
+        public async Task Should_Honor_Timeout()
+        {
+            /* Setup */
+            var cfg = RawRabbitConfiguration.Local;
+            cfg.RequestTimeout = TimeSpan.FromMilliseconds(200);
+            using (var client = TestClientFactory.CreateExtendable(ioc => ioc.AddSingleton(c => cfg)))
+            {
+                /* Test */
+                var chain = client.ExecuteSequence(c => c
+                    .PublishAsync<FirstMessage>()
+                    .Complete<SecondMessage>()
+                );
 
-				/* Assert */
-				await Assert.ThrowsAsync<TimeoutException>(async () => await chain.Task);
-			}
-		}
-	}
+                /* Assert */
+                await Assert.ThrowsAsync<TimeoutException>(async () => await chain.Task);
+            }
+        }
+    }
 }

--- a/test/RawRabbit.IntegrationTests/Extensions/TopologyUpdaterTests.cs
+++ b/test/RawRabbit.IntegrationTests/Extensions/TopologyUpdaterTests.cs
@@ -13,201 +13,201 @@ using ExchangeType = RawRabbit.Configuration.Exchange.ExchangeType;
 
 namespace RawRabbit.IntegrationTests.Extensions
 {
-	public class TopologyUpdaterTests : IntegrationTestBase
-	{
-		public TopologyUpdaterTests()
-		{
-			TestChannel.ExchangeDelete("rawrabbit.integrationtests.testmessages");
-		}
+    public class TopologyUpdaterTests : IntegrationTestBase
+    {
+        public TopologyUpdaterTests()
+        {
+            TestChannel.ExchangeDelete("rawrabbit.integrationtests.testmessages");
+        }
 
-		public override void Dispose()
-		{
-			try { TestChannel.ExchangeDelete("rawrabbit.integrationtests.testmessages"); }
-			catch (Exception) { }
-			base.Dispose();
-		}
+        public override void Dispose()
+        {
+            try { TestChannel.ExchangeDelete("rawrabbit.integrationtests.testmessages"); }
+            catch (Exception) { }
+            base.Dispose();
+        }
 
-		[Fact]
-		public async Task Should_Update_Exhange_Type()
-		{
-			/* Setup */
-			const string exchangeName = "topology";
-			TestChannel.ExchangeDelete(exchangeName);
-			TestChannel.ExchangeDeclare(exchangeName, RabbitMQ.Client.ExchangeType.Direct);
+        [Fact]
+        public async Task Should_Update_Exhange_Type()
+        {
+            /* Setup */
+            const string exchangeName = "topology";
+            TestChannel.ExchangeDelete(exchangeName);
+            TestChannel.ExchangeDeclare(exchangeName, RabbitMQ.Client.ExchangeType.Direct);
 
-			using (var client = TestClientFactory.CreateExtendable())
-			{
-				/* Test */
-				await client.UpdateTopologyAsync(t => t
-					.ForExchange(exchangeName)
-					.UseConfiguration(e => e
-						.WithType(ExchangeType.Topic)
-						.WithDurability(false))
-				);
+            using (var client = TestClientFactory.CreateExtendable())
+            {
+                /* Test */
+                await client.UpdateTopologyAsync(t => t
+                    .ForExchange(exchangeName)
+                    .UseConfiguration(e => e
+                        .WithType(ExchangeType.Topic)
+                        .WithDurability(false))
+                );
 
-				/* Assert */
-				TestChannel.ExchangeDeclare(exchangeName, RabbitMQ.Client.ExchangeType.Topic);
-				Assert.True(true, "Did not throw");
-				Assert.Throws<OperationInterruptedException>(() => TestChannel.ExchangeDeclare(exchangeName, RabbitMQ.Client.ExchangeType.Direct));
-			}
-		}
+                /* Assert */
+                TestChannel.ExchangeDeclare(exchangeName, RabbitMQ.Client.ExchangeType.Topic);
+                Assert.True(true, "Did not throw");
+                Assert.Throws<OperationInterruptedException>(() => TestChannel.ExchangeDeclare(exchangeName, RabbitMQ.Client.ExchangeType.Direct));
+            }
+        }
 
-		[Fact]
-		public async Task Should_Not_Interupt_Existing_Subscribers_When_Using_Custom_Config()
-		{
-			/* Setup */
-			var cfg = RawRabbitConfiguration.Local.AsLegacy();
-			using (var client = TestClientFactory.CreateExtendable(ioc => ioc.AddSingleton(s => cfg)))
-			{
-				var firstTcs = new TaskCompletionSource<BasicMessage>();
-				var secondTcs = new TaskCompletionSource<BasicMessage>();
-				client.SubscribeAsync<BasicMessage>((message, context) =>
-				{
-					if (!firstTcs.Task.IsCompleted)
-					{
-						firstTcs.SetResult(message);
-						return firstTcs.Task;
-					}
-					if (!secondTcs.Task.IsCompleted)
-					{
-						secondTcs.SetResult(message);
-						return secondTcs.Task;
-					}
-					return Task.FromResult(true);
-				});
+        [Fact]
+        public async Task Should_Not_Interupt_Existing_Subscribers_When_Using_Custom_Config()
+        {
+            /* Setup */
+            var cfg = RawRabbitConfiguration.Local.AsLegacy();
+            using (var client = TestClientFactory.CreateExtendable(ioc => ioc.AddSingleton(s => cfg)))
+            {
+                var firstTcs = new TaskCompletionSource<BasicMessage>();
+                var secondTcs = new TaskCompletionSource<BasicMessage>();
+                client.SubscribeAsync<BasicMessage>((message, context) =>
+                {
+                    if (!firstTcs.Task.IsCompleted)
+                    {
+                        firstTcs.SetResult(message);
+                        return firstTcs.Task;
+                    }
+                    if (!secondTcs.Task.IsCompleted)
+                    {
+                        secondTcs.SetResult(message);
+                        return secondTcs.Task;
+                    }
+                    return Task.FromResult(true);
+                });
 
-				/* Test */
-				// 1. Verify subscriber
-				client.PublishAsync<BasicMessage>();
-				await firstTcs.Task;
+                /* Test */
+                // 1. Verify subscriber
+                client.PublishAsync<BasicMessage>();
+                await firstTcs.Task;
 
-				// 2. Change Type
-				await client.UpdateTopologyAsync(c => c
-					.ExchangeForMessage<BasicMessage>()
-					.UseConfiguration(e => e.WithType(ExchangeType.Topic)));
+                // 2. Change Type
+                await client.UpdateTopologyAsync(c => c
+                    .ExchangeForMessage<BasicMessage>()
+                    .UseConfiguration(e => e.WithType(ExchangeType.Topic)));
 
-				// 3. Verify subscriber
-				client.PublishAsync<BasicMessage>();
-				await secondTcs.Task;
+                // 3. Verify subscriber
+                client.PublishAsync<BasicMessage>();
+                await secondTcs.Task;
 
-				/* Assert */
-				Assert.True(true, "First and second message was delivered.");
-			}
-		}
+                /* Assert */
+                Assert.True(true, "First and second message was delivered.");
+            }
+        }
 
-		[Fact]
-		public async Task Should_Not_Interupt_Existing_Subscribers_When_Using_Conventions()
-		{
-			/* Setup */
-			var cfg = RawRabbitConfiguration.Local.AsLegacy();
-			using (var client = TestClientFactory.CreateExtendable(ioc => ioc.AddSingleton(s => cfg)))
-			{
-				var firstTcs = new TaskCompletionSource<BasicMessage>();
-				var secondTcs = new TaskCompletionSource<BasicMessage>();
-				client.SubscribeAsync<BasicMessage>((message, context) =>
-				{
-					if (!firstTcs.Task.IsCompleted)
-					{
-						firstTcs.SetResult(message);
-						return firstTcs.Task;
-					}
-					if (!secondTcs.Task.IsCompleted)
-					{
-						secondTcs.SetResult(message);
-						return secondTcs.Task;
-					}
-					return Task.FromResult(true);
-				});
+        [Fact]
+        public async Task Should_Not_Interupt_Existing_Subscribers_When_Using_Conventions()
+        {
+            /* Setup */
+            var cfg = RawRabbitConfiguration.Local.AsLegacy();
+            using (var client = TestClientFactory.CreateExtendable(ioc => ioc.AddSingleton(s => cfg)))
+            {
+                var firstTcs = new TaskCompletionSource<BasicMessage>();
+                var secondTcs = new TaskCompletionSource<BasicMessage>();
+                client.SubscribeAsync<BasicMessage>((message, context) =>
+                {
+                    if (!firstTcs.Task.IsCompleted)
+                    {
+                        firstTcs.SetResult(message);
+                        return firstTcs.Task;
+                    }
+                    if (!secondTcs.Task.IsCompleted)
+                    {
+                        secondTcs.SetResult(message);
+                        return secondTcs.Task;
+                    }
+                    return Task.FromResult(true);
+                });
 
-				/* Test */
-				// 1. Verify subscriber
-				client.PublishAsync<BasicMessage>();
-				await firstTcs.Task;
+                /* Test */
+                // 1. Verify subscriber
+                client.PublishAsync<BasicMessage>();
+                await firstTcs.Task;
 
-				// 2. Change Type
-				await client.UpdateTopologyAsync(c => c
-					.UseConventionForExchange<BasicMessage>()
-				);
+                // 2. Change Type
+                await client.UpdateTopologyAsync(c => c
+                    .UseConventionForExchange<BasicMessage>()
+                );
 
-				// 3. Verify subscriber
-				client.PublishAsync<BasicMessage>();
-				await secondTcs.Task;
+                // 3. Verify subscriber
+                client.PublishAsync<BasicMessage>();
+                await secondTcs.Task;
 
-				/* Assert */
-				Assert.True(true, "First and second message was delivered.");
-			}
-		}
+                /* Assert */
+                Assert.True(true, "First and second message was delivered.");
+            }
+        }
 
-		[Fact]
-		public async Task Should_Honor_Last_Configuration()
-		{
-			/* Setup */
-			using (var client = TestClientFactory.CreateExtendable())
-			{
-				const string exchangeName = "topology";
-				TestChannel.ExchangeDelete(exchangeName);
+        [Fact]
+        public async Task Should_Honor_Last_Configuration()
+        {
+            /* Setup */
+            using (var client = TestClientFactory.CreateExtendable())
+            {
+                const string exchangeName = "topology";
+                TestChannel.ExchangeDelete(exchangeName);
 
-				/* Test */
-				var result = await client.UpdateTopologyAsync(c => c
-					.ForExchange(exchangeName)
-					.UseConfiguration(e => e.WithType(ExchangeType.Headers))
-					.ForExchange(exchangeName)
-					.UseConfiguration(e => e.WithType(ExchangeType.Topic))
-					.ForExchange(exchangeName)
-					.UseConfiguration(e => e.WithType(ExchangeType.Direct))
-					.ForExchange(exchangeName)
-					.UseConfiguration(e => e.WithType(ExchangeType.Fanout)));
+                /* Test */
+                var result = await client.UpdateTopologyAsync(c => c
+                    .ForExchange(exchangeName)
+                    .UseConfiguration(e => e.WithType(ExchangeType.Headers))
+                    .ForExchange(exchangeName)
+                    .UseConfiguration(e => e.WithType(ExchangeType.Topic))
+                    .ForExchange(exchangeName)
+                    .UseConfiguration(e => e.WithType(ExchangeType.Direct))
+                    .ForExchange(exchangeName)
+                    .UseConfiguration(e => e.WithType(ExchangeType.Fanout)));
 
-				/* Assert */
-				Assert.Equal(result.Exchanges[0].Exchange.ExchangeType, ExchangeType.Fanout.ToString().ToLower());
-			}
-		}
+                /* Assert */
+                Assert.Equal(result.Exchanges[0].Exchange.ExchangeType, ExchangeType.Fanout.ToString().ToLower());
+            }
+        }
 
-		[Fact]
-		public async Task Should_Use_Routing_Key_Transformer_If_Present()
-		{
-			/* Setup */
-			using (var legacyClient = TestClientFactory.CreateExtendable(ioc => ioc.AddSingleton(s => RawRabbitConfiguration.Local.AsLegacy())))
-			using (var currentClient = TestClientFactory.CreateExtendable())
-			{
-				var legacyTcs = new TaskCompletionSource<BasicMessage>();
-				var currentTcs = new TaskCompletionSource<BasicMessage>();
+        [Fact]
+        public async Task Should_Use_Routing_Key_Transformer_If_Present()
+        {
+            /* Setup */
+            using (var legacyClient = TestClientFactory.CreateExtendable(ioc => ioc.AddSingleton(s => RawRabbitConfiguration.Local.AsLegacy())))
+            using (var currentClient = TestClientFactory.CreateExtendable())
+            {
+                var legacyTcs = new TaskCompletionSource<BasicMessage>();
+                var currentTcs = new TaskCompletionSource<BasicMessage>();
 
-				currentClient.SubscribeAsync<BasicMessage>((message, context) =>
-				{
-					if (!currentTcs.Task.IsCompleted)
-					{
-						currentTcs.SetResult(message);
-						return currentTcs.Task;
-					}
-					if (!legacyTcs.Task.IsCompleted)
-					{
-						legacyTcs.SetResult(message);
-						return legacyTcs.Task;
-					}
-					return Task.FromResult(true);
-				});
+                currentClient.SubscribeAsync<BasicMessage>((message, context) =>
+                {
+                    if (!currentTcs.Task.IsCompleted)
+                    {
+                        currentTcs.SetResult(message);
+                        return currentTcs.Task;
+                    }
+                    if (!legacyTcs.Task.IsCompleted)
+                    {
+                        legacyTcs.SetResult(message);
+                        return legacyTcs.Task;
+                    }
+                    return Task.FromResult(true);
+                });
 
-				/* Test */
-				// 1. Verify subscriber
-				currentClient.PublishAsync<BasicMessage>();
-				await currentTcs.Task;
+                /* Test */
+                // 1. Verify subscriber
+                currentClient.PublishAsync<BasicMessage>();
+                await currentTcs.Task;
 
-				// 2. Change Type
-				await currentClient.UpdateTopologyAsync(c => c
-					.ExchangeForMessage<BasicMessage>()
-					.UseConfiguration(
-						exchange => exchange.WithType(ExchangeType.Direct),
-						bindingKey => bindingKey.Replace(".#", string.Empty))
-				);
+                // 2. Change Type
+                await currentClient.UpdateTopologyAsync(c => c
+                    .ExchangeForMessage<BasicMessage>()
+                    .UseConfiguration(
+                        exchange => exchange.WithType(ExchangeType.Direct),
+                        bindingKey => bindingKey.Replace(".#", string.Empty))
+                );
 
-				// 3. Verify subscriber
-				legacyClient.PublishAsync<BasicMessage>();
-				await legacyTcs.Task;
+                // 3. Verify subscriber
+                legacyClient.PublishAsync<BasicMessage>();
+                await legacyTcs.Task;
 
-				/* Assert */
-				Assert.True(true);
-			}
-		}
-	}
+                /* Assert */
+                Assert.True(true);
+            }
+        }
+    }
 }

--- a/test/RawRabbit.IntegrationTests/Features/AuthenticationTests.cs
+++ b/test/RawRabbit.IntegrationTests/Features/AuthenticationTests.cs
@@ -9,57 +9,57 @@ using Xunit;
 
 namespace RawRabbit.IntegrationTests.Features
 {
-	public class AuthenticationTests
-	{
-		[Fact]
-		public async Task Should_Give_Clear_Error_Message_If_User_Does_Not_Exist()
-		{
-			/* Setup */
-			var config = new RawRabbitConfiguration
-			{
-				Username = "RawRabbit",
-				Password = "wrong-pass",
-				Hostnames = {"localhost"},
-				VirtualHost = "/",
-				Port = 5672
-			};
+    public class AuthenticationTests
+    {
+        [Fact]
+        public async Task Should_Give_Clear_Error_Message_If_User_Does_Not_Exist()
+        {
+            /* Setup */
+            var config = new RawRabbitConfiguration
+            {
+                Username = "RawRabbit",
+                Password = "wrong-pass",
+                Hostnames = {"localhost"},
+                VirtualHost = "/",
+                Port = 5672
+            };
 
-			/* Test */
-			/* Assert */
-			Assert.ThrowsAny<AuthenticationFailureException>(() => TestClientFactory.CreateNormal(ioc => ioc.AddSingleton(p => config)));
-		}
+            /* Test */
+            /* Assert */
+            Assert.ThrowsAny<AuthenticationFailureException>(() => TestClientFactory.CreateNormal(ioc => ioc.AddSingleton(p => config)));
+        }
 
-		[Fact]
-		public async Task Should_Use_Guest_Credentials_By_Default()
-		{
-			/* Setup */
-			/* Test */
-			var b = TestClientFactory.CreateNormal();
-			b.Dispose();
+        [Fact]
+        public async Task Should_Use_Guest_Credentials_By_Default()
+        {
+            /* Setup */
+            /* Test */
+            var b = TestClientFactory.CreateNormal();
+            b.Dispose();
 
-			/* Assert */
-			Assert.True(true, "Does not throw.");
-		}
+            /* Assert */
+            Assert.True(true, "Does not throw.");
+        }
 
-		[Fact]
-		public async Task Should_Not_Throw_If_Credentials_Are_Correct()
-		{
-			/* Setup */
-			var config = new RawRabbitConfiguration
-			{
-				Username = "RawRabbit",
-				Password = "RawRabbit",
-				Hostnames = new List<string> {"localhost"},
-				VirtualHost = "/",
-				Port = 5672
-			};
+        [Fact]
+        public async Task Should_Not_Throw_If_Credentials_Are_Correct()
+        {
+            /* Setup */
+            var config = new RawRabbitConfiguration
+            {
+                Username = "RawRabbit",
+                Password = "RawRabbit",
+                Hostnames = new List<string> {"localhost"},
+                VirtualHost = "/",
+                Port = 5672
+            };
 
-			/* Test */
-			var b = TestClientFactory.CreateNormal(ioc => ioc.AddSingleton(p => config));
-			b.Dispose();
+            /* Test */
+            var b = TestClientFactory.CreateNormal(ioc => ioc.AddSingleton(p => config));
+            b.Dispose();
 
-			/* Assert */
-			Assert.True(true, "Does not throw.");
-		}
-	}
+            /* Assert */
+            Assert.True(true, "Does not throw.");
+        }
+    }
 }

--- a/test/RawRabbit.IntegrationTests/Features/MessageContextTests.cs
+++ b/test/RawRabbit.IntegrationTests/Features/MessageContextTests.cs
@@ -9,165 +9,165 @@ using Xunit;
 
 namespace RawRabbit.IntegrationTests.Features
 {
-	public class MessageContextTests
-	{
-		[Fact]
-		public async Task Should_Send_Message_Context_Correctly()
-		{
-			/* Setup */
+    public class MessageContextTests
+    {
+        [Fact]
+        public async Task Should_Send_Message_Context_Correctly()
+        {
+            /* Setup */
 
-			var expectedId = Guid.NewGuid();
-			var contextProvider = new MessageContextProvider<MessageContext>(new JsonSerializer(), () => new MessageContext { GlobalRequestId = expectedId });
-			using (var subscriber = TestClientFactory.CreateNormal())
-			using (var publisher = TestClientFactory.CreateNormal(collection => collection.AddSingleton<IMessageContextProvider<MessageContext>>(contextProvider)))
-			{
-				var subscribeTcs = new TaskCompletionSource<Guid>();
+            var expectedId = Guid.NewGuid();
+            var contextProvider = new MessageContextProvider<MessageContext>(new JsonSerializer(), () => new MessageContext { GlobalRequestId = expectedId });
+            using (var subscriber = TestClientFactory.CreateNormal())
+            using (var publisher = TestClientFactory.CreateNormal(collection => collection.AddSingleton<IMessageContextProvider<MessageContext>>(contextProvider)))
+            {
+                var subscribeTcs = new TaskCompletionSource<Guid>();
 
-				subscriber.SubscribeAsync<BasicMessage>((msg, c) =>
-				{
-					subscribeTcs.SetResult(c.GlobalRequestId);
-					return subscribeTcs.Task;
-				});
+                subscriber.SubscribeAsync<BasicMessage>((msg, c) =>
+                {
+                    subscribeTcs.SetResult(c.GlobalRequestId);
+                    return subscribeTcs.Task;
+                });
 
-				/* Test */
-				publisher.PublishAsync<BasicMessage>();
-				await subscribeTcs.Task;
+                /* Test */
+                publisher.PublishAsync<BasicMessage>();
+                await subscribeTcs.Task;
 
-				/* Assert */
-				Assert.Equal(expected: expectedId, actual: subscribeTcs.Task.Result);
-			}
-		}
+                /* Assert */
+                Assert.Equal(expected: expectedId, actual: subscribeTcs.Task.Result);
+            }
+        }
 
-		[Fact]
-		public async Task Should_Forward_Context_On_Publish()
-		{
-			/* Setup */
-			using (var publisher = TestClientFactory.CreateNormal())
-			using (var firstSubscriber = TestClientFactory.CreateNormal())
-			using (var secondSubscriber = TestClientFactory.CreateNormal())
-			{
-				var firstCtxTcs = new TaskCompletionSource<MessageContext>();
-				var secondCtxTcs = new TaskCompletionSource<MessageContext>();
-				firstSubscriber.SubscribeAsync<BasicMessage>((msg, i) =>
-				{
-					firstCtxTcs.SetResult(i);
-					firstSubscriber.PublishAsync(new SimpleMessage(), i.GlobalRequestId);
-					return firstCtxTcs.Task;
-				});
-				secondSubscriber.SubscribeAsync<SimpleMessage>((msg, i) =>
-				{
-					secondCtxTcs.SetResult(i);
-					return secondCtxTcs.Task;
-				});
+        [Fact]
+        public async Task Should_Forward_Context_On_Publish()
+        {
+            /* Setup */
+            using (var publisher = TestClientFactory.CreateNormal())
+            using (var firstSubscriber = TestClientFactory.CreateNormal())
+            using (var secondSubscriber = TestClientFactory.CreateNormal())
+            {
+                var firstCtxTcs = new TaskCompletionSource<MessageContext>();
+                var secondCtxTcs = new TaskCompletionSource<MessageContext>();
+                firstSubscriber.SubscribeAsync<BasicMessage>((msg, i) =>
+                {
+                    firstCtxTcs.SetResult(i);
+                    firstSubscriber.PublishAsync(new SimpleMessage(), i.GlobalRequestId);
+                    return firstCtxTcs.Task;
+                });
+                secondSubscriber.SubscribeAsync<SimpleMessage>((msg, i) =>
+                {
+                    secondCtxTcs.SetResult(i);
+                    return secondCtxTcs.Task;
+                });
 
-				/* Test */
-				publisher.PublishAsync<BasicMessage>();
-				Task.WaitAll(firstCtxTcs.Task, secondCtxTcs.Task);
+                /* Test */
+                publisher.PublishAsync<BasicMessage>();
+                Task.WaitAll(firstCtxTcs.Task, secondCtxTcs.Task);
 
-				/* Assert */
-				Assert.Equal(firstCtxTcs.Task.Result.GlobalRequestId, secondCtxTcs.Task.Result.GlobalRequestId);
-			}
-		}
+                /* Assert */
+                Assert.Equal(firstCtxTcs.Task.Result.GlobalRequestId, secondCtxTcs.Task.Result.GlobalRequestId);
+            }
+        }
 
-		[Fact]
-		public async Task Should_Implicit_Forward_Context_On_Publish()
-		{
-			/* Setup */
-			using (var publisher = TestClientFactory.CreateNormal())
-			using (var firstSubscriber = TestClientFactory.CreateNormal())
-			using (var secondSubscriber = TestClientFactory.CreateNormal())
-			{
-				var firstCtxTcs = new TaskCompletionSource<MessageContext>();
-				var secondCtxTcs = new TaskCompletionSource<MessageContext>();
+        [Fact]
+        public async Task Should_Implicit_Forward_Context_On_Publish()
+        {
+            /* Setup */
+            using (var publisher = TestClientFactory.CreateNormal())
+            using (var firstSubscriber = TestClientFactory.CreateNormal())
+            using (var secondSubscriber = TestClientFactory.CreateNormal())
+            {
+                var firstCtxTcs = new TaskCompletionSource<MessageContext>();
+                var secondCtxTcs = new TaskCompletionSource<MessageContext>();
 
-				firstSubscriber.SubscribeAsync<BasicMessage>((msg, i) =>
-				{
-					firstCtxTcs.SetResult(i);
-					firstSubscriber.PublishAsync(new SimpleMessage());
-					return firstCtxTcs.Task;
-				});
-				secondSubscriber.SubscribeAsync<SimpleMessage>((msg, i) =>
-				{
-					secondCtxTcs.SetResult(i);
-					return secondCtxTcs.Task;
-				});
+                firstSubscriber.SubscribeAsync<BasicMessage>((msg, i) =>
+                {
+                    firstCtxTcs.SetResult(i);
+                    firstSubscriber.PublishAsync(new SimpleMessage());
+                    return firstCtxTcs.Task;
+                });
+                secondSubscriber.SubscribeAsync<SimpleMessage>((msg, i) =>
+                {
+                    secondCtxTcs.SetResult(i);
+                    return secondCtxTcs.Task;
+                });
 
-				/* Test */
-				publisher.PublishAsync<BasicMessage>();
-				Task.WaitAll(firstCtxTcs.Task, secondCtxTcs.Task);
+                /* Test */
+                publisher.PublishAsync<BasicMessage>();
+                Task.WaitAll(firstCtxTcs.Task, secondCtxTcs.Task);
 
-				/* Assert */
-				Assert.Equal(firstCtxTcs.Task.Result.GlobalRequestId, secondCtxTcs.Task.Result.GlobalRequestId);
-			}
-		}
+                /* Assert */
+                Assert.Equal(firstCtxTcs.Task.Result.GlobalRequestId, secondCtxTcs.Task.Result.GlobalRequestId);
+            }
+        }
 
-		[Fact]
-		public async Task Should_Forward_Context_On_Rpc()
-		{
-			/* Setup */
-			using (var requester = TestClientFactory.CreateNormal())
-			using (var firstResponder = TestClientFactory.CreateNormal())
-			using (var secondResponder = TestClientFactory.CreateNormal())
-			{
-				var tcs = new TaskCompletionSource<bool>();
-				MessageContext firstContext = null;
-				MessageContext secondContext = null;
+        [Fact]
+        public async Task Should_Forward_Context_On_Rpc()
+        {
+            /* Setup */
+            using (var requester = TestClientFactory.CreateNormal())
+            using (var firstResponder = TestClientFactory.CreateNormal())
+            using (var secondResponder = TestClientFactory.CreateNormal())
+            {
+                var tcs = new TaskCompletionSource<bool>();
+                MessageContext firstContext = null;
+                MessageContext secondContext = null;
 
-				firstResponder.RespondAsync<FirstRequest, FirstResponse>(async (req, c) =>
-				{
-					firstContext = c;
-					var resp = await firstResponder.RequestAsync<SecondRequest, SecondResponse>(new SecondRequest(), c.GlobalRequestId);
-					return new FirstResponse { Infered = resp.Source };
-				});
-				secondResponder.RespondAsync<SecondRequest, SecondResponse>((req, c) =>
-				{
-					secondContext = c;
-					tcs.SetResult(true);
-					return Task.FromResult(new SecondResponse { Source = Guid.NewGuid() });
-				});
+                firstResponder.RespondAsync<FirstRequest, FirstResponse>(async (req, c) =>
+                {
+                    firstContext = c;
+                    var resp = await firstResponder.RequestAsync<SecondRequest, SecondResponse>(new SecondRequest(), c.GlobalRequestId);
+                    return new FirstResponse { Infered = resp.Source };
+                });
+                secondResponder.RespondAsync<SecondRequest, SecondResponse>((req, c) =>
+                {
+                    secondContext = c;
+                    tcs.SetResult(true);
+                    return Task.FromResult(new SecondResponse { Source = Guid.NewGuid() });
+                });
 
-				/* Test */
-				requester.RequestAsync<FirstRequest, FirstResponse>();
-				await tcs.Task;
+                /* Test */
+                requester.RequestAsync<FirstRequest, FirstResponse>();
+                await tcs.Task;
 
-				/* Assert */
-				Assert.Equal(firstContext.GlobalRequestId, secondContext.GlobalRequestId);
-			}
-			
-		}
+                /* Assert */
+                Assert.Equal(firstContext.GlobalRequestId, secondContext.GlobalRequestId);
+            }
+            
+        }
 
-		[Fact]
-		public async Task Should_Forward_Context_On_Rpc_To_Publish()
-		{
-			/* Setup */
-			using (var requester = TestClientFactory.CreateNormal())
-			using (var firstResponder = TestClientFactory.CreateNormal())
-			using (var firstSubscriber = TestClientFactory.CreateNormal())
-			{
-				var tcs = new TaskCompletionSource<bool>();
-				MessageContext firstContext = null;
-				MessageContext secondContext = null;
+        [Fact]
+        public async Task Should_Forward_Context_On_Rpc_To_Publish()
+        {
+            /* Setup */
+            using (var requester = TestClientFactory.CreateNormal())
+            using (var firstResponder = TestClientFactory.CreateNormal())
+            using (var firstSubscriber = TestClientFactory.CreateNormal())
+            {
+                var tcs = new TaskCompletionSource<bool>();
+                MessageContext firstContext = null;
+                MessageContext secondContext = null;
 
-				firstResponder.RespondAsync<FirstRequest, FirstResponse>(async (req, c) =>
-				{
-					firstContext = c;
-					await firstResponder.PublishAsync(new BasicMessage(), c.GlobalRequestId);
-					return new FirstResponse();
-				});
-				firstSubscriber.SubscribeAsync<BasicMessage>((req, c) =>
-				{
-					secondContext = c;
-					tcs.SetResult(true);
-					return tcs.Task;
-				});
+                firstResponder.RespondAsync<FirstRequest, FirstResponse>(async (req, c) =>
+                {
+                    firstContext = c;
+                    await firstResponder.PublishAsync(new BasicMessage(), c.GlobalRequestId);
+                    return new FirstResponse();
+                });
+                firstSubscriber.SubscribeAsync<BasicMessage>((req, c) =>
+                {
+                    secondContext = c;
+                    tcs.SetResult(true);
+                    return tcs.Task;
+                });
 
-				/* Test */
-				requester.RequestAsync<FirstRequest, FirstResponse>();
-				await tcs.Task;
+                /* Test */
+                requester.RequestAsync<FirstRequest, FirstResponse>();
+                await tcs.Task;
 
-				/* Assert */
-				Assert.Equal(firstContext.GlobalRequestId, secondContext.GlobalRequestId);
-			}
-		}
-	}
+                /* Assert */
+                Assert.Equal(firstContext.GlobalRequestId, secondContext.GlobalRequestId);
+            }
+        }
+    }
 }

--- a/test/RawRabbit.IntegrationTests/Features/MessageHandlerExceptionTests.cs
+++ b/test/RawRabbit.IntegrationTests/Features/MessageHandlerExceptionTests.cs
@@ -18,195 +18,195 @@ using Xunit;
 
 namespace RawRabbit.IntegrationTests.Features
 {
-	public class MessageHandlerExceptionTests : IDisposable
-	{
-		private readonly Mock<IErrorHandlingStrategy> _errorHandler;
-		private readonly RawRabbit.vNext.Disposable.IBusClient _client;
+    public class MessageHandlerExceptionTests : IDisposable
+    {
+        private readonly Mock<IErrorHandlingStrategy> _errorHandler;
+        private readonly RawRabbit.vNext.Disposable.IBusClient _client;
 
-		public MessageHandlerExceptionTests()
-		{
-			_errorHandler = new Mock<IErrorHandlingStrategy>();
-			_client = TestClientFactory.CreateNormal(ioc => ioc.AddSingleton(c => _errorHandler.Object));
-		}
+        public MessageHandlerExceptionTests()
+        {
+            _errorHandler = new Mock<IErrorHandlingStrategy>();
+            _client = TestClientFactory.CreateNormal(ioc => ioc.AddSingleton(c => _errorHandler.Object));
+        }
 
-		public void Dispose()
-		{
-			_client.Dispose();
-		}
+        public void Dispose()
+        {
+            _client.Dispose();
+        }
 
-		[Fact]
-		public async Task Should_Call_Subscribe_Error_Handler_On_Exception_In_Subscribe_Handler()
-		{
-			/* Setup */
-			var exception = new Exception("Oh oh, something when wrong!");
-			var realHandler = new DefaultStrategy(null, new NamingConventions(), null, null, null);
-			_errorHandler
-				.Setup(e => e.ExecuteAsync(
-						It.IsAny<Func<Task>>(),
-						It.IsAny<Func<Exception, Task>>()
-					))
-				.Callback((Func<Task> h, Func<Exception, Task> e) => realHandler.ExecuteAsync(h, e));
+        [Fact]
+        public async Task Should_Call_Subscribe_Error_Handler_On_Exception_In_Subscribe_Handler()
+        {
+            /* Setup */
+            var exception = new Exception("Oh oh, something when wrong!");
+            var realHandler = new DefaultStrategy(null, new NamingConventions(), null, null, null);
+            _errorHandler
+                .Setup(e => e.ExecuteAsync(
+                        It.IsAny<Func<Task>>(),
+                        It.IsAny<Func<Exception, Task>>()
+                    ))
+                .Callback((Func<Task> h, Func<Exception, Task> e) => realHandler.ExecuteAsync(h, e));
 
-			_errorHandler
-				.Setup(e => e.OnSubscriberExceptionAsync(
-					It.IsAny<IRawConsumer>(),
-					It.IsAny<SubscriptionConfiguration>(),
-					It.IsAny<BasicDeliverEventArgs>(),
-					exception
-				))
-				.Returns(Task.FromResult(true))
-				.Verifiable();
-			var recieveTcs = new TaskCompletionSource<BasicMessage>();
-			_client.SubscribeAsync<BasicMessage>((message, context) =>
-			{
-				recieveTcs.SetResult(message);
-				throw exception;
-			}, c => c.WithNoAck());
+            _errorHandler
+                .Setup(e => e.OnSubscriberExceptionAsync(
+                    It.IsAny<IRawConsumer>(),
+                    It.IsAny<SubscriptionConfiguration>(),
+                    It.IsAny<BasicDeliverEventArgs>(),
+                    exception
+                ))
+                .Returns(Task.FromResult(true))
+                .Verifiable();
+            var recieveTcs = new TaskCompletionSource<BasicMessage>();
+            _client.SubscribeAsync<BasicMessage>((message, context) =>
+            {
+                recieveTcs.SetResult(message);
+                throw exception;
+            }, c => c.WithNoAck());
 
-			/* Test */
-			_client.PublishAsync<BasicMessage>();
-			await recieveTcs.Task;
+            /* Test */
+            _client.PublishAsync<BasicMessage>();
+            await recieveTcs.Task;
 
-			/* Assert */
-			_errorHandler.VerifyAll();
-		}
+            /* Assert */
+            _errorHandler.VerifyAll();
+        }
 
-		[Fact]
-		public async Task Should_Throw_Exception_To_Requester_If_Responder_Throws_Async()
-		{
-			/* Setup */
-			using (var requester = TestClientFactory.CreateNormal())
-			using (var responder = TestClientFactory.CreateNormal())
-			{
-				responder.RespondAsync<BasicRequest, BasicResponse>((request, context) =>
-				{
-					throw new NotSupportedException("I'll throw this");
-				});
+        [Fact]
+        public async Task Should_Throw_Exception_To_Requester_If_Responder_Throws_Async()
+        {
+            /* Setup */
+            using (var requester = TestClientFactory.CreateNormal())
+            using (var responder = TestClientFactory.CreateNormal())
+            {
+                responder.RespondAsync<BasicRequest, BasicResponse>((request, context) =>
+                {
+                    throw new NotSupportedException("I'll throw this");
+                });
 
-				/* Test */
-				/* Assert */
-				var e = await Assert.ThrowsAsync<MessageHandlerException>(() => requester.RequestAsync<BasicRequest, BasicResponse>());
-				Assert.NotNull(e);
-			}
-		}
+                /* Test */
+                /* Assert */
+                var e = await Assert.ThrowsAsync<MessageHandlerException>(() => requester.RequestAsync<BasicRequest, BasicResponse>());
+                Assert.NotNull(e);
+            }
+        }
 
-		[Fact]
-		public async Task Should_Throw_Exception_To_Requester_If_Responder_Throws_Sync()
-		{
-			/* Setup */
-			using (var requester = TestClientFactory.CreateNormal())
-			using (var responder = TestClientFactory.CreateNormal())
-			{
-				var responseException = new NotSupportedException("I'll throw this");
-				responder.RespondAsync<BasicRequest, BasicResponse>((request, context) =>
-				{
-					throw responseException;
-				});
+        [Fact]
+        public async Task Should_Throw_Exception_To_Requester_If_Responder_Throws_Sync()
+        {
+            /* Setup */
+            using (var requester = TestClientFactory.CreateNormal())
+            using (var responder = TestClientFactory.CreateNormal())
+            {
+                var responseException = new NotSupportedException("I'll throw this");
+                responder.RespondAsync<BasicRequest, BasicResponse>((request, context) =>
+                {
+                    throw responseException;
+                });
 
-				/* Test */
-				/* Assert */
-				var e = await Assert.ThrowsAsync<MessageHandlerException>(() => requester.RequestAsync<BasicRequest, BasicResponse>());
-				Assert.Equal(expected: responseException.Message, actual: e.InnerMessage);
-			}
-		}
+                /* Test */
+                /* Assert */
+                var e = await Assert.ThrowsAsync<MessageHandlerException>(() => requester.RequestAsync<BasicRequest, BasicResponse>());
+                Assert.Equal(expected: responseException.Message, actual: e.InnerMessage);
+            }
+        }
 
-		[Fact]
-		public async Task Should_Throw_Exception_If_Deserialization_Of_Response_Fails()
-		{
-			/* Setup */
-			var exception = new Exception("Can not serialize");
-			var brokenMsgSerializer = new Mock<IMessageSerializer>();
-			brokenMsgSerializer
-				.Setup(s => s.Deserialize(It.IsAny<BasicDeliverEventArgs>()))
-				.Throws(exception);
-			using (var brokenClient = TestClientFactory.CreateNormal(ioc => ioc.AddSingleton(provider => brokenMsgSerializer.Object)))
-			{
-				brokenClient.RespondAsync<BasicRequest, BasicResponse>(
-					(request, context) => Task.FromResult(new BasicResponse()));
+        [Fact]
+        public async Task Should_Throw_Exception_If_Deserialization_Of_Response_Fails()
+        {
+            /* Setup */
+            var exception = new Exception("Can not serialize");
+            var brokenMsgSerializer = new Mock<IMessageSerializer>();
+            brokenMsgSerializer
+                .Setup(s => s.Deserialize(It.IsAny<BasicDeliverEventArgs>()))
+                .Throws(exception);
+            using (var brokenClient = TestClientFactory.CreateNormal(ioc => ioc.AddSingleton(provider => brokenMsgSerializer.Object)))
+            {
+                brokenClient.RespondAsync<BasicRequest, BasicResponse>(
+                    (request, context) => Task.FromResult(new BasicResponse()));
 
-				/* Test */
-				/* Assert */
-				var e = await Assert.ThrowsAsync<Exception>(() => brokenClient.RequestAsync<BasicRequest, BasicResponse>());
-				Assert.Equal(e, exception);
-			}
-		}
+                /* Test */
+                /* Assert */
+                var e = await Assert.ThrowsAsync<Exception>(() => brokenClient.RequestAsync<BasicRequest, BasicResponse>());
+                Assert.Equal(e, exception);
+            }
+        }
 
-		[Fact]
-		public async Task Should_Publish_Message_On_Error_Exchange_If_Subscribe_Throws_Exception()
-		{
-			/* Setup */
-			var conventions = new NamingConventions();
-			using (var client = TestClientFactory.CreateNormal(ioc => ioc.AddSingleton(c => conventions)))
-			{
-				var recieveTcs = new TaskCompletionSource<HandlerExceptionMessage>();
-				MessageContext firstRecieved = null;
-				MessageContext secondRecieved = null;
-				client.SubscribeAsync<HandlerExceptionMessage>((message, context) =>
-				{
-					secondRecieved = context;
-					recieveTcs.TrySetResult(message);
-					return Task.FromResult(true);
-				}, c => c
-					.WithExchange(e => e
-						.WithName(conventions.ErrorExchangeNamingConvention())
-						.WithDurability(false))
-					.WithQueue(q => q.WithArgument(QueueArgument.MessageTtl, (int)TimeSpan.FromSeconds(1).TotalMilliseconds).WithAutoDelete())
-					.WithRoutingKey("#"));
-				client.SubscribeAsync<BasicMessage>((message, context) =>
-				{
-					firstRecieved = context;
-					throw new Exception("Oh oh!");
-				});
-				var originalMsg = new BasicMessage { Prop = "Hello, world" };
+        [Fact]
+        public async Task Should_Publish_Message_On_Error_Exchange_If_Subscribe_Throws_Exception()
+        {
+            /* Setup */
+            var conventions = new NamingConventions();
+            using (var client = TestClientFactory.CreateNormal(ioc => ioc.AddSingleton(c => conventions)))
+            {
+                var recieveTcs = new TaskCompletionSource<HandlerExceptionMessage>();
+                MessageContext firstRecieved = null;
+                MessageContext secondRecieved = null;
+                client.SubscribeAsync<HandlerExceptionMessage>((message, context) =>
+                {
+                    secondRecieved = context;
+                    recieveTcs.TrySetResult(message);
+                    return Task.FromResult(true);
+                }, c => c
+                    .WithExchange(e => e
+                        .WithName(conventions.ErrorExchangeNamingConvention())
+                        .WithDurability(false))
+                    .WithQueue(q => q.WithArgument(QueueArgument.MessageTtl, (int)TimeSpan.FromSeconds(1).TotalMilliseconds).WithAutoDelete())
+                    .WithRoutingKey("#"));
+                client.SubscribeAsync<BasicMessage>((message, context) =>
+                {
+                    firstRecieved = context;
+                    throw new Exception("Oh oh!");
+                });
+                var originalMsg = new BasicMessage { Prop = "Hello, world" };
 
-				/* Test */
-				client.PublishAsync(originalMsg);
-				await recieveTcs.Task;
+                /* Test */
+                client.PublishAsync(originalMsg);
+                await recieveTcs.Task;
 
-				/* Assert */
-				Assert.Equal(((BasicMessage)recieveTcs.Task.Result.Message).Prop, originalMsg.Prop);
-				Assert.NotNull(firstRecieved);
-				Assert.NotNull(secondRecieved);
-				Assert.Equal(firstRecieved.GlobalRequestId, secondRecieved.GlobalRequestId);
-			}
-		}
+                /* Assert */
+                Assert.Equal(((BasicMessage)recieveTcs.Task.Result.Message).Prop, originalMsg.Prop);
+                Assert.NotNull(firstRecieved);
+                Assert.NotNull(secondRecieved);
+                Assert.Equal(firstRecieved.GlobalRequestId, secondRecieved.GlobalRequestId);
+            }
+        }
 
-		[Fact]
-		public async Task Should_Keep_Consumer_Open_After_Publish_Exception()
-		{
-			/* Setup */
-			using (var client = TestClientFactory.CreateNormal())
-			{
-				var hasThrownTcs = new TaskCompletionSource<bool>();
-				var hasRecievedTcs = new TaskCompletionSource<bool>();
-				client.SubscribeAsync<BasicMessage>((message, context) =>
-				{
-					if (!hasThrownTcs.Task.IsCompleted)
-					{
-						Timer timer = null;
-						timer = new Timer(state =>
-						{
-							timer?.Dispose();
-							hasThrownTcs.SetResult(true);
-						}, null, TimeSpan.FromMilliseconds(100), new TimeSpan(-1));
-						throw new Exception("Uh uh!");
-					}
-					else
-					{
-						hasRecievedTcs.SetResult(true);
-					}
-					return Task.FromResult(true);
-				});
+        [Fact]
+        public async Task Should_Keep_Consumer_Open_After_Publish_Exception()
+        {
+            /* Setup */
+            using (var client = TestClientFactory.CreateNormal())
+            {
+                var hasThrownTcs = new TaskCompletionSource<bool>();
+                var hasRecievedTcs = new TaskCompletionSource<bool>();
+                client.SubscribeAsync<BasicMessage>((message, context) =>
+                {
+                    if (!hasThrownTcs.Task.IsCompleted)
+                    {
+                        Timer timer = null;
+                        timer = new Timer(state =>
+                        {
+                            timer?.Dispose();
+                            hasThrownTcs.SetResult(true);
+                        }, null, TimeSpan.FromMilliseconds(100), new TimeSpan(-1));
+                        throw new Exception("Uh uh!");
+                    }
+                    else
+                    {
+                        hasRecievedTcs.SetResult(true);
+                    }
+                    return Task.FromResult(true);
+                });
 
-				/* Test */
-				client.PublishAsync(new BasicMessage());
-				await hasThrownTcs.Task;
-				client.PublishAsync(new BasicMessage());
-				await hasRecievedTcs.Task;
+                /* Test */
+                client.PublishAsync(new BasicMessage());
+                await hasThrownTcs.Task;
+                client.PublishAsync(new BasicMessage());
+                await hasRecievedTcs.Task;
 
-				/* Assert */
-				Assert.True(true);
-			}
-		}
-	}
+                /* Assert */
+                Assert.True(true);
+            }
+        }
+    }
 }

--- a/test/RawRabbit.IntegrationTests/Features/NackingTests.cs
+++ b/test/RawRabbit.IntegrationTests/Features/NackingTests.cs
@@ -8,97 +8,97 @@ using Xunit;
 
 namespace RawRabbit.IntegrationTests.Features
 {
-	public class NackingTests : IntegrationTestBase
-	{
-		public NackingTests()
-		{
-			TestChannel.QueueDelete("basicmessage");
-		}
+    public class NackingTests : IntegrationTestBase
+    {
+        public NackingTests()
+        {
+            TestChannel.QueueDelete("basicmessage");
+        }
 
-		[Fact]
-		public async Task Should_Be_Able_To_Nack_Message()
-		{
-			/* Setup */
-			using (var firstResponder = TestClientFactory.CreateNormal<AdvancedMessageContext>())
-			using (var secondResponder = TestClientFactory.CreateNormal<AdvancedMessageContext>())
-			using (var requester = TestClientFactory.CreateNormal<AdvancedMessageContext>())
-			{
+        [Fact]
+        public async Task Should_Be_Able_To_Nack_Message()
+        {
+            /* Setup */
+            using (var firstResponder = TestClientFactory.CreateNormal<AdvancedMessageContext>())
+            using (var secondResponder = TestClientFactory.CreateNormal<AdvancedMessageContext>())
+            using (var requester = TestClientFactory.CreateNormal<AdvancedMessageContext>())
+            {
 
-				var hasBeenNacked = false;
-				firstResponder.RespondAsync<BasicRequest, BasicResponse>((request, context) =>
-				{
-					BasicResponse response = null;
-					if (!hasBeenNacked)
-					{
-						context?.Nack();
-						hasBeenNacked = true;
-					}
-					else
-					{
-						response = new BasicResponse();
-					}
-					return Task.FromResult(response);
-				}, c => c.WithNoAck(false));
-				secondResponder.RespondAsync<BasicRequest, BasicResponse>((request, context) =>
-				{
-					BasicResponse response = null;
-					if (!hasBeenNacked)
-					{
-						context?.Nack();
-						hasBeenNacked = true;
-					}
-					else
-					{
-						response = new BasicResponse();
-					}
-					return Task.FromResult(response);
-				}, c => c.WithNoAck(false));
+                var hasBeenNacked = false;
+                firstResponder.RespondAsync<BasicRequest, BasicResponse>((request, context) =>
+                {
+                    BasicResponse response = null;
+                    if (!hasBeenNacked)
+                    {
+                        context?.Nack();
+                        hasBeenNacked = true;
+                    }
+                    else
+                    {
+                        response = new BasicResponse();
+                    }
+                    return Task.FromResult(response);
+                }, c => c.WithNoAck(false));
+                secondResponder.RespondAsync<BasicRequest, BasicResponse>((request, context) =>
+                {
+                    BasicResponse response = null;
+                    if (!hasBeenNacked)
+                    {
+                        context?.Nack();
+                        hasBeenNacked = true;
+                    }
+                    else
+                    {
+                        response = new BasicResponse();
+                    }
+                    return Task.FromResult(response);
+                }, c => c.WithNoAck(false));
 
-				/* Test */
-				var result = await requester.RequestAsync<BasicRequest, BasicResponse>(new BasicRequest(), configuration: cfg => cfg
-						 .WithReplyQueue(
-							 q => q.WithName("special_reply_queue")));
+                /* Test */
+                var result = await requester.RequestAsync<BasicRequest, BasicResponse>(new BasicRequest(), configuration: cfg => cfg
+                         .WithReplyQueue(
+                             q => q.WithName("special_reply_queue")));
 
-				/* Assert */
-				Assert.NotNull(result);
-				Assert.True(hasBeenNacked);
-			}
-		}
+                /* Assert */
+                Assert.NotNull(result);
+                Assert.True(hasBeenNacked);
+            }
+        }
 
-		[Fact]
-		public async Task Should_Be_Able_To_Nack_On_Subscribe()
-		{
-			/* Setup */
-			using (var subscriber = TestClientFactory.CreateNormal<AdvancedMessageContext>())
-			using (var secondSubscriber = TestClientFactory.CreateNormal<AdvancedMessageContext>())
-			using (var publisher = TestClientFactory.CreateNormal<AdvancedMessageContext>())
-			{
-				var callcount = 0;
-				var subscribeTcs = new TaskCompletionSource<bool>();
-				var secondSubscribeTcs = new TaskCompletionSource<bool>();
-				subscriber.SubscribeAsync<BasicMessage>((message, context) =>
-				{
-					Interlocked.Increment(ref callcount);
-					context?.Nack();
-					subscribeTcs.TrySetResult(true);
-					return Task.FromResult(true);
-				});
-				secondSubscriber.SubscribeAsync<BasicMessage>((message, context) =>
-				{
-					secondSubscribeTcs.TrySetResult(true);
-					return Task.FromResult(true);
-				});
+        [Fact]
+        public async Task Should_Be_Able_To_Nack_On_Subscribe()
+        {
+            /* Setup */
+            using (var subscriber = TestClientFactory.CreateNormal<AdvancedMessageContext>())
+            using (var secondSubscriber = TestClientFactory.CreateNormal<AdvancedMessageContext>())
+            using (var publisher = TestClientFactory.CreateNormal<AdvancedMessageContext>())
+            {
+                var callcount = 0;
+                var subscribeTcs = new TaskCompletionSource<bool>();
+                var secondSubscribeTcs = new TaskCompletionSource<bool>();
+                subscriber.SubscribeAsync<BasicMessage>((message, context) =>
+                {
+                    Interlocked.Increment(ref callcount);
+                    context?.Nack();
+                    subscribeTcs.TrySetResult(true);
+                    return Task.FromResult(true);
+                });
+                secondSubscriber.SubscribeAsync<BasicMessage>((message, context) =>
+                {
+                    secondSubscribeTcs.TrySetResult(true);
+                    return Task.FromResult(true);
+                });
 
-				Task.WaitAll(
-					publisher.PublishAsync<BasicMessage>(),
-					subscribeTcs.Task,
-					secondSubscribeTcs.Task
-				);
+                Task.WaitAll(
+                    publisher.PublishAsync<BasicMessage>(),
+                    subscribeTcs.Task,
+                    secondSubscribeTcs.Task
+                );
 
-				TestChannel.QueueDelete("basicmessage");
+                TestChannel.QueueDelete("basicmessage");
 
-				Assert.Equal(expected: 1, actual: callcount);
-			}
-		}
-	}
+                Assert.Equal(expected: 1, actual: callcount);
+            }
+        }
+    }
 }

--- a/test/RawRabbit.IntegrationTests/Features/RetryWithDelayTests.cs
+++ b/test/RawRabbit.IntegrationTests/Features/RetryWithDelayTests.cs
@@ -10,122 +10,122 @@ using Xunit;
 
 namespace RawRabbit.IntegrationTests.Features
 {
-	public class RetryWithDelayTests
-	{
-		[Fact]
-		public async Task Should_Retry_For_Publish_Subscribe_After_Given_Timespan()
-		{
-			/* Setup */
-			using (var subscriber = TestClientFactory.CreateNormal<AdvancedMessageContext>())
-			using (var publisher = TestClientFactory.CreateNormal<AdvancedMessageContext>())
-			{
-				var subscribeTcs = new TaskCompletionSource<bool>();
-				var delay = TimeSpan.FromSeconds(1);
-				var hasBeenDelayed = false;
-				var firstRecieved = DateTime.MinValue;
-				var secondRecieved = DateTime.MinValue;
+    public class RetryWithDelayTests
+    {
+        [Fact]
+        public async Task Should_Retry_For_Publish_Subscribe_After_Given_Timespan()
+        {
+            /* Setup */
+            using (var subscriber = TestClientFactory.CreateNormal<AdvancedMessageContext>())
+            using (var publisher = TestClientFactory.CreateNormal<AdvancedMessageContext>())
+            {
+                var subscribeTcs = new TaskCompletionSource<bool>();
+                var delay = TimeSpan.FromSeconds(1);
+                var hasBeenDelayed = false;
+                var firstRecieved = DateTime.MinValue;
+                var secondRecieved = DateTime.MinValue;
 
-				subscriber.SubscribeAsync<BasicMessage>((message, context) =>
-				{
-					if (!hasBeenDelayed)
-					{
-						firstRecieved = DateTime.Now;
-						context.RetryLater(delay);
-						hasBeenDelayed = true;
-						return Task.FromResult(true);
-					}
-					secondRecieved = DateTime.Now;
-					return Task.Delay(10).ContinueWith(t => subscribeTcs.SetResult(true));
-				});
+                subscriber.SubscribeAsync<BasicMessage>((message, context) =>
+                {
+                    if (!hasBeenDelayed)
+                    {
+                        firstRecieved = DateTime.Now;
+                        context.RetryLater(delay);
+                        hasBeenDelayed = true;
+                        return Task.FromResult(true);
+                    }
+                    secondRecieved = DateTime.Now;
+                    return Task.Delay(10).ContinueWith(t => subscribeTcs.SetResult(true));
+                });
 
-				/* Test */
-				await publisher.PublishAsync(new BasicMessage { Prop = "I'm about to be reborn!" });
-				await subscribeTcs.Task;
-				var actualDelay = secondRecieved - firstRecieved;
-				await Task.Delay(80);
+                /* Test */
+                await publisher.PublishAsync(new BasicMessage { Prop = "I'm about to be reborn!" });
+                await subscribeTcs.Task;
+                var actualDelay = secondRecieved - firstRecieved;
+                await Task.Delay(80);
 
-				/* Assert */
-				Assert.Equal(expected: delay.Seconds, actual: actualDelay.Seconds);
-			}
-		}
+                /* Assert */
+                Assert.Equal(expected: delay.Seconds, actual: actualDelay.Seconds);
+            }
+        }
 
-		[Fact]
-		public async Task Should_Retry_And_Leave_Requester_Hanging_On_Rpc()
-		{
-			using (var requester = TestClientFactory.CreateNormal<AdvancedMessageContext>())
-			using (var responder = TestClientFactory.CreateNormal<AdvancedMessageContext>())
-			{
-				var delay = TimeSpan.FromSeconds(1);
-				var hasBeenDelayed = false;
-				var firstRecieved = DateTime.MinValue;
-				var secondRecieved = DateTime.MinValue;
+        [Fact]
+        public async Task Should_Retry_And_Leave_Requester_Hanging_On_Rpc()
+        {
+            using (var requester = TestClientFactory.CreateNormal<AdvancedMessageContext>())
+            using (var responder = TestClientFactory.CreateNormal<AdvancedMessageContext>())
+            {
+                var delay = TimeSpan.FromSeconds(1);
+                var hasBeenDelayed = false;
+                var firstRecieved = DateTime.MinValue;
+                var secondRecieved = DateTime.MinValue;
 
-				responder.RespondAsync<BasicRequest, BasicResponse>((request, context) =>
-				{
-					if (!hasBeenDelayed)
-					{
-						firstRecieved = DateTime.Now;
-						hasBeenDelayed = true;
-						context.RetryLater(delay);
-						return Task.FromResult<BasicResponse>(null);
-					}
-					secondRecieved = DateTime.Now;
-					return Task.FromResult(new BasicResponse());
-				});
+                responder.RespondAsync<BasicRequest, BasicResponse>((request, context) =>
+                {
+                    if (!hasBeenDelayed)
+                    {
+                        firstRecieved = DateTime.Now;
+                        hasBeenDelayed = true;
+                        context.RetryLater(delay);
+                        return Task.FromResult<BasicResponse>(null);
+                    }
+                    secondRecieved = DateTime.Now;
+                    return Task.FromResult(new BasicResponse());
+                });
 
-				/* Test */
-				var response = await requester.RequestAsync<BasicRequest, BasicResponse>();
-				var actualDelay = secondRecieved - firstRecieved;
-				await Task.Delay(80);
+                /* Test */
+                var response = await requester.RequestAsync<BasicRequest, BasicResponse>();
+                var actualDelay = secondRecieved - firstRecieved;
+                await Task.Delay(80);
 
-				/* Assert */
-				Assert.Equal(expected: delay.Seconds, actual: actualDelay.Seconds);
-			}
-		}
+                /* Assert */
+                Assert.Equal(expected: delay.Seconds, actual: actualDelay.Seconds);
+            }
+        }
 
-		[Fact]
-		public async Task Should_Successfully_Retry_With_Different_TimeSpans()
-		{
-			/* Setup */
-			using (var subscriber = TestClientFactory.CreateNormal<AdvancedMessageContext>())
-			using (var publisher = TestClientFactory.CreateNormal<AdvancedMessageContext>())
-			{
-				var recived = new List<DateTime>();
-				var redelivered = new List<DateTime>();
-				var allRedelivered = new TaskCompletionSource<bool>();
-				var recievedCount = 0;
+        [Fact]
+        public async Task Should_Successfully_Retry_With_Different_TimeSpans()
+        {
+            /* Setup */
+            using (var subscriber = TestClientFactory.CreateNormal<AdvancedMessageContext>())
+            using (var publisher = TestClientFactory.CreateNormal<AdvancedMessageContext>())
+            {
+                var recived = new List<DateTime>();
+                var redelivered = new List<DateTime>();
+                var allRedelivered = new TaskCompletionSource<bool>();
+                var recievedCount = 0;
 
-				subscriber.SubscribeAsync<BasicMessage>((message, context) =>
-				{
-					recievedCount++;
-					if (recievedCount <= 3)
-					{
-						recived.Add(DateTime.Now);
-						context.RetryLater(TimeSpan.FromSeconds(recievedCount));
-					}
-					else
-					{
-						redelivered.Add(DateTime.Now);
-						if (redelivered.Count == 3)
-						{
-							allRedelivered.SetResult(true);
-						}
-					}
-					return Task.FromResult(true);
-				});
+                subscriber.SubscribeAsync<BasicMessage>((message, context) =>
+                {
+                    recievedCount++;
+                    if (recievedCount <= 3)
+                    {
+                        recived.Add(DateTime.Now);
+                        context.RetryLater(TimeSpan.FromSeconds(recievedCount));
+                    }
+                    else
+                    {
+                        redelivered.Add(DateTime.Now);
+                        if (redelivered.Count == 3)
+                        {
+                            allRedelivered.SetResult(true);
+                        }
+                    }
+                    return Task.FromResult(true);
+                });
 
-				/* Test */
-				await publisher.PublishAsync(new BasicMessage { Prop = "I'm about to be reborn!" });
-				await publisher.PublishAsync(new BasicMessage { Prop = "I'm about to be reborn!" });
-				await publisher.PublishAsync(new BasicMessage { Prop = "I'm about to be reborn!" });
-				await allRedelivered.Task;
+                /* Test */
+                await publisher.PublishAsync(new BasicMessage { Prop = "I'm about to be reborn!" });
+                await publisher.PublishAsync(new BasicMessage { Prop = "I'm about to be reborn!" });
+                await publisher.PublishAsync(new BasicMessage { Prop = "I'm about to be reborn!" });
+                await allRedelivered.Task;
 
-				/* Assert */
-				for (var i = 0; i < 3; i++)
-				{
-					Assert.Equal(expected: (redelivered[i]-recived[i]).Seconds, actual: i+1);
-				}
-			}
-		}
-	}
+                /* Assert */
+                for (var i = 0; i < 3; i++)
+                {
+                    Assert.Equal(expected: (redelivered[i]-recived[i]).Seconds, actual: i+1);
+                }
+            }
+        }
+    }
 }

--- a/test/RawRabbit.IntegrationTests/Features/TimeoutTests.cs
+++ b/test/RawRabbit.IntegrationTests/Features/TimeoutTests.cs
@@ -9,64 +9,64 @@ using Xunit;
 
 namespace RawRabbit.IntegrationTests.Features
 {
-	public class TimeoutTests
-	{
-		[Fact]
-		public async Task Should_Interupt_Task_After_Timeout_Not_Met()
-		{
-			/* Setup */
-			var requester = TestClientFactory.CreateNormal(ioc =>
-			{
-				ioc.AddSingleton(p =>
-				{
-					var cfg = RawRabbitConfiguration.Local;
-					cfg.RequestTimeout = TimeSpan.FromMilliseconds(200);
-					return cfg;
-				});
-			});
-			using (var responder = TestClientFactory.CreateNormal())
-			using (requester)
-			{
-				responder.RespondAsync<FirstRequest, FirstResponse>((request, context) =>
-				{
-					return Task
-						.Run(() => Task.Delay(250))
-						.ContinueWith(t => new FirstResponse());
-				}, cfg => cfg.WithQueue(q => q.WithAutoDelete()));
+    public class TimeoutTests
+    {
+        [Fact]
+        public async Task Should_Interupt_Task_After_Timeout_Not_Met()
+        {
+            /* Setup */
+            var requester = TestClientFactory.CreateNormal(ioc =>
+            {
+                ioc.AddSingleton(p =>
+                {
+                    var cfg = RawRabbitConfiguration.Local;
+                    cfg.RequestTimeout = TimeSpan.FromMilliseconds(200);
+                    return cfg;
+                });
+            });
+            using (var responder = TestClientFactory.CreateNormal())
+            using (requester)
+            {
+                responder.RespondAsync<FirstRequest, FirstResponse>((request, context) =>
+                {
+                    return Task
+                        .Run(() => Task.Delay(250))
+                        .ContinueWith(t => new FirstResponse());
+                }, cfg => cfg.WithQueue(q => q.WithAutoDelete()));
 
-				/* Test */
-				/* Assert */
-				await Assert.ThrowsAsync<TimeoutException>(() => requester.RequestAsync<FirstRequest, FirstResponse>());
-			}
-		}
+                /* Test */
+                /* Assert */
+                await Assert.ThrowsAsync<TimeoutException>(() => requester.RequestAsync<FirstRequest, FirstResponse>());
+            }
+        }
 
-		[Fact]
-		public async Task Should_Not_Throw_If_Response_Is_Handled_Within_Time_Limit()
-		{
-			/* Setup */
-			var requester = TestClientFactory.CreateNormal(ioc =>
-			{
-				ioc.AddSingleton(p =>
-				{
-					var cfg = RawRabbitConfiguration.Local;
-					cfg.RequestTimeout = TimeSpan.FromMilliseconds(200);
-					return cfg;
-				});
-			});
-			using (var responder = TestClientFactory.CreateNormal())
-			using (requester)
-			{
-				responder.RespondAsync<FirstRequest, FirstResponse>((request, context) =>
-				{
-					return Task.FromResult(new FirstResponse());
-				}, cfg => cfg.WithQueue(q => q.WithAutoDelete()));
+        [Fact]
+        public async Task Should_Not_Throw_If_Response_Is_Handled_Within_Time_Limit()
+        {
+            /* Setup */
+            var requester = TestClientFactory.CreateNormal(ioc =>
+            {
+                ioc.AddSingleton(p =>
+                {
+                    var cfg = RawRabbitConfiguration.Local;
+                    cfg.RequestTimeout = TimeSpan.FromMilliseconds(200);
+                    return cfg;
+                });
+            });
+            using (var responder = TestClientFactory.CreateNormal())
+            using (requester)
+            {
+                responder.RespondAsync<FirstRequest, FirstResponse>((request, context) =>
+                {
+                    return Task.FromResult(new FirstResponse());
+                }, cfg => cfg.WithQueue(q => q.WithAutoDelete()));
 
-				/* Test */
-				await requester.RequestAsync<FirstRequest, FirstResponse>();
+                /* Test */
+                await requester.RequestAsync<FirstRequest, FirstResponse>();
 
-				/* Assert */
-				Assert.True(true, "Response recieved without throwing.");
-			}
-		}
-	}
+                /* Assert */
+                Assert.True(true, "Response recieved without throwing.");
+            }
+        }
+    }
 }

--- a/test/RawRabbit.IntegrationTests/IntegrationTestBase.cs
+++ b/test/RawRabbit.IntegrationTests/IntegrationTestBase.cs
@@ -3,25 +3,25 @@ using RabbitMQ.Client;
 
 namespace RawRabbit.IntegrationTests
 {
-	public class IntegrationTestBase : IDisposable
-	{
-		protected IModel TestChannel => _testChannel.Value;
-		private readonly Lazy<IModel> _testChannel;
-		private IConnection _connection;
-		
-		public IntegrationTestBase()
-		{
-			_testChannel = new Lazy<IModel>(() =>
-			{
-				_connection = new ConnectionFactory { HostName = "localhost" }.CreateConnection();
-				return _connection.CreateModel();
-			});
-		}
+    public class IntegrationTestBase : IDisposable
+    {
+        protected IModel TestChannel => _testChannel.Value;
+        private readonly Lazy<IModel> _testChannel;
+        private IConnection _connection;
+        
+        public IntegrationTestBase()
+        {
+            _testChannel = new Lazy<IModel>(() =>
+            {
+                _connection = new ConnectionFactory { HostName = "localhost" }.CreateConnection();
+                return _connection.CreateModel();
+            });
+        }
 
-		public virtual void Dispose()
-		{
-			TestChannel?.Dispose();
-			_connection?.Dispose();
-		}
-	}
+        public virtual void Dispose()
+        {
+            TestChannel?.Dispose();
+            _connection?.Dispose();
+        }
+    }
 }

--- a/test/RawRabbit.IntegrationTests/RabbitMqTutorial/HelloWorldTest.cs
+++ b/test/RawRabbit.IntegrationTests/RabbitMqTutorial/HelloWorldTest.cs
@@ -6,42 +6,42 @@ using Xunit;
 
 namespace RawRabbit.IntegrationTests.RabbitMqTutorial
 {
-	public class HelloWorldTest : IntegrationTestBase
-	{
-		[Fact]
-		public async Task Should_Support_The_Hello_World_Tutorial()
-		{
-			/* Setup */
-			using (var sender = TestClientFactory.CreateNormal())
-			using (var reciever = TestClientFactory.CreateNormal())
-			{
-				var sent = new BasicMessage { Prop = "Hello, world!" };
-				var recieved = new TaskCompletionSource<BasicMessage>();
+    public class HelloWorldTest : IntegrationTestBase
+    {
+        [Fact]
+        public async Task Should_Support_The_Hello_World_Tutorial()
+        {
+            /* Setup */
+            using (var sender = TestClientFactory.CreateNormal())
+            using (var reciever = TestClientFactory.CreateNormal())
+            {
+                var sent = new BasicMessage { Prop = "Hello, world!" };
+                var recieved = new TaskCompletionSource<BasicMessage>();
 
-				reciever.SubscribeAsync<BasicMessage>((message, info) =>
-				{
-					recieved.SetResult(message);
-					return Task.FromResult(true);
-				}, configuration => configuration
-						.WithQueue(queue =>
-							queue
-								.WithName("hello")
-								.WithExclusivity(false)
-								.WithAutoDelete(false)
-							)
-						.WithRoutingKey("hello")
-				);
+                reciever.SubscribeAsync<BasicMessage>((message, info) =>
+                {
+                    recieved.SetResult(message);
+                    return Task.FromResult(true);
+                }, configuration => configuration
+                        .WithQueue(queue =>
+                            queue
+                                .WithName("hello")
+                                .WithExclusivity(false)
+                                .WithAutoDelete(false)
+                            )
+                        .WithRoutingKey("hello")
+                );
 
-				/* Test */
-				await sender.PublishAsync(sent,
-					configuration: builder => builder
-						.WithRoutingKey("hello")
-				);
-				await recieved.Task;
+                /* Test */
+                await sender.PublishAsync(sent,
+                    configuration: builder => builder
+                        .WithRoutingKey("hello")
+                );
+                await recieved.Task;
 
-				/* Assert */
-				Assert.Equal(expected: sent.Prop, actual: recieved.Task.Result.Prop);
-			}
-		}
-	}
+                /* Assert */
+                Assert.Equal(expected: sent.Prop, actual: recieved.Task.Result.Prop);
+            }
+        }
+    }
 }

--- a/test/RawRabbit.IntegrationTests/RabbitMqTutorial/WorkQueueTest.cs
+++ b/test/RawRabbit.IntegrationTests/RabbitMqTutorial/WorkQueueTest.cs
@@ -7,53 +7,53 @@ using Xunit;
 
 namespace RawRabbit.IntegrationTests.RabbitMqTutorial
 {
-	public class WorkQueueTest : IntegrationTestBase
-	{
-		public WorkQueueTest()
-		{
-			TestChannel.QueueDelete("task_queue");
-		}
+    public class WorkQueueTest : IntegrationTestBase
+    {
+        public WorkQueueTest()
+        {
+            TestChannel.QueueDelete("task_queue");
+        }
 
-		public override void Dispose()
-		{
-			TestChannel.QueueDelete("task_queue");
-			base.Dispose();
-		}
+        public override void Dispose()
+        {
+            TestChannel.QueueDelete("task_queue");
+            base.Dispose();
+        }
 
-		[Fact]
-		public async Task Should_Support_The_Worker_Queues_Tutorial()
-		{
-			/* Setup */
-			using (var sender = TestClientFactory.CreateNormal())
-			using (var reciever = TestClientFactory.CreateNormal())
-			{
-				var sent = new BasicMessage { Prop = "Hello, world!" };
-				var recieved = new TaskCompletionSource<BasicMessage>();
+        [Fact]
+        public async Task Should_Support_The_Worker_Queues_Tutorial()
+        {
+            /* Setup */
+            using (var sender = TestClientFactory.CreateNormal())
+            using (var reciever = TestClientFactory.CreateNormal())
+            {
+                var sent = new BasicMessage { Prop = "Hello, world!" };
+                var recieved = new TaskCompletionSource<BasicMessage>();
 
-				reciever.SubscribeAsync<BasicMessage>((message, info) =>
-				{
-					recieved.SetResult(message);
-					return Task.FromResult(true);
-				}, configuration => configuration
-						.WithPrefetchCount(1)
-						.WithQueue(queue =>
-							queue
-								.WithName("task_queue")
-								.WithDurability()
-							)
-						.WithRoutingKey("task_queue")
-				);
+                reciever.SubscribeAsync<BasicMessage>((message, info) =>
+                {
+                    recieved.SetResult(message);
+                    return Task.FromResult(true);
+                }, configuration => configuration
+                        .WithPrefetchCount(1)
+                        .WithQueue(queue =>
+                            queue
+                                .WithName("task_queue")
+                                .WithDurability()
+                            )
+                        .WithRoutingKey("task_queue")
+                );
 
-				/* Test */
-				await sender.PublishAsync(sent,
-					configuration: builder => builder
-						.WithRoutingKey("task_queue")
-				);
-				await recieved.Task;
+                /* Test */
+                await sender.PublishAsync(sent,
+                    configuration: builder => builder
+                        .WithRoutingKey("task_queue")
+                );
+                await recieved.Task;
 
-				/* Assert */
-				Assert.Equal(expected: sent.Prop, actual: recieved.Task.Result.Prop);
-			}
-		}
-	}
+                /* Assert */
+                Assert.Equal(expected: sent.Prop, actual: recieved.Task.Result.Prop);
+            }
+        }
+    }
 }

--- a/test/RawRabbit.IntegrationTests/SimpleUse/MultipleRequestsTests.cs
+++ b/test/RawRabbit.IntegrationTests/SimpleUse/MultipleRequestsTests.cs
@@ -7,83 +7,83 @@ using Xunit;
 
 namespace RawRabbit.IntegrationTests.SimpleUse
 {
-	public class MultipleRequestsTests
-	{
-		[Fact]
-		public async Task Should_Just_Work()
-		{
-			/* Setup */
-			using (var requester = TestClientFactory.CreateNormal())
-			using (var responder = TestClientFactory.CreateNormal())
-			{
-				const int numberOfCalls = 10000;
-				var array = new Task[numberOfCalls];
-				responder.RespondAsync<FirstRequest, FirstResponse>((req, i) =>
-					Task.FromResult(new FirstResponse { Infered = Guid.NewGuid() })
-				);
+    public class MultipleRequestsTests
+    {
+        [Fact]
+        public async Task Should_Just_Work()
+        {
+            /* Setup */
+            using (var requester = TestClientFactory.CreateNormal())
+            using (var responder = TestClientFactory.CreateNormal())
+            {
+                const int numberOfCalls = 10000;
+                var array = new Task[numberOfCalls];
+                responder.RespondAsync<FirstRequest, FirstResponse>((req, i) =>
+                    Task.FromResult(new FirstResponse { Infered = Guid.NewGuid() })
+                );
 
-				/* Test */
-				var sw = new Stopwatch();
-				sw.Start();
-				for (var i = 0; i < numberOfCalls; i++)
-				{
-					var response = requester.RequestAsync<FirstRequest, FirstResponse>();
-					array[i] = response;
-				}
-				Task.WaitAll(array);
-				sw.Stop();
-				var ids = array
-					.OfType<Task<FirstResponse>>()
-					.Select(b => b.Result.Infered)
-					.Where(id => id != Guid.Empty)
-					.Distinct()
-					.ToList();
+                /* Test */
+                var sw = new Stopwatch();
+                sw.Start();
+                for (var i = 0; i < numberOfCalls; i++)
+                {
+                    var response = requester.RequestAsync<FirstRequest, FirstResponse>();
+                    array[i] = response;
+                }
+                Task.WaitAll(array);
+                sw.Stop();
+                var ids = array
+                    .OfType<Task<FirstResponse>>()
+                    .Select(b => b.Result.Infered)
+                    .Where(id => id != Guid.Empty)
+                    .Distinct()
+                    .ToList();
 
-				/* Assert */
-				Assert.Equal(expected: numberOfCalls, actual: ids.Count);
-			}
-		}
+                /* Assert */
+                Assert.Equal(expected: numberOfCalls, actual: ids.Count);
+            }
+        }
 
-		[Fact]
-		public async Task Should_Work_For_Multiple_Types()
-		{
-			/* Setup */
-			using (var requester = TestClientFactory.CreateNormal())
-			using (var responder = TestClientFactory.CreateNormal())
-			{
-				const int numberOfCalls = 10000;
-				var firstResponseTasks = new Task[numberOfCalls];
-				var secondResponseTasks = new Task[numberOfCalls];
-				responder.RespondAsync<FirstRequest, FirstResponse>((req, i) =>
-					Task.FromResult(new FirstResponse { Infered = Guid.NewGuid() }));
-				responder.RespondAsync<SecondRequest, SecondResponse>((request, context) =>
-					Task.FromResult(new SecondResponse { Source = Guid.NewGuid() }));
+        [Fact]
+        public async Task Should_Work_For_Multiple_Types()
+        {
+            /* Setup */
+            using (var requester = TestClientFactory.CreateNormal())
+            using (var responder = TestClientFactory.CreateNormal())
+            {
+                const int numberOfCalls = 10000;
+                var firstResponseTasks = new Task[numberOfCalls];
+                var secondResponseTasks = new Task[numberOfCalls];
+                responder.RespondAsync<FirstRequest, FirstResponse>((req, i) =>
+                    Task.FromResult(new FirstResponse { Infered = Guid.NewGuid() }));
+                responder.RespondAsync<SecondRequest, SecondResponse>((request, context) =>
+                    Task.FromResult(new SecondResponse { Source = Guid.NewGuid() }));
 
-				/* Test */
-				for (var i = 0; i < numberOfCalls; i++)
-				{
-					var firstResponse = requester.RequestAsync<FirstRequest, FirstResponse>();
-					var secondResponse = requester.RequestAsync<SecondRequest, SecondResponse>();
-					firstResponseTasks[i] = firstResponse;
-					secondResponseTasks[i] = secondResponse;
-				}
-				Task.WaitAll(firstResponseTasks.Concat(secondResponseTasks).ToArray());
-				var firstIds = firstResponseTasks
-					.OfType<Task<FirstResponse>>()
-					.Select(b => b.Result.Infered)
-					.Where(id => id != Guid.Empty)
-					.Distinct()
-					.ToList();
-				var secondIds = secondResponseTasks
-					.OfType<Task<SecondResponse>>()
-					.Select(b => b.Result.Source)
-					.Where(id => id != Guid.Empty)
-					.Distinct()
-					.ToList();
-				/* Assert */
-				Assert.Equal(expected: numberOfCalls, actual: firstIds.Count);
-				Assert.Equal(expected: numberOfCalls, actual: secondIds.Count);
-			}
-		}
-	}
+                /* Test */
+                for (var i = 0; i < numberOfCalls; i++)
+                {
+                    var firstResponse = requester.RequestAsync<FirstRequest, FirstResponse>();
+                    var secondResponse = requester.RequestAsync<SecondRequest, SecondResponse>();
+                    firstResponseTasks[i] = firstResponse;
+                    secondResponseTasks[i] = secondResponse;
+                }
+                Task.WaitAll(firstResponseTasks.Concat(secondResponseTasks).ToArray());
+                var firstIds = firstResponseTasks
+                    .OfType<Task<FirstResponse>>()
+                    .Select(b => b.Result.Infered)
+                    .Where(id => id != Guid.Empty)
+                    .Distinct()
+                    .ToList();
+                var secondIds = secondResponseTasks
+                    .OfType<Task<SecondResponse>>()
+                    .Select(b => b.Result.Source)
+                    .Where(id => id != Guid.Empty)
+                    .Distinct()
+                    .ToList();
+                /* Assert */
+                Assert.Equal(expected: numberOfCalls, actual: firstIds.Count);
+                Assert.Equal(expected: numberOfCalls, actual: secondIds.Count);
+            }
+        }
+    }
 }

--- a/test/RawRabbit.IntegrationTests/SimpleUse/PublishAndSubscribeTests.cs
+++ b/test/RawRabbit.IntegrationTests/SimpleUse/PublishAndSubscribeTests.cs
@@ -15,399 +15,399 @@ using ExchangeType = RawRabbit.Configuration.Exchange.ExchangeType;
 
 namespace RawRabbit.IntegrationTests.SimpleUse
 {
-	public class PublishAndSubscribeTests : IntegrationTestBase
-	{
+    public class PublishAndSubscribeTests : IntegrationTestBase
+    {
 
-		[Fact]
-		public async Task Should_Be_Able_To_Subscribe_Without_Any_Additional_Config()
-		{
-			/* Setup */
-			using (var publisher = TestClientFactory.CreateNormal())
-			using (var subscriber = TestClientFactory.CreateNormal())
-			{
-				var message = new BasicMessage { Prop = "Hello, world!" };
-				var recievedTcs = new TaskCompletionSource<BasicMessage>();
+        [Fact]
+        public async Task Should_Be_Able_To_Subscribe_Without_Any_Additional_Config()
+        {
+            /* Setup */
+            using (var publisher = TestClientFactory.CreateNormal())
+            using (var subscriber = TestClientFactory.CreateNormal())
+            {
+                var message = new BasicMessage { Prop = "Hello, world!" };
+                var recievedTcs = new TaskCompletionSource<BasicMessage>();
 
-				subscriber.SubscribeAsync<BasicMessage>((msg, info) =>
-				{
-					if (msg.Prop == message.Prop)
-					{
-						recievedTcs.SetResult(msg);
-					}
-					return Task.FromResult(true);
-				});
+                subscriber.SubscribeAsync<BasicMessage>((msg, info) =>
+                {
+                    if (msg.Prop == message.Prop)
+                    {
+                        recievedTcs.SetResult(msg);
+                    }
+                    return Task.FromResult(true);
+                });
 
-				/* Test */
-				publisher.PublishAsync(message);
-				await recievedTcs.Task;
+                /* Test */
+                publisher.PublishAsync(message);
+                await recievedTcs.Task;
 
-				/* Assert */
-				Assert.Equal(expected: message.Prop, actual: recievedTcs.Task.Result.Prop);
-			}
-		}
+                /* Assert */
+                Assert.Equal(expected: message.Prop, actual: recievedTcs.Task.Result.Prop);
+            }
+        }
 
-		[Fact]
-		public async Task Should_Be_Able_To_Perform_Multiple_Pub_Subs()
-		{
-			/* Setup */
-			using (var subscriber = TestClientFactory.CreateNormal())
-			using (var publisher = TestClientFactory.CreateNormal())
-			{
-				const int numberOfCalls = 100;
-				var recived = 0;
-				var recievedTcs = new TaskCompletionSource<bool>();
-				subscriber.SubscribeAsync<BasicMessage>((message, context) =>
-				{
-					Interlocked.Increment(ref recived);
-					if (numberOfCalls == recived)
-					{
-						recievedTcs.SetResult(true);
-					}
-					return Task.FromResult(true);
-				});
+        [Fact]
+        public async Task Should_Be_Able_To_Perform_Multiple_Pub_Subs()
+        {
+            /* Setup */
+            using (var subscriber = TestClientFactory.CreateNormal())
+            using (var publisher = TestClientFactory.CreateNormal())
+            {
+                const int numberOfCalls = 100;
+                var recived = 0;
+                var recievedTcs = new TaskCompletionSource<bool>();
+                subscriber.SubscribeAsync<BasicMessage>((message, context) =>
+                {
+                    Interlocked.Increment(ref recived);
+                    if (numberOfCalls == recived)
+                    {
+                        recievedTcs.SetResult(true);
+                    }
+                    return Task.FromResult(true);
+                });
 
-				/* Test */
-				var sw = Stopwatch.StartNew();
-				for (int i = 0; i < numberOfCalls; i++)
-				{
-					publisher.PublishAsync<BasicMessage>();
-				}
-				await recievedTcs.Task;
-				sw.Stop();
+                /* Test */
+                var sw = Stopwatch.StartNew();
+                for (int i = 0; i < numberOfCalls; i++)
+                {
+                    publisher.PublishAsync<BasicMessage>();
+                }
+                await recievedTcs.Task;
+                sw.Stop();
 
-				/* Assert */
-				Assert.True(true, $"Completed {numberOfCalls} in {sw.ElapsedMilliseconds} ms.");
-			}
-		}
+                /* Assert */
+                Assert.True(true, $"Completed {numberOfCalls} in {sw.ElapsedMilliseconds} ms.");
+            }
+        }
 
-		[Fact]
-		public void Should_Be_Able_To_Perform_Subscribe_For_Multiple_Types()
-		{
-			/* Setup */
-			using (var subscriber = TestClientFactory.CreateNormal())
-			using (var publisher = TestClientFactory.CreateNormal())
-			{
-				var basicTcs = new TaskCompletionSource<BasicMessage>();
-				var simpleTcs = new TaskCompletionSource<SimpleMessage>();
-				subscriber.SubscribeAsync<BasicMessage>((message, context) =>
-				{
-					basicTcs.SetResult(message);
-					return Task.FromResult(true);
-				});
-				subscriber.SubscribeAsync<SimpleMessage>((message, context) =>
-				{
-					simpleTcs.SetResult(message);
-					return Task.FromResult(true);
-				});
+        [Fact]
+        public void Should_Be_Able_To_Perform_Subscribe_For_Multiple_Types()
+        {
+            /* Setup */
+            using (var subscriber = TestClientFactory.CreateNormal())
+            using (var publisher = TestClientFactory.CreateNormal())
+            {
+                var basicTcs = new TaskCompletionSource<BasicMessage>();
+                var simpleTcs = new TaskCompletionSource<SimpleMessage>();
+                subscriber.SubscribeAsync<BasicMessage>((message, context) =>
+                {
+                    basicTcs.SetResult(message);
+                    return Task.FromResult(true);
+                });
+                subscriber.SubscribeAsync<SimpleMessage>((message, context) =>
+                {
+                    simpleTcs.SetResult(message);
+                    return Task.FromResult(true);
+                });
 
-				/* Test */
-				publisher.PublishAsync<BasicMessage>();
-				publisher.PublishAsync<SimpleMessage>();
-				Task.WaitAll(basicTcs.Task, simpleTcs.Task);
+                /* Test */
+                publisher.PublishAsync<BasicMessage>();
+                publisher.PublishAsync<SimpleMessage>();
+                Task.WaitAll(basicTcs.Task, simpleTcs.Task);
 
-				/* Assert */
-				Assert.True(true, "Successfully recieved messages.");
-			}
-		}
+                /* Assert */
+                Assert.True(true, "Successfully recieved messages.");
+            }
+        }
 
-		[Fact]
-		public async Task Should_Throw_Publish_Confirm_Exception_If_Server_Doesnt_Respond_Within_Time_Limit()
-		{
-			/* Setup */
-			var publisher = TestClientFactory.CreateNormal(ioc => ioc.AddSingleton(p =>
-			{
-				var config = RawRabbitConfiguration.Local;
-				config.PublishConfirmTimeout = TimeSpan.FromTicks(1);
-				return config;
-			}));
-			using (publisher)
-			{
-				/* Test */
-				/* Assert */
-				try
-				{
-					await publisher.PublishAsync<BasicMessage>();
-				}
-				catch (PublishConfirmException)
-				{
-					Assert.True(true);
-				}
-			}
-		}
+        [Fact]
+        public async Task Should_Throw_Publish_Confirm_Exception_If_Server_Doesnt_Respond_Within_Time_Limit()
+        {
+            /* Setup */
+            var publisher = TestClientFactory.CreateNormal(ioc => ioc.AddSingleton(p =>
+            {
+                var config = RawRabbitConfiguration.Local;
+                config.PublishConfirmTimeout = TimeSpan.FromTicks(1);
+                return config;
+            }));
+            using (publisher)
+            {
+                /* Test */
+                /* Assert */
+                try
+                {
+                    await publisher.PublishAsync<BasicMessage>();
+                }
+                catch (PublishConfirmException)
+                {
+                    Assert.True(true);
+                }
+            }
+        }
 
-		[Fact]
-		public void Should_Be_Able_To_Confirm_Multiple_Messages()
-		{
-			/* Setup */
-			const int numberOfCalls = 100;
-			var confirmTasks = new Task[numberOfCalls];
-			using (var publisher = TestClientFactory.CreateNormal())
-			{
-				for (int i = 0; i < numberOfCalls; i++)
-				{
-					var confirmTask = publisher.PublishAsync<BasicMessage>();
-					confirmTasks[i] = confirmTask;
-				}
-				Task.WaitAll(confirmTasks);
-				Task.Delay(500).Wait();
+        [Fact]
+        public void Should_Be_Able_To_Confirm_Multiple_Messages()
+        {
+            /* Setup */
+            const int numberOfCalls = 100;
+            var confirmTasks = new Task[numberOfCalls];
+            using (var publisher = TestClientFactory.CreateNormal())
+            {
+                for (int i = 0; i < numberOfCalls; i++)
+                {
+                    var confirmTask = publisher.PublishAsync<BasicMessage>();
+                    confirmTasks[i] = confirmTask;
+                }
+                Task.WaitAll(confirmTasks);
+                Task.Delay(500).Wait();
 
-				Assert.True(true, "Successfully confirmed all messages.");
-			}
-		}
+                Assert.True(true, "Successfully confirmed all messages.");
+            }
+        }
 
-		[Fact]
-		public void Should_Be_Able_To_Delivery_Message_To_Multiple_Subscribers_On_Same_Host()
-		{
-			/* Setup */
-			using (var subscriber = TestClientFactory.CreateNormal())
-			using (var publisher = TestClientFactory.CreateNormal())
-			{
-				var firstTcs = new TaskCompletionSource<bool>();
-				var secondTcs = new TaskCompletionSource<bool>();
-				subscriber.SubscribeAsync<BasicMessage>((message, context) =>
-				{
-					firstTcs.SetResult(true);
-					return Task.FromResult(true);
-				});
-				subscriber.SubscribeAsync<BasicMessage>((message, context) =>
-				{
-					secondTcs.SetResult(true);
-					return Task.FromResult(true);
-				});
+        [Fact]
+        public void Should_Be_Able_To_Delivery_Message_To_Multiple_Subscribers_On_Same_Host()
+        {
+            /* Setup */
+            using (var subscriber = TestClientFactory.CreateNormal())
+            using (var publisher = TestClientFactory.CreateNormal())
+            {
+                var firstTcs = new TaskCompletionSource<bool>();
+                var secondTcs = new TaskCompletionSource<bool>();
+                subscriber.SubscribeAsync<BasicMessage>((message, context) =>
+                {
+                    firstTcs.SetResult(true);
+                    return Task.FromResult(true);
+                });
+                subscriber.SubscribeAsync<BasicMessage>((message, context) =>
+                {
+                    secondTcs.SetResult(true);
+                    return Task.FromResult(true);
+                });
 
-				/* Test */
-				var ackTask = publisher.PublishAsync<BasicMessage>();
-				Task.WaitAll(ackTask, firstTcs.Task, secondTcs.Task);
+                /* Test */
+                var ackTask = publisher.PublishAsync<BasicMessage>();
+                Task.WaitAll(ackTask, firstTcs.Task, secondTcs.Task);
 
-				/* Assert */
-				Assert.True(true, "Published and subscribe sucessfull.");
-			}
-		}
+                /* Assert */
+                Assert.True(true, "Published and subscribe sucessfull.");
+            }
+        }
 
-		[Fact]
-		public void Should_Be_Able_To_Deliver_Messages_To_Unique_Subscribers()
-		{
-			/* Setup */
-			using (var firstSubscriber = TestClientFactory.CreateNormal())
-			using (var secondSubscriber = TestClientFactory.CreateNormal())
-			using (var publisher = TestClientFactory.CreateNormal())
-			{
-				var firstTcs = new TaskCompletionSource<bool>();
-				var secondTcs = new TaskCompletionSource<bool>();
-				firstSubscriber.SubscribeAsync<BasicMessage>((message, context) =>
-				{
-					firstTcs.SetResult(true);
-					return Task.FromResult(true);
-				}, cfg => cfg.WithSubscriberId("first_subscriber"));
-				secondSubscriber.SubscribeAsync<BasicMessage>((message, context) =>
-				{
-					secondTcs.SetResult(true);
-					return Task.FromResult(true);
-				}, cfg => cfg.WithSubscriberId("second_subscriber"));
+        [Fact]
+        public void Should_Be_Able_To_Deliver_Messages_To_Unique_Subscribers()
+        {
+            /* Setup */
+            using (var firstSubscriber = TestClientFactory.CreateNormal())
+            using (var secondSubscriber = TestClientFactory.CreateNormal())
+            using (var publisher = TestClientFactory.CreateNormal())
+            {
+                var firstTcs = new TaskCompletionSource<bool>();
+                var secondTcs = new TaskCompletionSource<bool>();
+                firstSubscriber.SubscribeAsync<BasicMessage>((message, context) =>
+                {
+                    firstTcs.SetResult(true);
+                    return Task.FromResult(true);
+                }, cfg => cfg.WithSubscriberId("first_subscriber"));
+                secondSubscriber.SubscribeAsync<BasicMessage>((message, context) =>
+                {
+                    secondTcs.SetResult(true);
+                    return Task.FromResult(true);
+                }, cfg => cfg.WithSubscriberId("second_subscriber"));
 
-				/* Test */
-				var ackTask = publisher.PublishAsync<BasicMessage>();
-				Task.WaitAll(ackTask, firstTcs.Task, secondTcs.Task);
+                /* Test */
+                var ackTask = publisher.PublishAsync<BasicMessage>();
+                Task.WaitAll(ackTask, firstTcs.Task, secondTcs.Task);
 
-				/* Assert */
-				Assert.True(true, "Published and subscribe sucessfull.");
+                /* Assert */
+                Assert.True(true, "Published and subscribe sucessfull.");
 
-			}
-		}
+            }
+        }
 
-		[Fact]
-		public async Task Should_Be_Able_To_Use_Priority()
-		{
-			/* Setup */
-			using (var subscriber = TestClientFactory.CreateNormal())
-			using (var publisher = TestClientFactory.CreateNormal())
-			{
-				var prioritySent = false;
-				var queueBuilt = new TaskCompletionSource<bool>();
-				var priorityTcs = new TaskCompletionSource<BasicMessage>();
-				subscriber.SubscribeAsync<BasicMessage>(async (message, context) =>
-				{
-					await queueBuilt.Task;
-					if (!prioritySent)
-					{
-						await subscriber.PublishAsync(new BasicMessage
-						{
-							Prop = "I am important!"
-						}, configuration: cfg => cfg.WithProperties(p =>
-						{
-							p.Priority = 3;
-						}));
-						prioritySent = true;
-					}
-					else
-					{
-						priorityTcs.TrySetResult(message);
-					}
+        [Fact]
+        public async Task Should_Be_Able_To_Use_Priority()
+        {
+            /* Setup */
+            using (var subscriber = TestClientFactory.CreateNormal())
+            using (var publisher = TestClientFactory.CreateNormal())
+            {
+                var prioritySent = false;
+                var queueBuilt = new TaskCompletionSource<bool>();
+                var priorityTcs = new TaskCompletionSource<BasicMessage>();
+                subscriber.SubscribeAsync<BasicMessage>(async (message, context) =>
+                {
+                    await queueBuilt.Task;
+                    if (!prioritySent)
+                    {
+                        await subscriber.PublishAsync(new BasicMessage
+                        {
+                            Prop = "I am important!"
+                        }, configuration: cfg => cfg.WithProperties(p =>
+                        {
+                            p.Priority = 3;
+                        }));
+                        prioritySent = true;
+                    }
+                    else
+                    {
+                        priorityTcs.TrySetResult(message);
+                    }
 
-				}, cfg => cfg
-					.WithQueue(q => q.WithArgument(QueueArgument.MaxPriority, 3))
-					.WithSubscriberId("priority")
-					.WithPrefetchCount(1));
+                }, cfg => cfg
+                    .WithQueue(q => q.WithArgument(QueueArgument.MaxPriority, 3))
+                    .WithSubscriberId("priority")
+                    .WithPrefetchCount(1));
 
-				/* Test */
-				await publisher.PublishAsync(new BasicMessage { Prop = "I will be delivered" });
-				await publisher.PublishAsync(new BasicMessage { Prop = "Someone will pass me in the queue" }, configuration: cfg => cfg.WithProperties(p => p.Priority = 0));
-				queueBuilt.SetResult(true);
-				await priorityTcs.Task;
+                /* Test */
+                await publisher.PublishAsync(new BasicMessage { Prop = "I will be delivered" });
+                await publisher.PublishAsync(new BasicMessage { Prop = "Someone will pass me in the queue" }, configuration: cfg => cfg.WithProperties(p => p.Priority = 0));
+                queueBuilt.SetResult(true);
+                await priorityTcs.Task;
 
-				/* Asset */
-				Assert.Equal(expected: "I am important!", actual: priorityTcs.Task.Result.Prop);
-			}
-		}
+                /* Asset */
+                Assert.Equal(expected: "I am important!", actual: priorityTcs.Task.Result.Prop);
+            }
+        }
 
-		[Fact]
-		public async Task Should_Stop_Subscribe_When_Subscription_Is_Disposed()
-		{
-			/* Setup */
-			using (var publisher = TestClientFactory.CreateNormal())
-			using (var subscriber = TestClientFactory.CreateNormal())
-			{
-				var firstMessage = new BasicMessage { Prop = "Value" };
-				var secondMessage = new BasicMessage { Prop = "AnotherValue" };
-				var firstRecievedTcs = new TaskCompletionSource<BasicMessage>();
-				var secondRecievedTcs = new TaskCompletionSource<BasicMessage>();
-				var recievedCount = 0;
+        [Fact]
+        public async Task Should_Stop_Subscribe_When_Subscription_Is_Disposed()
+        {
+            /* Setup */
+            using (var publisher = TestClientFactory.CreateNormal())
+            using (var subscriber = TestClientFactory.CreateNormal())
+            {
+                var firstMessage = new BasicMessage { Prop = "Value" };
+                var secondMessage = new BasicMessage { Prop = "AnotherValue" };
+                var firstRecievedTcs = new TaskCompletionSource<BasicMessage>();
+                var secondRecievedTcs = new TaskCompletionSource<BasicMessage>();
+                var recievedCount = 0;
 
-				var subscription = subscriber.SubscribeAsync<BasicMessage>((message, context) =>
-				{
-					recievedCount++;
-					if (!firstRecievedTcs.Task.IsCompleted)
-					{
-						firstRecievedTcs.SetResult(message);
-					}
-					return Task.FromResult(true);
-				}, cfg => cfg.WithQueue(q => q.WithAutoDelete(false)));
+                var subscription = subscriber.SubscribeAsync<BasicMessage>((message, context) =>
+                {
+                    recievedCount++;
+                    if (!firstRecievedTcs.Task.IsCompleted)
+                    {
+                        firstRecievedTcs.SetResult(message);
+                    }
+                    return Task.FromResult(true);
+                }, cfg => cfg.WithQueue(q => q.WithAutoDelete(false)));
 
-				/* Test */
-				publisher.PublishAsync(firstMessage);
-				await firstRecievedTcs.Task;
-				subscription.Dispose();
-				var recievedAfterFirstPublish = recievedCount;
-				publisher.PublishAsync(secondMessage);
-				await Task.Delay(20);
-				publisher.SubscribeAsync<BasicMessage>((message, context) =>
-				{
-					secondRecievedTcs.SetResult(message);
-					return Task.FromResult(true);
-				}, cfg => cfg.WithQueue(q => q.WithAutoDelete(false)));
-				await secondRecievedTcs.Task;
-				TestChannel.QueueDelete(subscription.QueueName);
-				/* Assert */
-				Assert.Equal(recievedAfterFirstPublish, recievedCount);
-				Assert.Equal(firstRecievedTcs.Task.Result.Prop, firstMessage.Prop);
-				Assert.Equal(secondRecievedTcs.Task.Result.Prop, secondMessage.Prop);
-			}
-		}
+                /* Test */
+                publisher.PublishAsync(firstMessage);
+                await firstRecievedTcs.Task;
+                subscription.Dispose();
+                var recievedAfterFirstPublish = recievedCount;
+                publisher.PublishAsync(secondMessage);
+                await Task.Delay(20);
+                publisher.SubscribeAsync<BasicMessage>((message, context) =>
+                {
+                    secondRecievedTcs.SetResult(message);
+                    return Task.FromResult(true);
+                }, cfg => cfg.WithQueue(q => q.WithAutoDelete(false)));
+                await secondRecievedTcs.Task;
+                TestChannel.QueueDelete(subscription.QueueName);
+                /* Assert */
+                Assert.Equal(recievedAfterFirstPublish, recievedCount);
+                Assert.Equal(firstRecievedTcs.Task.Result.Prop, firstMessage.Prop);
+                Assert.Equal(secondRecievedTcs.Task.Result.Prop, secondMessage.Prop);
+            }
+        }
 
-		[Fact]
-		public async Task Should_Be_Able_To_Subscibe_To_Pure_Json_Message()
-		{
-			var conventions = new NamingConventions();
-			using (var client = TestClientFactory.CreateNormal(ioc => ioc.AddSingleton<INamingConventions>(c => conventions)))
-			{
-				/* Setup */
-				var tcs = new TaskCompletionSource<BasicMessage>();
-				var subscription = client.SubscribeAsync<BasicMessage>((message, context) =>
-				{
-					tcs.TrySetResult(message);
-					return Task.FromResult(true);
-				});
-				var uniqueValue = Guid.NewGuid().ToString();
-				var jsonMsg = JsonConvert.SerializeObject(new BasicMessage { Prop = uniqueValue });
+        [Fact]
+        public async Task Should_Be_Able_To_Subscibe_To_Pure_Json_Message()
+        {
+            var conventions = new NamingConventions();
+            using (var client = TestClientFactory.CreateNormal(ioc => ioc.AddSingleton<INamingConventions>(c => conventions)))
+            {
+                /* Setup */
+                var tcs = new TaskCompletionSource<BasicMessage>();
+                var subscription = client.SubscribeAsync<BasicMessage>((message, context) =>
+                {
+                    tcs.TrySetResult(message);
+                    return Task.FromResult(true);
+                });
+                var uniqueValue = Guid.NewGuid().ToString();
+                var jsonMsg = JsonConvert.SerializeObject(new BasicMessage { Prop = uniqueValue });
 
-				/* Test */
-				TestChannel.BasicPublish(
-					conventions.ExchangeNamingConvention(typeof(BasicMessage)),
-					conventions.QueueNamingConvention(typeof(BasicMessage)),
-					true,
-					null,
-					Encoding.UTF8.GetBytes(jsonMsg));
-				await tcs.Task;
+                /* Test */
+                TestChannel.BasicPublish(
+                    conventions.ExchangeNamingConvention(typeof(BasicMessage)),
+                    conventions.QueueNamingConvention(typeof(BasicMessage)),
+                    true,
+                    null,
+                    Encoding.UTF8.GetBytes(jsonMsg));
+                await tcs.Task;
 
-				/* Assert */
-				Assert.Equal(uniqueValue, tcs.Task.Result.Prop);
-			}
-		}
+                /* Assert */
+                Assert.Equal(uniqueValue, tcs.Task.Result.Prop);
+            }
+        }
 
-		[Fact]
-		public async void Should_Be_Able_To_Publish_Dynamic_Objects()
-		{
-			using (var client = TestClientFactory.CreateNormal())
-			{
-				/* Setup */
-				var tcs = new TaskCompletionSource<DynamicMessage>();
-				client.SubscribeAsync<DynamicMessage>((message, context) =>
-				{
-					tcs.TrySetResult(message);
-					return Task.FromResult(true);
-				});
+        [Fact]
+        public async void Should_Be_Able_To_Publish_Dynamic_Objects()
+        {
+            using (var client = TestClientFactory.CreateNormal())
+            {
+                /* Setup */
+                var tcs = new TaskCompletionSource<DynamicMessage>();
+                client.SubscribeAsync<DynamicMessage>((message, context) =>
+                {
+                    tcs.TrySetResult(message);
+                    return Task.FromResult(true);
+                });
 
-				/* Test */
-				client.PublishAsync(new DynamicMessage { Body = new { IsDynamic = true } });
-				await tcs.Task;
+                /* Test */
+                client.PublishAsync(new DynamicMessage { Body = new { IsDynamic = true } });
+                await tcs.Task;
 
-				/* Assert */
-				Assert.True(tcs.Task.Result.Body.IsDynamic);
-			}
-		}
+                /* Assert */
+                Assert.True(tcs.Task.Result.Body.IsDynamic);
+            }
+        }
 
-		[Fact]
-		public async Task Should_Be_Able_To_Publish_Message_After_Failed_Publish()
-		{
-			using(var firstClient = TestClientFactory.CreateNormal())
-			using (var secondClient = TestClientFactory.CreateNormal())
-			{
-				/* Setup */
-				var tcs = new TaskCompletionSource<bool>();
-				firstClient.SubscribeAsync<SimpleMessage>((message, context) =>
-				{
-					tcs.TrySetResult(true);
-					return Task.FromResult(true);
-				});
+        [Fact]
+        public async Task Should_Be_Able_To_Publish_Message_After_Failed_Publish()
+        {
+            using(var firstClient = TestClientFactory.CreateNormal())
+            using (var secondClient = TestClientFactory.CreateNormal())
+            {
+                /* Setup */
+                var tcs = new TaskCompletionSource<bool>();
+                firstClient.SubscribeAsync<SimpleMessage>((message, context) =>
+                {
+                    tcs.TrySetResult(true);
+                    return Task.FromResult(true);
+                });
 
-				/* Test */
-				try
-				{
-					await
-						secondClient.PublishAsync(new SimpleMessage(),
-							configuration: cfg => cfg.WithExchange(e => e.WithType(ExchangeType.Direct)));
-				}
-				catch (Exception)
-				{
-					await Task.Delay(50);
-					Assert.False(tcs.Task.IsCompleted);
-				}
-				secondClient.PublishAsync(new SimpleMessage());
-				await tcs.Task;
-				/* Assert */
-				Assert.True(true);
-			}
-		}
+                /* Test */
+                try
+                {
+                    await
+                        secondClient.PublishAsync(new SimpleMessage(),
+                            configuration: cfg => cfg.WithExchange(e => e.WithType(ExchangeType.Direct)));
+                }
+                catch (Exception)
+                {
+                    await Task.Delay(50);
+                    Assert.False(tcs.Task.IsCompleted);
+                }
+                secondClient.PublishAsync(new SimpleMessage());
+                await tcs.Task;
+                /* Assert */
+                Assert.True(true);
+            }
+        }
 
-		[Fact]
-		public async Task Should_Run_Basic_Return_When_The_Manatory_Set_After_Failed_Publish()
-		{
-			/* Setup */
-			using (var client = TestClientFactory.CreateNormal())
-			{
-				var tcs = new TaskCompletionSource<bool>();
-				/* Test */
-				await client.PublishAsync(new SimpleMessage(),
-					configuration: cfg => cfg
-						.WithMandatoryDelivery((obj, evt) =>
-						{
-							tcs.SetResult(true);
-						}));
+        [Fact]
+        public async Task Should_Run_Basic_Return_When_The_Manatory_Set_After_Failed_Publish()
+        {
+            /* Setup */
+            using (var client = TestClientFactory.CreateNormal())
+            {
+                var tcs = new TaskCompletionSource<bool>();
+                /* Test */
+                await client.PublishAsync(new SimpleMessage(),
+                    configuration: cfg => cfg
+                        .WithMandatoryDelivery((obj, evt) =>
+                        {
+                            tcs.SetResult(true);
+                        }));
 
-				/* Assert */
-				Assert.True(tcs.Task.Result);
-			}
-		}
-	}
+                /* Assert */
+                Assert.True(tcs.Task.Result);
+            }
+        }
+    }
 }
 

--- a/test/RawRabbit.IntegrationTests/SimpleUse/RpcTest.cs
+++ b/test/RawRabbit.IntegrationTests/SimpleUse/RpcTest.cs
@@ -9,178 +9,178 @@ using Xunit;
 
 namespace RawRabbit.IntegrationTests.SimpleUse
 {
-	public class RpcTest : IntegrationTestBase
-	{
-		[Fact]
-		public async Task Should_Perform_Basic_Rpc_Without_Any_Config()
-		{
-			/* Setup */
-			using (var requester = TestClientFactory.CreateNormal())
-			using (var responder = TestClientFactory.CreateNormal())
-			{
-				var response = new BasicResponse { Prop = "This is the response." };
-				responder.RespondAsync<BasicRequest, BasicResponse>((req, i) =>
-				{
-					return Task.FromResult(response);
-				});
+    public class RpcTest : IntegrationTestBase
+    {
+        [Fact]
+        public async Task Should_Perform_Basic_Rpc_Without_Any_Config()
+        {
+            /* Setup */
+            using (var requester = TestClientFactory.CreateNormal())
+            using (var responder = TestClientFactory.CreateNormal())
+            {
+                var response = new BasicResponse { Prop = "This is the response." };
+                responder.RespondAsync<BasicRequest, BasicResponse>((req, i) =>
+                {
+                    return Task.FromResult(response);
+                });
 
-				/* Test */
-				var recieved = await requester.RequestAsync<BasicRequest, BasicResponse>();
+                /* Test */
+                var recieved = await requester.RequestAsync<BasicRequest, BasicResponse>();
 
-				/* Assert */
-				Assert.Equal(expected: response.Prop, actual: recieved.Prop);
-			}
-		}
+                /* Assert */
+                Assert.Equal(expected: response.Prop, actual: recieved.Prop);
+            }
+        }
 
-		[Fact]
-		public async Task Should_Perform_Basic_Rpc_For_Generic_Message_Types()
-		{
-			/* Setup */
-			using (var requester = TestClientFactory.CreateNormal())
-			using (var responder = TestClientFactory.CreateNormal())
-			{
-				var response = new GenericResponse<First, Second> { Prop = "This is the response." };
-				responder.RespondAsync<GenericRequest<First, Second>, GenericResponse<First, Second>>((req, i) =>
-				{
-					return Task.FromResult(response);
-				});
+        [Fact]
+        public async Task Should_Perform_Basic_Rpc_For_Generic_Message_Types()
+        {
+            /* Setup */
+            using (var requester = TestClientFactory.CreateNormal())
+            using (var responder = TestClientFactory.CreateNormal())
+            {
+                var response = new GenericResponse<First, Second> { Prop = "This is the response." };
+                responder.RespondAsync<GenericRequest<First, Second>, GenericResponse<First, Second>>((req, i) =>
+                {
+                    return Task.FromResult(response);
+                });
 
-				/* Test */
-				var recieved = await requester.RequestAsync<GenericRequest<First, Second>, GenericResponse<First, Second>>();
+                /* Test */
+                var recieved = await requester.RequestAsync<GenericRequest<First, Second>, GenericResponse<First, Second>>();
 
-				/* Assert */
-				Assert.Equal(expected: response.Prop, actual: recieved.Prop);
-			}
-		}
+                /* Assert */
+                Assert.Equal(expected: response.Prop, actual: recieved.Prop);
+            }
+        }
 
-		[Fact]
-		public async Task Should_Perform_Rpc_Without_Direct_Reply_To()
-		{
-			/* Setup */
-			using (var requester = TestClientFactory.CreateNormal())
-			using (var responder = TestClientFactory.CreateNormal())
-			{
-				var response = new BasicResponse { Prop = "This is the response." };
-				responder.RespondAsync<BasicRequest, BasicResponse>((req, i) =>
-				{
-					return Task.FromResult(response);
-				});
+        [Fact]
+        public async Task Should_Perform_Rpc_Without_Direct_Reply_To()
+        {
+            /* Setup */
+            using (var requester = TestClientFactory.CreateNormal())
+            using (var responder = TestClientFactory.CreateNormal())
+            {
+                var response = new BasicResponse { Prop = "This is the response." };
+                responder.RespondAsync<BasicRequest, BasicResponse>((req, i) =>
+                {
+                    return Task.FromResult(response);
+                });
 
-				/* Test */
-				var firstRecieved = await requester.RequestAsync<BasicRequest, BasicResponse>(new BasicRequest(),
-					configuration: cfg => cfg
-						.WithReplyQueue(
-							q => q
-								.WithName("special_reply_queue")
-								.WithAutoDelete())
-						.WithNoAck(false));
-				var secondRecieved = await requester.RequestAsync<BasicRequest, BasicResponse>(new BasicRequest(),
-					configuration: cfg => cfg
-						.WithReplyQueue(
-							q => q
-								.WithName("another_special_reply_queue")
-								.WithAutoDelete())
-						.WithNoAck(false)
-				);
+                /* Test */
+                var firstRecieved = await requester.RequestAsync<BasicRequest, BasicResponse>(new BasicRequest(),
+                    configuration: cfg => cfg
+                        .WithReplyQueue(
+                            q => q
+                                .WithName("special_reply_queue")
+                                .WithAutoDelete())
+                        .WithNoAck(false));
+                var secondRecieved = await requester.RequestAsync<BasicRequest, BasicResponse>(new BasicRequest(),
+                    configuration: cfg => cfg
+                        .WithReplyQueue(
+                            q => q
+                                .WithName("another_special_reply_queue")
+                                .WithAutoDelete())
+                        .WithNoAck(false)
+                );
 
-				/* Assert */
-				Assert.Equal(expected: response.Prop, actual: firstRecieved.Prop);
-				Assert.Equal(expected: response.Prop, actual: secondRecieved.Prop);
-			}
-		}
+                /* Assert */
+                Assert.Equal(expected: response.Prop, actual: firstRecieved.Prop);
+                Assert.Equal(expected: response.Prop, actual: secondRecieved.Prop);
+            }
+        }
 
-		[Fact]
-		public async Task Should_Succeed_With_Multiple_Rpc_Calls_At_The_Same_Time()
-		{
-			/* Setup */
-			using (var requester = TestClientFactory.CreateNormal())
-			using (var responder = TestClientFactory.CreateNormal())
-			{
-				var payloads = new List<Guid> { Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid() };
-				var uniqueResponse = new ConcurrentStack<Guid>(payloads);
-				responder.RespondAsync<BasicRequest, BasicResponse>((req, i) =>
-				{
-					Guid payload;
-					if (!uniqueResponse.TryPop(out payload))
-					{
-						Assert.True(false, "No entities in stack. Try purgin the response queue.");
-					};
-					return Task.FromResult(new BasicResponse { Payload = payload });
-				});
+        [Fact]
+        public async Task Should_Succeed_With_Multiple_Rpc_Calls_At_The_Same_Time()
+        {
+            /* Setup */
+            using (var requester = TestClientFactory.CreateNormal())
+            using (var responder = TestClientFactory.CreateNormal())
+            {
+                var payloads = new List<Guid> { Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid() };
+                var uniqueResponse = new ConcurrentStack<Guid>(payloads);
+                responder.RespondAsync<BasicRequest, BasicResponse>((req, i) =>
+                {
+                    Guid payload;
+                    if (!uniqueResponse.TryPop(out payload))
+                    {
+                        Assert.True(false, "No entities in stack. Try purgin the response queue.");
+                    };
+                    return Task.FromResult(new BasicResponse { Payload = payload });
+                });
 
-				/* Test */
-				var first = requester.RequestAsync<BasicRequest, BasicResponse>(new BasicRequest { Number = 1 });
-				var second = requester.RequestAsync<BasicRequest, BasicResponse>(new BasicRequest { Number = 2 });
-				var third = requester.RequestAsync<BasicRequest, BasicResponse>(new BasicRequest { Number = 3 });
-				Task.WaitAll(first, second, third);
+                /* Test */
+                var first = requester.RequestAsync<BasicRequest, BasicResponse>(new BasicRequest { Number = 1 });
+                var second = requester.RequestAsync<BasicRequest, BasicResponse>(new BasicRequest { Number = 2 });
+                var third = requester.RequestAsync<BasicRequest, BasicResponse>(new BasicRequest { Number = 3 });
+                Task.WaitAll(first, second, third);
 
-				/* Assert */
-				Assert.Contains(first.Result.Payload, payloads);
-				Assert.Contains(second.Result.Payload, payloads);
-				Assert.Contains(third.Result.Payload, payloads);
-				Assert.NotEqual(first.Result.Payload, second.Result.Payload);
-				Assert.NotEqual(second.Result.Payload, third.Result.Payload);
-				Assert.NotEqual(first.Result.Payload, third.Result.Payload);
-			}
-		}
+                /* Assert */
+                Assert.Contains(first.Result.Payload, payloads);
+                Assert.Contains(second.Result.Payload, payloads);
+                Assert.Contains(third.Result.Payload, payloads);
+                Assert.NotEqual(first.Result.Payload, second.Result.Payload);
+                Assert.NotEqual(second.Result.Payload, third.Result.Payload);
+                Assert.NotEqual(first.Result.Payload, third.Result.Payload);
+            }
+        }
 
-		[Fact]
-		public async Task Should_Successfully_Perform_Nested_Requests()
-		{
-			/* Setup */
-			using (var requester = TestClientFactory.CreateNormal())
-			using (var firstResponder = TestClientFactory.CreateNormal())
-			using (var secondResponder = TestClientFactory.CreateNormal())
-			{
-				var payload = Guid.NewGuid();
+        [Fact]
+        public async Task Should_Successfully_Perform_Nested_Requests()
+        {
+            /* Setup */
+            using (var requester = TestClientFactory.CreateNormal())
+            using (var firstResponder = TestClientFactory.CreateNormal())
+            using (var secondResponder = TestClientFactory.CreateNormal())
+            {
+                var payload = Guid.NewGuid();
 
-				firstResponder.RespondAsync<FirstRequest, FirstResponse>(async (req, i) =>
-				{
-					var secondResp = await firstResponder.RequestAsync<SecondRequest, SecondResponse>(new SecondRequest());
-					return new FirstResponse { Infered = secondResp.Source };
-				});
-				secondResponder.RespondAsync<SecondRequest, SecondResponse>((req, i) =>
-					Task.FromResult(new SecondResponse { Source = payload })
-				);
+                firstResponder.RespondAsync<FirstRequest, FirstResponse>(async (req, i) =>
+                {
+                    var secondResp = await firstResponder.RequestAsync<SecondRequest, SecondResponse>(new SecondRequest());
+                    return new FirstResponse { Infered = secondResp.Source };
+                });
+                secondResponder.RespondAsync<SecondRequest, SecondResponse>((req, i) =>
+                    Task.FromResult(new SecondResponse { Source = payload })
+                );
 
-				/* Test */
-				var response = await requester.RequestAsync<FirstRequest, FirstResponse>(new FirstRequest());
+                /* Test */
+                var response = await requester.RequestAsync<FirstRequest, FirstResponse>(new FirstRequest());
 
-				/* Assert */
-				Assert.Equal(expected: payload, actual: response.Infered);
-			}
-		}
+                /* Assert */
+                Assert.Equal(expected: payload, actual: response.Infered);
+            }
+        }
 
-		[Fact]
-		public async Task Should_Work_When_Not_Awaiting_One_Response_At_A_Time()
-		{
-			/* Setup */
-			using (var requester = TestClientFactory.CreateNormal())
-			using (var responder = TestClientFactory.CreateNormal())
-			{
-				const int numberOfCalls = 10;
-				var tasks = new Task[numberOfCalls];
+        [Fact]
+        public async Task Should_Work_When_Not_Awaiting_One_Response_At_A_Time()
+        {
+            /* Setup */
+            using (var requester = TestClientFactory.CreateNormal())
+            using (var responder = TestClientFactory.CreateNormal())
+            {
+                const int numberOfCalls = 10;
+                var tasks = new Task[numberOfCalls];
 
-				responder.RespondAsync<FirstRequest, FirstResponse>((req, i) =>
-					Task.FromResult(new FirstResponse { Infered = Guid.NewGuid() }),
-					cfg => cfg.WithQueue(q => q.WithAutoDelete()));
+                responder.RespondAsync<FirstRequest, FirstResponse>((req, i) =>
+                    Task.FromResult(new FirstResponse { Infered = Guid.NewGuid() }),
+                    cfg => cfg.WithQueue(q => q.WithAutoDelete()));
 
-				/* Test */
-				for (int i = 0; i < numberOfCalls; i++)
-				{
-					var responseTask = requester.RequestAsync<FirstRequest, FirstResponse>();
-					tasks[i] = responseTask;
-				}
-				Task.WaitAll(tasks);
-				var ids = tasks
-					.OfType<Task<FirstResponse>>()
-					.Select(t => t.Result.Infered)
-					.Distinct()
-					.ToList();
+                /* Test */
+                for (int i = 0; i < numberOfCalls; i++)
+                {
+                    var responseTask = requester.RequestAsync<FirstRequest, FirstResponse>();
+                    tasks[i] = responseTask;
+                }
+                Task.WaitAll(tasks);
+                var ids = tasks
+                    .OfType<Task<FirstResponse>>()
+                    .Select(t => t.Result.Infered)
+                    .Distinct()
+                    .ToList();
 
-				/* Assert */
-				Assert.Equal(expected: numberOfCalls, actual: ids.Count);
-			}
-		}
-	}
+                /* Assert */
+                Assert.Equal(expected: numberOfCalls, actual: ids.Count);
+            }
+        }
+    }
 }

--- a/test/RawRabbit.IntegrationTests/SimpleUse/SubscribeToDifferentMessageTypes.cs
+++ b/test/RawRabbit.IntegrationTests/SimpleUse/SubscribeToDifferentMessageTypes.cs
@@ -6,49 +6,49 @@ using Xunit;
 
 namespace RawRabbit.IntegrationTests.SimpleUse
 {
-	public class SubscribeToDifferentMessageTypes : IntegrationTestBase
-	{
-		[Fact]
-		public async Task Should_Be_Able_To_Recieve_Different_Types_Of_Messages()
-		{
-			/* Setup */
-			using (var publisher = TestClientFactory.CreateNormal())
-			using (var subscriber = TestClientFactory.CreateNormal())
-			{
-				var basicMsg = new BasicMessage { Prop = "Hello, world!" };
-				var simpleMsg = new SimpleMessage { IsSimple = true };
+    public class SubscribeToDifferentMessageTypes : IntegrationTestBase
+    {
+        [Fact]
+        public async Task Should_Be_Able_To_Recieve_Different_Types_Of_Messages()
+        {
+            /* Setup */
+            using (var publisher = TestClientFactory.CreateNormal())
+            using (var subscriber = TestClientFactory.CreateNormal())
+            {
+                var basicMsg = new BasicMessage { Prop = "Hello, world!" };
+                var simpleMsg = new SimpleMessage { IsSimple = true };
 
-				var basicMsgTcs = new TaskCompletionSource<BasicMessage>();
-				var simpleMsgTcs = new TaskCompletionSource<SimpleMessage>();
+                var basicMsgTcs = new TaskCompletionSource<BasicMessage>();
+                var simpleMsgTcs = new TaskCompletionSource<SimpleMessage>();
 
-				subscriber.SubscribeAsync<BasicMessage>((msg, i) =>
-				{
-					basicMsgTcs.SetResult(msg);
-					return basicMsgTcs.Task;
-				});
-				subscriber.SubscribeAsync<SimpleMessage>((msg, i) =>
-				{
-					simpleMsgTcs.SetResult(msg);
-					return basicMsgTcs.Task;
-				});
+                subscriber.SubscribeAsync<BasicMessage>((msg, i) =>
+                {
+                    basicMsgTcs.SetResult(msg);
+                    return basicMsgTcs.Task;
+                });
+                subscriber.SubscribeAsync<SimpleMessage>((msg, i) =>
+                {
+                    simpleMsgTcs.SetResult(msg);
+                    return basicMsgTcs.Task;
+                });
 
-				/* Test */
-				publisher.PublishAsync(basicMsg);
-				publisher.PublishAsync(simpleMsg);
-				Task.WaitAll(basicMsgTcs.Task, simpleMsgTcs.Task);
+                /* Test */
+                publisher.PublishAsync(basicMsg);
+                publisher.PublishAsync(simpleMsg);
+                Task.WaitAll(basicMsgTcs.Task, simpleMsgTcs.Task);
 
-				/* Assert */
-				Assert.Equal(expected: basicMsg.Prop, actual: basicMsgTcs.Task.Result.Prop);
-				Assert.Equal(expected: simpleMsg.IsSimple, actual: simpleMsgTcs.Task.Result.IsSimple);
-			}
-		}
+                /* Assert */
+                Assert.Equal(expected: basicMsg.Prop, actual: basicMsgTcs.Task.Result.Prop);
+                Assert.Equal(expected: simpleMsg.IsSimple, actual: simpleMsgTcs.Task.Result.IsSimple);
+            }
+        }
 
-		public override void Dispose()
-		{
-			TestChannel.ExchangeDelete("rawrabbit.integrationtests.testmessages");
-			TestChannel.QueueDelete("basicmessage");
-			TestChannel.QueueDelete("simplemessage");
-			base.Dispose();
-		}
-	}
+        public override void Dispose()
+        {
+            TestChannel.ExchangeDelete("rawrabbit.integrationtests.testmessages");
+            TestChannel.QueueDelete("basicmessage");
+            TestChannel.QueueDelete("simplemessage");
+            base.Dispose();
+        }
+    }
 }

--- a/test/RawRabbit.IntegrationTests/SimpleUse/TopicExchangeTests.cs
+++ b/test/RawRabbit.IntegrationTests/SimpleUse/TopicExchangeTests.cs
@@ -7,63 +7,63 @@ using ExchangeType = RawRabbit.Configuration.Exchange.ExchangeType;
 
 namespace RawRabbit.IntegrationTests.SimpleUse
 {
-	public class TopicExchangeTests : IntegrationTestBase
-	{
-		public TopicExchangeTests()
-		{
-			TestChannel.ExchangeDelete("rawrabbit.integrationtests.testmessages");
-			TestChannel.QueueDelete("basicmessage");
-			TestChannel.QueueDelete("simplemessage");
-		}
+    public class TopicExchangeTests : IntegrationTestBase
+    {
+        public TopicExchangeTests()
+        {
+            TestChannel.ExchangeDelete("rawrabbit.integrationtests.testmessages");
+            TestChannel.QueueDelete("basicmessage");
+            TestChannel.QueueDelete("simplemessage");
+        }
 
-		public override void Dispose()
-		{
-			TestChannel.ExchangeDelete("rawrabbit.integrationtests.testmessages");
-			TestChannel.QueueDelete("basicmessage");
-			TestChannel.QueueDelete("simplemessage");
-			base.Dispose();
-		}
+        public override void Dispose()
+        {
+            TestChannel.ExchangeDelete("rawrabbit.integrationtests.testmessages");
+            TestChannel.QueueDelete("basicmessage");
+            TestChannel.QueueDelete("simplemessage");
+            base.Dispose();
+        }
 
-		[Fact]
-		public async Task Should_Deliver_Message_To_All_Subscribers_On_Exchange()
-		{
-			/* Setup */
-			using (var publisher = TestClientFactory.CreateNormal())
-			using (var firstSubscriber = TestClientFactory.CreateNormal())
-			using (var secondSubscriber = TestClientFactory.CreateNormal())
-			{
-				var firstMsgTcs = new TaskCompletionSource<BasicMessage>();
-				var secondMsgTcs = new TaskCompletionSource<BasicMessage>();
+        [Fact]
+        public async Task Should_Deliver_Message_To_All_Subscribers_On_Exchange()
+        {
+            /* Setup */
+            using (var publisher = TestClientFactory.CreateNormal())
+            using (var firstSubscriber = TestClientFactory.CreateNormal())
+            using (var secondSubscriber = TestClientFactory.CreateNormal())
+            {
+                var firstMsgTcs = new TaskCompletionSource<BasicMessage>();
+                var secondMsgTcs = new TaskCompletionSource<BasicMessage>();
 
-				firstSubscriber.SubscribeAsync<BasicMessage>((msg, i) =>
-				{
-					firstMsgTcs.SetResult(msg);
-					return firstMsgTcs.Task;
-				}, cfg => cfg
-					.WithQueue(q => q
-						.WithName("first.topic.queue"))
-					.WithRoutingKey("*.topic.queue")
-					.WithExchange(e => e.WithType(ExchangeType.Topic)));
-				secondSubscriber.SubscribeAsync<BasicMessage>((msg, i) =>
-				{
-					secondMsgTcs.SetResult(msg);
-					return firstMsgTcs.Task;
-				}, cfg => cfg
-					.WithQueue(q => q
-						.WithName("second.topic.queue"))
-					.WithRoutingKey("*.topic.queue")
-					.WithExchange(e => e.AssumeInitialized()));
+                firstSubscriber.SubscribeAsync<BasicMessage>((msg, i) =>
+                {
+                    firstMsgTcs.SetResult(msg);
+                    return firstMsgTcs.Task;
+                }, cfg => cfg
+                    .WithQueue(q => q
+                        .WithName("first.topic.queue"))
+                    .WithRoutingKey("*.topic.queue")
+                    .WithExchange(e => e.WithType(ExchangeType.Topic)));
+                secondSubscriber.SubscribeAsync<BasicMessage>((msg, i) =>
+                {
+                    secondMsgTcs.SetResult(msg);
+                    return firstMsgTcs.Task;
+                }, cfg => cfg
+                    .WithQueue(q => q
+                        .WithName("second.topic.queue"))
+                    .WithRoutingKey("*.topic.queue")
+                    .WithExchange(e => e.AssumeInitialized()));
 
-				/* Test */
-				await publisher.PublishAsync(new BasicMessage(), configuration: cfg => cfg
-					 .WithExchange(exchange => exchange.AssumeInitialized())
-					 .WithRoutingKey("this.topic.queue"));
-				Task.WaitAll(firstMsgTcs.Task, secondMsgTcs.Task);
+                /* Test */
+                await publisher.PublishAsync(new BasicMessage(), configuration: cfg => cfg
+                     .WithExchange(exchange => exchange.AssumeInitialized())
+                     .WithRoutingKey("this.topic.queue"));
+                Task.WaitAll(firstMsgTcs.Task, secondMsgTcs.Task);
 
-				/* Assert */
-				Assert.NotNull(firstMsgTcs.Task.Result);
-				Assert.NotNull(secondMsgTcs.Task.Result);
-			}
-		}
-	}
+                /* Assert */
+                Assert.NotNull(firstMsgTcs.Task.Result);
+                Assert.NotNull(secondMsgTcs.Task.Result);
+            }
+        }
+    }
 }

--- a/test/RawRabbit.IntegrationTests/SimpleUse/WorkerQueuesTest.cs
+++ b/test/RawRabbit.IntegrationTests/SimpleUse/WorkerQueuesTest.cs
@@ -6,59 +6,59 @@ using Xunit;
 
 namespace RawRabbit.IntegrationTests.SimpleUse
 {
-	public class WorkerQueuesTest : IntegrationTestBase
-	{
-		[Fact]
-		public async Task Should_Call_Handle_Method_Just_As_Many_Times_As_Published()
-		{
-			/* Setup */
-			using (var firstWorker = TestClientFactory.CreateNormal())
-			using (var secondWorker = TestClientFactory.CreateNormal())
-			using (var publisher = TestClientFactory.CreateNormal())
-			{
-				var allCallTcs = new TaskCompletionSource<int>();
-				const int noOfPublishes = 8;
-				var firstWorkerCalls = 0;
-				var secondWorkerCalls = 0;
+    public class WorkerQueuesTest : IntegrationTestBase
+    {
+        [Fact]
+        public async Task Should_Call_Handle_Method_Just_As_Many_Times_As_Published()
+        {
+            /* Setup */
+            using (var firstWorker = TestClientFactory.CreateNormal())
+            using (var secondWorker = TestClientFactory.CreateNormal())
+            using (var publisher = TestClientFactory.CreateNormal())
+            {
+                var allCallTcs = new TaskCompletionSource<int>();
+                const int noOfPublishes = 8;
+                var firstWorkerCalls = 0;
+                var secondWorkerCalls = 0;
 
-				firstWorker.SubscribeAsync<BasicMessage>((msg, i) =>
-				{
-					firstWorkerCalls++;
-					if (firstWorkerCalls + secondWorkerCalls == noOfPublishes)
-					{
-						allCallTcs.SetResult(noOfPublishes);
-					}
-					return Task.FromResult(true);
-				}, cfg => cfg.WithPrefetchCount(1));
-				secondWorker.SubscribeAsync<BasicMessage>((msg, i) =>
-				{
-					secondWorkerCalls++;
-					if (firstWorkerCalls + secondWorkerCalls == noOfPublishes)
-					{
-						allCallTcs.SetResult(noOfPublishes);
-					}
-					return allCallTcs.Task;
-				}, cfg => cfg.WithPrefetchCount(1));
+                firstWorker.SubscribeAsync<BasicMessage>((msg, i) =>
+                {
+                    firstWorkerCalls++;
+                    if (firstWorkerCalls + secondWorkerCalls == noOfPublishes)
+                    {
+                        allCallTcs.SetResult(noOfPublishes);
+                    }
+                    return Task.FromResult(true);
+                }, cfg => cfg.WithPrefetchCount(1));
+                secondWorker.SubscribeAsync<BasicMessage>((msg, i) =>
+                {
+                    secondWorkerCalls++;
+                    if (firstWorkerCalls + secondWorkerCalls == noOfPublishes)
+                    {
+                        allCallTcs.SetResult(noOfPublishes);
+                    }
+                    return allCallTcs.Task;
+                }, cfg => cfg.WithPrefetchCount(1));
 
-				/* Test */
-				for (var i = 0; i < noOfPublishes; i++)
-				{
-					publisher.PublishAsync(new BasicMessage());
-				}
-				await allCallTcs.Task;
+                /* Test */
+                for (var i = 0; i < noOfPublishes; i++)
+                {
+                    publisher.PublishAsync(new BasicMessage());
+                }
+                await allCallTcs.Task;
 
-				/* Assert */
-				Assert.Equal(expected: noOfPublishes, actual: firstWorkerCalls + secondWorkerCalls);
-				Assert.NotEqual(firstWorkerCalls, 0);
-				Assert.NotEqual(secondWorkerCalls, 0);
-			}
-		}
+                /* Assert */
+                Assert.Equal(expected: noOfPublishes, actual: firstWorkerCalls + secondWorkerCalls);
+                Assert.NotEqual(firstWorkerCalls, 0);
+                Assert.NotEqual(secondWorkerCalls, 0);
+            }
+        }
 
-		public override void Dispose()
-		{
-			TestChannel.ExchangeDelete("rawrabbit.integrationtests.testmessages");
-			TestChannel.QueueDelete("basicmessage");
-			base.Dispose();
-		}
-	}
+        public override void Dispose()
+        {
+            TestChannel.ExchangeDelete("rawrabbit.integrationtests.testmessages");
+            TestChannel.QueueDelete("basicmessage");
+            base.Dispose();
+        }
+    }
 }

--- a/test/RawRabbit.IntegrationTests/TestClientFactory.cs
+++ b/test/RawRabbit.IntegrationTests/TestClientFactory.cs
@@ -10,44 +10,44 @@ using RawRabbit.vNext;
 
 namespace RawRabbit.IntegrationTests
 {
-	public class TestClientFactory
-	{
-		public static vNext.Disposable.IBusClient CreateNormal(Action<IServiceCollection> action = null, Action<IConfigurationBuilder> config = null)
-		{
-			action = AddTestConfig(action);
-			return BusClientFactory.CreateDefault(config, action);
-		}
+    public class TestClientFactory
+    {
+        public static vNext.Disposable.IBusClient CreateNormal(Action<IServiceCollection> action = null, Action<IConfigurationBuilder> config = null)
+        {
+            action = AddTestConfig(action);
+            return BusClientFactory.CreateDefault(config, action);
+        }
 
-		public static vNext.Disposable.IBusClient<TMessageContext> CreateNormal<TMessageContext>(Action<IServiceCollection> action = null,
-			Action<IConfigurationBuilder> config = null) where TMessageContext : IMessageContext
-		{
-			action = AddTestConfig(action);
-			return BusClientFactory.CreateDefault<TMessageContext>(config, action);
-		}
+        public static vNext.Disposable.IBusClient<TMessageContext> CreateNormal<TMessageContext>(Action<IServiceCollection> action = null,
+            Action<IConfigurationBuilder> config = null) where TMessageContext : IMessageContext
+        {
+            action = AddTestConfig(action);
+            return BusClientFactory.CreateDefault<TMessageContext>(config, action);
+        }
 
-		public static RawRabbit.Extensions.Disposable.IBusClient CreateExtendable(Action<IServiceCollection> custom = null)
-		{
-			custom = AddTestConfig(custom);
-			return RawRabbitFactory.Create(custom);
-		}
+        public static RawRabbit.Extensions.Disposable.IBusClient CreateExtendable(Action<IServiceCollection> custom = null)
+        {
+            custom = AddTestConfig(custom);
+            return RawRabbitFactory.Create(custom);
+        }
 
-		private static Action<IServiceCollection> AddTestConfig(Action<IServiceCollection> action)
-		{
-			action = action ?? (collection => { });
-			action += collection =>
-			{
-				var prevRegged = collection
-					.LastOrDefault(c => c.ServiceType == typeof(RawRabbitConfiguration))?
-					.ImplementationFactory(null) as RawRabbitConfiguration;
-				if (prevRegged != null)
-				{
-					prevRegged.Queue.AutoDelete = true;
-					collection.AddSingleton<RawRabbitConfiguration>(p => prevRegged);
-				}
+        private static Action<IServiceCollection> AddTestConfig(Action<IServiceCollection> action)
+        {
+            action = action ?? (collection => { });
+            action += collection =>
+            {
+                var prevRegged = collection
+                    .LastOrDefault(c => c.ServiceType == typeof(RawRabbitConfiguration))?
+                    .ImplementationFactory(null) as RawRabbitConfiguration;
+                if (prevRegged != null)
+                {
+                    prevRegged.Queue.AutoDelete = true;
+                    collection.AddSingleton<RawRabbitConfiguration>(p => prevRegged);
+                }
 
-				collection.AddSingleton<ILoggerFactory, VoidLoggerFactory>();
-			};
-			return action;
-		}
-	}
+                collection.AddSingleton<ILoggerFactory, VoidLoggerFactory>();
+            };
+            return action;
+        }
+    }
 }

--- a/test/RawRabbit.IntegrationTests/TestMessages/BasicMessage.cs
+++ b/test/RawRabbit.IntegrationTests/TestMessages/BasicMessage.cs
@@ -1,7 +1,7 @@
 ﻿namespace RawRabbit.IntegrationTests.TestMessages
 {
-	public class BasicMessage
-	{
-		public string Prop { get; set; }
-	}
+    public class BasicMessage
+    {
+        public string Prop { get; set; }
+    }
 }

--- a/test/RawRabbit.IntegrationTests/TestMessages/BasicRequest.cs
+++ b/test/RawRabbit.IntegrationTests/TestMessages/BasicRequest.cs
@@ -1,7 +1,7 @@
 ﻿namespace RawRabbit.IntegrationTests.TestMessages
 {
-	public class BasicRequest
-	{
-		public int Number { get; set; }
-	}
+    public class BasicRequest
+    {
+        public int Number { get; set; }
+    }
 }

--- a/test/RawRabbit.IntegrationTests/TestMessages/BasicResponse.cs
+++ b/test/RawRabbit.IntegrationTests/TestMessages/BasicResponse.cs
@@ -2,9 +2,9 @@
 
 namespace RawRabbit.IntegrationTests.TestMessages
 {
-	public class BasicResponse
-	{
-		public string Prop { get; set; }
-		public Guid Payload { get; set; }
-	}
+    public class BasicResponse
+    {
+        public string Prop { get; set; }
+        public Guid Payload { get; set; }
+    }
 }

--- a/test/RawRabbit.IntegrationTests/TestMessages/DynamicMessage.cs
+++ b/test/RawRabbit.IntegrationTests/TestMessages/DynamicMessage.cs
@@ -1,7 +1,7 @@
 ﻿namespace RawRabbit.IntegrationTests.TestMessages
 {
-	public class DynamicMessage
-	{
-		public dynamic Body { get; set; }
-	}
+    public class DynamicMessage
+    {
+        public dynamic Body { get; set; }
+    }
 }

--- a/test/RawRabbit.IntegrationTests/TestMessages/FirstRequest.cs
+++ b/test/RawRabbit.IntegrationTests/TestMessages/FirstRequest.cs
@@ -1,7 +1,7 @@
 ﻿namespace RawRabbit.IntegrationTests.TestMessages
 {
-	public class FirstRequest
-	{
+    public class FirstRequest
+    {
 
-	}
+    }
 }

--- a/test/RawRabbit.IntegrationTests/TestMessages/FirstResponse.cs
+++ b/test/RawRabbit.IntegrationTests/TestMessages/FirstResponse.cs
@@ -2,8 +2,8 @@
 
 namespace RawRabbit.IntegrationTests.TestMessages
 {
-	public class FirstResponse
-	{
-		public Guid Infered { get; set; }
-	}
+    public class FirstResponse
+    {
+        public Guid Infered { get; set; }
+    }
 }

--- a/test/RawRabbit.IntegrationTests/TestMessages/GenericRequest.cs
+++ b/test/RawRabbit.IntegrationTests/TestMessages/GenericRequest.cs
@@ -1,13 +1,13 @@
 ﻿namespace RawRabbit.IntegrationTests.TestMessages
 {
-	public class First { }
-	public class Second { }
-	public class GenericRequest<TFirst, TSecond>
-	{
-	}
+    public class First { }
+    public class Second { }
+    public class GenericRequest<TFirst, TSecond>
+    {
+    }
 
-	public class GenericResponse<TFirst, TSecond>
-	{
-		public string Prop { get; set; }
-	}
+    public class GenericResponse<TFirst, TSecond>
+    {
+        public string Prop { get; set; }
+    }
 }

--- a/test/RawRabbit.IntegrationTests/TestMessages/NumberedMessages.cs
+++ b/test/RawRabbit.IntegrationTests/TestMessages/NumberedMessages.cs
@@ -1,8 +1,8 @@
 ﻿namespace RawRabbit.IntegrationTests.TestMessages
 {
-	public class FirstMessage { }
-	public class SecondMessage { }
-	public class ThirdMessage { }
-	public class ForthMessage { }
-	public class FifthMessage { }
+    public class FirstMessage { }
+    public class SecondMessage { }
+    public class ThirdMessage { }
+    public class ForthMessage { }
+    public class FifthMessage { }
 }

--- a/test/RawRabbit.IntegrationTests/TestMessages/SecondRequest.cs
+++ b/test/RawRabbit.IntegrationTests/TestMessages/SecondRequest.cs
@@ -1,6 +1,6 @@
 ﻿namespace RawRabbit.IntegrationTests.TestMessages
 {
-	public class SecondRequest
-	{
-	}
+    public class SecondRequest
+    {
+    }
 }

--- a/test/RawRabbit.IntegrationTests/TestMessages/SecondResponse.cs
+++ b/test/RawRabbit.IntegrationTests/TestMessages/SecondResponse.cs
@@ -2,8 +2,8 @@
 
 namespace RawRabbit.IntegrationTests.TestMessages
 {
-	public class SecondResponse
-	{
-		public Guid Source { get; set; }
-	}
+    public class SecondResponse
+    {
+        public Guid Source { get; set; }
+    }
 }

--- a/test/RawRabbit.IntegrationTests/TestMessages/SimpleMessage.cs
+++ b/test/RawRabbit.IntegrationTests/TestMessages/SimpleMessage.cs
@@ -1,7 +1,7 @@
 ﻿namespace RawRabbit.IntegrationTests.TestMessages
 {
-	public class SimpleMessage
-	{
-		public bool IsSimple { get; set; }
-	}
+    public class SimpleMessage
+    {
+        public bool IsSimple { get; set; }
+    }
 }

--- a/test/RawRabbit.IntegrationTests/project.json
+++ b/test/RawRabbit.IntegrationTests/project.json
@@ -1,32 +1,32 @@
 ﻿{
-	"version": "1.0.0-*",
-	"authors": [ "par.dahlman" ],
-	"testRunner": "xunit",
+    "version": "1.0.0-*",
+    "authors": [ "par.dahlman" ],
+    "testRunner": "xunit",
 
-	"dependencies": {
-		"RawRabbit": { "target": "project" },
-		"RawRabbit.DependencyInjection.Autofac": { "target": "project" },
-		"RawRabbit.DependencyInjection.Ninject": { "target": "project" },
-		"RawRabbit.Attributes": { "target": "project" },
-		"RawRabbit.Extensions": { "target": "project" },
-		"RawRabbit.vNext": { "target": "project" },
-		"Moq": "4.6.38-alpha",
-		"xunit": "2.2.0-beta2-build3300",
-		"dotnet-test-xunit": "2.2.0-preview2-build1029"
-	},
-	"frameworks": {
-		"net451" :  {} 
-		//"netcoreapp1.0": {
-		//	"dependencies": {
-		//		"Microsoft.NETCore.App": {
-		//			"type": "platform",
-		//			"version": "1.0.0"
-		//		}
-		//	},
-		//	"imports": [
-		//		"dotnet5.4",
-		//		"portable-net451+win8"
-		//	]
-		//}
-	}
+    "dependencies": {
+        "RawRabbit": { "target": "project" },
+        "RawRabbit.DependencyInjection.Autofac": { "target": "project" },
+        "RawRabbit.DependencyInjection.Ninject": { "target": "project" },
+        "RawRabbit.Attributes": { "target": "project" },
+        "RawRabbit.Extensions": { "target": "project" },
+        "RawRabbit.vNext": { "target": "project" },
+        "Moq": "4.6.38-alpha",
+        "xunit": "2.2.0-beta2-build3300",
+        "dotnet-test-xunit": "2.2.0-preview2-build1029"
+    },
+    "frameworks": {
+        "net451" :  {} 
+        //"netcoreapp1.0": {
+        //    "dependencies": {
+        //        "Microsoft.NETCore.App": {
+        //            "type": "platform",
+        //            "version": "1.0.0"
+        //        }
+        //    },
+        //    "imports": [
+        //        "dotnet5.4",
+        //        "portable-net451+win8"
+        //    ]
+        //}
+    }
 }

--- a/test/RawRabbit.Tests/Channel/ChannelFactoryTests.cs
+++ b/test/RawRabbit.Tests/Channel/ChannelFactoryTests.cs
@@ -10,141 +10,141 @@ using Xunit;
 
 namespace RawRabbit.Tests.Channel
 {
-	public class ChannelFactoryTests
-	{
-		private readonly Mock<IConnectionFactory> _connectionFactory;
-		private readonly RawRabbitConfiguration _config;
-		private readonly ChannelFactoryConfiguration _channelConfig;
-		private readonly Mock<IConnection> _connection;
-		private readonly Mock<IModel> _firstChannel;
-		private readonly Mock<IModel> _secondChannel;
-		private readonly Mock<IModel> _thirdChannel;
+    public class ChannelFactoryTests
+    {
+        private readonly Mock<IConnectionFactory> _connectionFactory;
+        private readonly RawRabbitConfiguration _config;
+        private readonly ChannelFactoryConfiguration _channelConfig;
+        private readonly Mock<IConnection> _connection;
+        private readonly Mock<IModel> _firstChannel;
+        private readonly Mock<IModel> _secondChannel;
+        private readonly Mock<IModel> _thirdChannel;
 
-		public ChannelFactoryTests()
-		{
-			LogManager.CurrentFactory = new VoidLoggerFactory();
-			_connectionFactory = new Mock<IConnectionFactory>();
-			_connection = new Mock<IConnection>();
-			_firstChannel = new Mock<IModel>();
-			_secondChannel = new Mock<IModel>();
-			_thirdChannel = new Mock<IModel>();
-			_config = RawRabbitConfiguration.Local;
-			_channelConfig = ChannelFactoryConfiguration.Default;
+        public ChannelFactoryTests()
+        {
+            LogManager.CurrentFactory = new VoidLoggerFactory();
+            _connectionFactory = new Mock<IConnectionFactory>();
+            _connection = new Mock<IConnection>();
+            _firstChannel = new Mock<IModel>();
+            _secondChannel = new Mock<IModel>();
+            _thirdChannel = new Mock<IModel>();
+            _config = RawRabbitConfiguration.Local;
+            _channelConfig = ChannelFactoryConfiguration.Default;
 
-			_connectionFactory
-				.Setup(c => c.CreateConnection(It.IsAny<IList<string>>()))
-				.Returns(_connection.Object);
-		}
+            _connectionFactory
+                .Setup(c => c.CreateConnection(It.IsAny<IList<string>>()))
+                .Returns(_connection.Object);
+        }
 
-		[Theory]
-		[InlineData(0)]
-		[InlineData(1)]
-		[InlineData(2)]
-		[InlineData(3)]
-		public async Task Should_Create_Initial_Channels_Based_On_Config(int initialChannelCount)
-		{
-			/* Setup */
-			_channelConfig.MaxChannelCount = initialChannelCount;
-			_channelConfig.InitialChannelCount = initialChannelCount;
-			_connection
-				.Setup(c => c.IsOpen)
-				.Returns(true);
-			_connection
-				.Setup(c=> c.CreateModel())
-				.Returns(_firstChannel.Object)
-				.Verifiable();
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(2)]
+        [InlineData(3)]
+        public async Task Should_Create_Initial_Channels_Based_On_Config(int initialChannelCount)
+        {
+            /* Setup */
+            _channelConfig.MaxChannelCount = initialChannelCount;
+            _channelConfig.InitialChannelCount = initialChannelCount;
+            _connection
+                .Setup(c => c.IsOpen)
+                .Returns(true);
+            _connection
+                .Setup(c=> c.CreateModel())
+                .Returns(_firstChannel.Object)
+                .Verifiable();
 
-			/* Test */
-			var factory = new ChannelFactory(_connectionFactory.Object, _config, _channelConfig);
+            /* Test */
+            var factory = new ChannelFactory(_connectionFactory.Object, _config, _channelConfig);
 
-			/* Assert */
-			_connection.Verify(c => c.CreateModel(), Times.Exactly(initialChannelCount));
-		}
+            /* Assert */
+            _connection.Verify(c => c.CreateModel(), Times.Exactly(initialChannelCount));
+        }
 
-		[Fact]
-		public async Task Should_Round_Robin_Between_Existing_Channels()
-		{
-			/* Setup */
-			_channelConfig.MaxChannelCount = 3;
-			_channelConfig.InitialChannelCount = 3;
-			_connection
-				.Setup(c => c.IsOpen)
-				.Returns(true);
-			_connection
-				.SetupSequence(c => c.CreateModel())
-				.Returns(_thirdChannel.Object)
-				.Returns(_firstChannel.Object)
-				.Returns(_secondChannel.Object);
-			_firstChannel
-				.Setup(c => c.IsOpen)
-				.Returns(true);
-			_secondChannel
-				.Setup(c => c.IsOpen)
-				.Returns(true);
-			_thirdChannel
-				.Setup(c => c.IsOpen)
-				.Returns(true);
-			var factory = new ChannelFactory(_connectionFactory.Object, _config, _channelConfig);
+        [Fact]
+        public async Task Should_Round_Robin_Between_Existing_Channels()
+        {
+            /* Setup */
+            _channelConfig.MaxChannelCount = 3;
+            _channelConfig.InitialChannelCount = 3;
+            _connection
+                .Setup(c => c.IsOpen)
+                .Returns(true);
+            _connection
+                .SetupSequence(c => c.CreateModel())
+                .Returns(_thirdChannel.Object)
+                .Returns(_firstChannel.Object)
+                .Returns(_secondChannel.Object);
+            _firstChannel
+                .Setup(c => c.IsOpen)
+                .Returns(true);
+            _secondChannel
+                .Setup(c => c.IsOpen)
+                .Returns(true);
+            _thirdChannel
+                .Setup(c => c.IsOpen)
+                .Returns(true);
+            var factory = new ChannelFactory(_connectionFactory.Object, _config, _channelConfig);
 
-			/* Test */
-			var first = await factory.GetChannelAsync();
-			var second = await factory.GetChannelAsync();
-			var third = await factory.GetChannelAsync();
-			var firstAgain = await factory.GetChannelAsync();
-			var secondAgain = await factory.GetChannelAsync();
-			var thirdAgain = await factory.GetChannelAsync();
+            /* Test */
+            var first = await factory.GetChannelAsync();
+            var second = await factory.GetChannelAsync();
+            var third = await factory.GetChannelAsync();
+            var firstAgain = await factory.GetChannelAsync();
+            var secondAgain = await factory.GetChannelAsync();
+            var thirdAgain = await factory.GetChannelAsync();
 
-			/* Assert */
-			Assert.Equal(first, _firstChannel.Object);
-			Assert.Equal(second, _secondChannel.Object);
-			Assert.Equal(third, _thirdChannel.Object);
-			Assert.Equal(firstAgain, _firstChannel.Object);
-			Assert.Equal(secondAgain, _secondChannel.Object);
-			Assert.Equal(thirdAgain, _thirdChannel.Object);
-		}
+            /* Assert */
+            Assert.Equal(first, _firstChannel.Object);
+            Assert.Equal(second, _secondChannel.Object);
+            Assert.Equal(third, _thirdChannel.Object);
+            Assert.Equal(firstAgain, _firstChannel.Object);
+            Assert.Equal(secondAgain, _secondChannel.Object);
+            Assert.Equal(thirdAgain, _thirdChannel.Object);
+        }
 
-		[Fact]
-		public async Task Should_Not_Return_Close_Channel()
-		{
-			/* Setup */
-			_channelConfig.MaxChannelCount = 3;
-			_channelConfig.InitialChannelCount = 3;
-			_connection
-				.Setup(c => c.IsOpen)
-				.Returns(true);
-			_connection
-				.SetupSequence(c => c.CreateModel())
-				.Returns(_thirdChannel.Object)
-				.Returns(_firstChannel.Object)
-				.Returns(_secondChannel.Object);
-			_firstChannel
-				.Setup(c => c.IsOpen)
-				.Returns(true);
-			_secondChannel
-				.SetupSequence( c => c.IsOpen)
-				.Returns(true)
-				.Returns(false);
-			_thirdChannel
-				.Setup(c => c.IsOpen)
-				.Returns(true);
-			_secondChannel
-				.Setup(c => c.CloseReason)
-				.Returns(new ShutdownEventArgs(ShutdownInitiator.Application, 200, "Test"));
-			var factory = new ChannelFactory(_connectionFactory.Object, _config, _channelConfig);
+        [Fact]
+        public async Task Should_Not_Return_Close_Channel()
+        {
+            /* Setup */
+            _channelConfig.MaxChannelCount = 3;
+            _channelConfig.InitialChannelCount = 3;
+            _connection
+                .Setup(c => c.IsOpen)
+                .Returns(true);
+            _connection
+                .SetupSequence(c => c.CreateModel())
+                .Returns(_thirdChannel.Object)
+                .Returns(_firstChannel.Object)
+                .Returns(_secondChannel.Object);
+            _firstChannel
+                .Setup(c => c.IsOpen)
+                .Returns(true);
+            _secondChannel
+                .SetupSequence( c => c.IsOpen)
+                .Returns(true)
+                .Returns(false);
+            _thirdChannel
+                .Setup(c => c.IsOpen)
+                .Returns(true);
+            _secondChannel
+                .Setup(c => c.CloseReason)
+                .Returns(new ShutdownEventArgs(ShutdownInitiator.Application, 200, "Test"));
+            var factory = new ChannelFactory(_connectionFactory.Object, _config, _channelConfig);
 
-			/* Test */
-			var first = await factory.GetChannelAsync();
-			var second = await factory.GetChannelAsync();
-			var third = await factory.GetChannelAsync();
-			var firstAgain = await factory.GetChannelAsync();
-			var thirdAgain = await factory.GetChannelAsync();
+            /* Test */
+            var first = await factory.GetChannelAsync();
+            var second = await factory.GetChannelAsync();
+            var third = await factory.GetChannelAsync();
+            var firstAgain = await factory.GetChannelAsync();
+            var thirdAgain = await factory.GetChannelAsync();
 
-			/* Assert */
-			Assert.Equal(first, _firstChannel.Object);
-			Assert.Equal(second, _secondChannel.Object);
-			Assert.Equal(third, _thirdChannel.Object);
-			Assert.Equal(firstAgain, _firstChannel.Object);
-			Assert.Equal(thirdAgain, _thirdChannel.Object);
-		}
-	}
+            /* Assert */
+            Assert.Equal(first, _firstChannel.Object);
+            Assert.Equal(second, _secondChannel.Object);
+            Assert.Equal(third, _thirdChannel.Object);
+            Assert.Equal(firstAgain, _firstChannel.Object);
+            Assert.Equal(thirdAgain, _thirdChannel.Object);
+        }
+    }
 }

--- a/test/RawRabbit.Tests/Common/BasicPropertiesProviderTests.cs
+++ b/test/RawRabbit.Tests/Common/BasicPropertiesProviderTests.cs
@@ -4,47 +4,47 @@ using RawRabbit.Configuration;
 
 namespace RawRabbit.Tests.Common
 {
-	public class BasicPropertiesProviderTests
-	{
-		[Fact]
-		public void Should_Be_Able_To_Get_Type_Property_For_Basic_Type()
-		{
-			/* Setup */
-			var provider = new BasicPropertiesProvider(new RawRabbitConfiguration());
+    public class BasicPropertiesProviderTests
+    {
+        [Fact]
+        public void Should_Be_Able_To_Get_Type_Property_For_Basic_Type()
+        {
+            /* Setup */
+            var provider = new BasicPropertiesProvider(new RawRabbitConfiguration());
 
-			/* Test */
-			var type = provider.GetProperties<First>().Headers[PropertyHeaders.MessageType];
+            /* Test */
+            var type = provider.GetProperties<First>().Headers[PropertyHeaders.MessageType];
 
-			/* Assert */
-			Assert.Equal(expected: "RawRabbit.Tests.Common.First, RawRabbit.Tests", actual: type);
-		}
+            /* Assert */
+            Assert.Equal(expected: "RawRabbit.Tests.Common.First, RawRabbit.Tests", actual: type);
+        }
 
-		[Fact]
-		public void Should_Be_Able_To_Get_Type_Property_For_Type_With_Generic_Type_Arguments()
-		{
-			/* Setup */
-			var provider = new BasicPropertiesProvider(new RawRabbitConfiguration());
+        [Fact]
+        public void Should_Be_Able_To_Get_Type_Property_For_Type_With_Generic_Type_Arguments()
+        {
+            /* Setup */
+            var provider = new BasicPropertiesProvider(new RawRabbitConfiguration());
 
-			/* Test */
-			var type = provider.GetProperties<Generic<First, Second>>().Headers[PropertyHeaders.MessageType];
+            /* Test */
+            var type = provider.GetProperties<Generic<First, Second>>().Headers[PropertyHeaders.MessageType];
 
-			/* Assert */
-			Assert.Equal(expected: "RawRabbit.Tests.Common.Generic`2[[RawRabbit.Tests.Common.First, RawRabbit.Tests],[RawRabbit.Tests.Common.Second, RawRabbit.Tests]], RawRabbit.Tests", actual: type);
-		}
+            /* Assert */
+            Assert.Equal(expected: "RawRabbit.Tests.Common.Generic`2[[RawRabbit.Tests.Common.First, RawRabbit.Tests],[RawRabbit.Tests.Common.Second, RawRabbit.Tests]], RawRabbit.Tests", actual: type);
+        }
 
-		private class Generic<TFirst, TSecond>
-		{
-			public TFirst First;
-			public TSecond Second;
-		}
+        private class Generic<TFirst, TSecond>
+        {
+            public TFirst First;
+            public TSecond Second;
+        }
 
-		private class First
-		{
-		}
+        private class First
+        {
+        }
 
-		private class Second
-		{
-		}
+        private class Second
+        {
+        }
 
-	}
+    }
 }

--- a/test/RawRabbit.Tests/Common/ConnectionStringParserTests.cs
+++ b/test/RawRabbit.Tests/Common/ConnectionStringParserTests.cs
@@ -4,353 +4,353 @@ using Xunit;
 
 namespace RawRabbit.Tests.Common
 {
-	public class ConnectionStringParserTests
-	{
-		[Fact]
-		public void Should_Be_Able_To_Parse_ConnectionString_Without_Credentials()
-		{
-			/* Setup */
-			const string connectionString = "host";
+    public class ConnectionStringParserTests
+    {
+        [Fact]
+        public void Should_Be_Able_To_Parse_ConnectionString_Without_Credentials()
+        {
+            /* Setup */
+            const string connectionString = "host";
 
-			/* Test */
-			var config = ConnectionStringParser.Parse(connectionString);
+            /* Test */
+            var config = ConnectionStringParser.Parse(connectionString);
 
-			/* Assert */
-			Assert.Equal(expected: "guest", actual: config.Username);
-			Assert.Equal(expected: "guest", actual: config.Password);
-			Assert.Equal(expected: "/", actual: config.VirtualHost);
-			Assert.Equal(expected: "host", actual: config.Hostnames[0]);
-			Assert.Equal(expected: 5672, actual: config.Port);
-		}
+            /* Assert */
+            Assert.Equal(expected: "guest", actual: config.Username);
+            Assert.Equal(expected: "guest", actual: config.Password);
+            Assert.Equal(expected: "/", actual: config.VirtualHost);
+            Assert.Equal(expected: "host", actual: config.Hostnames[0]);
+            Assert.Equal(expected: 5672, actual: config.Port);
+        }
 
-		[Fact]
-		public void Should_Be_Able_To_Parse_ConnectionString_Without_Credentials_With_Port()
-		{
-			/* Setup */
-			const string connectionString = "host:1234";
+        [Fact]
+        public void Should_Be_Able_To_Parse_ConnectionString_Without_Credentials_With_Port()
+        {
+            /* Setup */
+            const string connectionString = "host:1234";
 
-			/* Test */
-			var config = ConnectionStringParser.Parse(connectionString);
+            /* Test */
+            var config = ConnectionStringParser.Parse(connectionString);
 
-			/* Assert */
-			Assert.Equal(expected: "guest", actual: config.Username);
-			Assert.Equal(expected: "guest", actual: config.Password);
-			Assert.Equal(expected: "/", actual: config.VirtualHost);
-			Assert.Equal(expected: "host", actual: config.Hostnames[0]);
-			Assert.Equal(expected: 1234, actual: config.Port);
-		}
+            /* Assert */
+            Assert.Equal(expected: "guest", actual: config.Username);
+            Assert.Equal(expected: "guest", actual: config.Password);
+            Assert.Equal(expected: "/", actual: config.VirtualHost);
+            Assert.Equal(expected: "host", actual: config.Hostnames[0]);
+            Assert.Equal(expected: 1234, actual: config.Port);
+        }
 
-		[Fact]
-		public void Should_Be_Able_To_Parse_ConnectionString_Without_Credentials_With_VirtualHost()
-		{
-			/* Setup */
-			const string connectionString = "host/virtualHost";
+        [Fact]
+        public void Should_Be_Able_To_Parse_ConnectionString_Without_Credentials_With_VirtualHost()
+        {
+            /* Setup */
+            const string connectionString = "host/virtualHost";
 
-			/* Test */
-			var config = ConnectionStringParser.Parse(connectionString);
+            /* Test */
+            var config = ConnectionStringParser.Parse(connectionString);
 
-			/* Assert */
-			Assert.Equal(expected: "guest", actual: config.Username);
-			Assert.Equal(expected: "guest", actual: config.Password);
-			Assert.Equal(expected: "virtualHost", actual: config.VirtualHost);
-			Assert.Equal(expected: "host", actual: config.Hostnames[0]);
-			Assert.Equal(expected: 5672, actual: config.Port);
-		}
+            /* Assert */
+            Assert.Equal(expected: "guest", actual: config.Username);
+            Assert.Equal(expected: "guest", actual: config.Password);
+            Assert.Equal(expected: "virtualHost", actual: config.VirtualHost);
+            Assert.Equal(expected: "host", actual: config.Hostnames[0]);
+            Assert.Equal(expected: 5672, actual: config.Port);
+        }
 
-		[Fact]
-		public void Should_Be_Able_To_Parse_ConnectionString_Without_Credentials_With_Parameters()
-		{
-			/* Setup */
-			const string connectionString = "host1,host2?" +
-											"requestTimeout=10" +
-											"&publishConfirmTimeout=20" +
-											"&recoveryInterval=30" +
-											"&autoCloseConnection=false" +
-											"&persistentDeliveryMode=false" +
-											"&automaticRecovery=false" +
-											"&topologyRecovery=false";
+        [Fact]
+        public void Should_Be_Able_To_Parse_ConnectionString_Without_Credentials_With_Parameters()
+        {
+            /* Setup */
+            const string connectionString = "host1,host2?" +
+                                            "requestTimeout=10" +
+                                            "&publishConfirmTimeout=20" +
+                                            "&recoveryInterval=30" +
+                                            "&autoCloseConnection=false" +
+                                            "&persistentDeliveryMode=false" +
+                                            "&automaticRecovery=false" +
+                                            "&topologyRecovery=false";
 
-			/* Test */
-			var config = ConnectionStringParser.Parse(connectionString);
+            /* Test */
+            var config = ConnectionStringParser.Parse(connectionString);
 
-			/* Assert */
-			Assert.Equal(expected: "guest", actual: config.Username);
-			Assert.Equal(expected: "guest", actual: config.Password);
-			Assert.Equal(expected: "/", actual: config.VirtualHost);
-			Assert.Equal(expected: "host1", actual: config.Hostnames[0]);
-			Assert.Equal(expected: "host2", actual: config.Hostnames[1]);
-			Assert.Equal(expected: 5672, actual: config.Port);
-			Assert.Equal(expected: TimeSpan.FromSeconds(10), actual: config.RequestTimeout);
-			Assert.Equal(expected: TimeSpan.FromSeconds(20), actual: config.PublishConfirmTimeout);
-			Assert.Equal(expected: TimeSpan.FromSeconds(30), actual: config.RecoveryInterval);
-			Assert.Equal(expected: false, actual: config.AutoCloseConnection);
-			Assert.Equal(expected: false, actual: config.PersistentDeliveryMode);
-			Assert.Equal(expected: false, actual: config.AutomaticRecovery);
-			Assert.Equal(expected: false, actual: config.TopologyRecovery);
-		}
+            /* Assert */
+            Assert.Equal(expected: "guest", actual: config.Username);
+            Assert.Equal(expected: "guest", actual: config.Password);
+            Assert.Equal(expected: "/", actual: config.VirtualHost);
+            Assert.Equal(expected: "host1", actual: config.Hostnames[0]);
+            Assert.Equal(expected: "host2", actual: config.Hostnames[1]);
+            Assert.Equal(expected: 5672, actual: config.Port);
+            Assert.Equal(expected: TimeSpan.FromSeconds(10), actual: config.RequestTimeout);
+            Assert.Equal(expected: TimeSpan.FromSeconds(20), actual: config.PublishConfirmTimeout);
+            Assert.Equal(expected: TimeSpan.FromSeconds(30), actual: config.RecoveryInterval);
+            Assert.Equal(expected: false, actual: config.AutoCloseConnection);
+            Assert.Equal(expected: false, actual: config.PersistentDeliveryMode);
+            Assert.Equal(expected: false, actual: config.AutomaticRecovery);
+            Assert.Equal(expected: false, actual: config.TopologyRecovery);
+        }
 
-		[Fact]
-		public void Should_Be_Able_To_Parse_ConnectionString_Without_Credentials_With_Port_And_VirtualHost()
-		{
-			/* Setup */
-			const string connectionString = "host:1234/virtualHost";
+        [Fact]
+        public void Should_Be_Able_To_Parse_ConnectionString_Without_Credentials_With_Port_And_VirtualHost()
+        {
+            /* Setup */
+            const string connectionString = "host:1234/virtualHost";
 
-			/* Test */
-			var config = ConnectionStringParser.Parse(connectionString);
+            /* Test */
+            var config = ConnectionStringParser.Parse(connectionString);
 
-			/* Assert */
-			Assert.Equal(expected: "guest", actual: config.Username);
-			Assert.Equal(expected: "guest", actual: config.Password);
-			Assert.Equal(expected: "virtualHost", actual: config.VirtualHost);
-			Assert.Equal(expected: "host", actual: config.Hostnames[0]);
-			Assert.Equal(expected: 1234, actual: config.Port);
-		}
+            /* Assert */
+            Assert.Equal(expected: "guest", actual: config.Username);
+            Assert.Equal(expected: "guest", actual: config.Password);
+            Assert.Equal(expected: "virtualHost", actual: config.VirtualHost);
+            Assert.Equal(expected: "host", actual: config.Hostnames[0]);
+            Assert.Equal(expected: 1234, actual: config.Port);
+        }
 
-		[Fact]
-		public void Should_Be_Able_To_Parse_ConnectionString_Without_Port()
-		{
-			/* Setup */
-			const string connectionString = "username:password@host1,host2";
+        [Fact]
+        public void Should_Be_Able_To_Parse_ConnectionString_Without_Port()
+        {
+            /* Setup */
+            const string connectionString = "username:password@host1,host2";
 
-			/* Test */
-			var config = ConnectionStringParser.Parse(connectionString);
+            /* Test */
+            var config = ConnectionStringParser.Parse(connectionString);
 
-			/* Assert */
-			Assert.Equal(expected: "username", actual: config.Username);
-			Assert.Equal(expected: "password", actual: config.Password);
-			Assert.Equal(expected: "/", actual: config.VirtualHost);
-			Assert.Equal(expected: "host1", actual: config.Hostnames[0]);
-			Assert.Equal(expected: "host2", actual: config.Hostnames[1]);
-			Assert.Equal(expected: 5672, actual: config.Port);
-		}
+            /* Assert */
+            Assert.Equal(expected: "username", actual: config.Username);
+            Assert.Equal(expected: "password", actual: config.Password);
+            Assert.Equal(expected: "/", actual: config.VirtualHost);
+            Assert.Equal(expected: "host1", actual: config.Hostnames[0]);
+            Assert.Equal(expected: "host2", actual: config.Hostnames[1]);
+            Assert.Equal(expected: 5672, actual: config.Port);
+        }
 
-		[Fact]
-		public void Should_Be_Able_To_Parse_ConnectionString_Without_Port_With_VirtualHost()
-		{
-			/* Setup */
-			const string connectionString = "username:password@host1,host2/virtualHost";
+        [Fact]
+        public void Should_Be_Able_To_Parse_ConnectionString_Without_Port_With_VirtualHost()
+        {
+            /* Setup */
+            const string connectionString = "username:password@host1,host2/virtualHost";
 
-			/* Test */
-			var config = ConnectionStringParser.Parse(connectionString);
+            /* Test */
+            var config = ConnectionStringParser.Parse(connectionString);
 
-			/* Assert */
-			Assert.Equal(expected: "username", actual: config.Username);
-			Assert.Equal(expected: "password", actual: config.Password);
-			Assert.Equal(expected: "virtualHost", actual: config.VirtualHost);
-			Assert.Equal(expected: "host1", actual: config.Hostnames[0]);
-			Assert.Equal(expected: "host2", actual: config.Hostnames[1]);
-			Assert.Equal(expected: 5672, actual: config.Port);
-		}
+            /* Assert */
+            Assert.Equal(expected: "username", actual: config.Username);
+            Assert.Equal(expected: "password", actual: config.Password);
+            Assert.Equal(expected: "virtualHost", actual: config.VirtualHost);
+            Assert.Equal(expected: "host1", actual: config.Hostnames[0]);
+            Assert.Equal(expected: "host2", actual: config.Hostnames[1]);
+            Assert.Equal(expected: 5672, actual: config.Port);
+        }
 
-		[Fact]
-		public void Should_Be_Able_To_Parse_ConnectionString_With_Port_Without_VirtualHost()
-		{
-			/* Setup */
-			const string connectionString = "username:password@host1,host2:1234";
+        [Fact]
+        public void Should_Be_Able_To_Parse_ConnectionString_With_Port_Without_VirtualHost()
+        {
+            /* Setup */
+            const string connectionString = "username:password@host1,host2:1234";
 
-			/* Test */
-			var config = ConnectionStringParser.Parse(connectionString);
+            /* Test */
+            var config = ConnectionStringParser.Parse(connectionString);
 
-			/* Assert */
-			Assert.Equal(expected: "username", actual: config.Username);
-			Assert.Equal(expected: "password", actual: config.Password);
-			Assert.Equal(expected: "/", actual: config.VirtualHost);
-			Assert.Equal(expected: "host1", actual: config.Hostnames[0]);
-			Assert.Equal(expected: "host2", actual: config.Hostnames[1]);
-			Assert.Equal(expected: 1234, actual: config.Port);
-		}
+            /* Assert */
+            Assert.Equal(expected: "username", actual: config.Username);
+            Assert.Equal(expected: "password", actual: config.Password);
+            Assert.Equal(expected: "/", actual: config.VirtualHost);
+            Assert.Equal(expected: "host1", actual: config.Hostnames[0]);
+            Assert.Equal(expected: "host2", actual: config.Hostnames[1]);
+            Assert.Equal(expected: 1234, actual: config.Port);
+        }
 
-		[Fact]
-		public void Should_Be_Able_To_Parse_ConnectionString_With_Port_And_VirtualHost()
-		{
-			/* Setup */
-			const string connectionString = "username:password@host1,host2:1234/virtualHost";
+        [Fact]
+        public void Should_Be_Able_To_Parse_ConnectionString_With_Port_And_VirtualHost()
+        {
+            /* Setup */
+            const string connectionString = "username:password@host1,host2:1234/virtualHost";
 
-			/* Test */
-			var config = ConnectionStringParser.Parse(connectionString);
+            /* Test */
+            var config = ConnectionStringParser.Parse(connectionString);
 
-			/* Assert */
-			Assert.Equal(expected: "username", actual: config.Username);
-			Assert.Equal(expected: "password", actual: config.Password);
-			Assert.Equal(expected: "virtualHost", actual: config.VirtualHost);
-			Assert.Equal(expected: "host1", actual: config.Hostnames[0]);
-			Assert.Equal(expected: "host2", actual: config.Hostnames[1]);
-			Assert.Equal(expected: 1234, actual: config.Port);
-		}
+            /* Assert */
+            Assert.Equal(expected: "username", actual: config.Username);
+            Assert.Equal(expected: "password", actual: config.Password);
+            Assert.Equal(expected: "virtualHost", actual: config.VirtualHost);
+            Assert.Equal(expected: "host1", actual: config.Hostnames[0]);
+            Assert.Equal(expected: "host2", actual: config.Hostnames[1]);
+            Assert.Equal(expected: 1234, actual: config.Port);
+        }
 
-		[Fact]
-		public void Should_Be_Able_To_Parse_ConnectionString_With_All_Attributes_And_Parameters()
-		{
-			/* Setup */
-			const string connectionString = "username:password@host1,host2:1234/virtualHost?" +
-											"requestTimeout=10" +
-											"&publishConfirmTimeout=20" +
-											"&recoveryInterval=30" +
-											"&autoCloseConnection=false" +
-											"&persistentDeliveryMode=false" +
-											"&automaticRecovery=false" +
-											"&topologyRecovery=false";
+        [Fact]
+        public void Should_Be_Able_To_Parse_ConnectionString_With_All_Attributes_And_Parameters()
+        {
+            /* Setup */
+            const string connectionString = "username:password@host1,host2:1234/virtualHost?" +
+                                            "requestTimeout=10" +
+                                            "&publishConfirmTimeout=20" +
+                                            "&recoveryInterval=30" +
+                                            "&autoCloseConnection=false" +
+                                            "&persistentDeliveryMode=false" +
+                                            "&automaticRecovery=false" +
+                                            "&topologyRecovery=false";
 
-			/* Test */
-			var config = ConnectionStringParser.Parse(connectionString);
+            /* Test */
+            var config = ConnectionStringParser.Parse(connectionString);
 
-			/* Assert */
-			Assert.Equal(expected: "username", actual: config.Username);
-			Assert.Equal(expected: "password", actual: config.Password);
-			Assert.Equal(expected: "virtualHost", actual: config.VirtualHost);
-			Assert.Equal(expected: "host1", actual: config.Hostnames[0]);
-			Assert.Equal(expected: "host2", actual: config.Hostnames[1]);
-			Assert.Equal(expected: 1234, actual: config.Port);
-			Assert.Equal(expected: TimeSpan.FromSeconds(10), actual: config.RequestTimeout);
-			Assert.Equal(expected: TimeSpan.FromSeconds(20), actual: config.PublishConfirmTimeout);
-			Assert.Equal(expected: TimeSpan.FromSeconds(30), actual: config.RecoveryInterval);
-			Assert.Equal(expected: false, actual: config.AutoCloseConnection);
-			Assert.Equal(expected: false, actual: config.PersistentDeliveryMode);
-			Assert.Equal(expected: false, actual: config.AutomaticRecovery);
-			Assert.Equal(expected: false, actual: config.TopologyRecovery);
-		}
+            /* Assert */
+            Assert.Equal(expected: "username", actual: config.Username);
+            Assert.Equal(expected: "password", actual: config.Password);
+            Assert.Equal(expected: "virtualHost", actual: config.VirtualHost);
+            Assert.Equal(expected: "host1", actual: config.Hostnames[0]);
+            Assert.Equal(expected: "host2", actual: config.Hostnames[1]);
+            Assert.Equal(expected: 1234, actual: config.Port);
+            Assert.Equal(expected: TimeSpan.FromSeconds(10), actual: config.RequestTimeout);
+            Assert.Equal(expected: TimeSpan.FromSeconds(20), actual: config.PublishConfirmTimeout);
+            Assert.Equal(expected: TimeSpan.FromSeconds(30), actual: config.RecoveryInterval);
+            Assert.Equal(expected: false, actual: config.AutoCloseConnection);
+            Assert.Equal(expected: false, actual: config.PersistentDeliveryMode);
+            Assert.Equal(expected: false, actual: config.AutomaticRecovery);
+            Assert.Equal(expected: false, actual: config.TopologyRecovery);
+        }
 
-		[Fact]
-		public void Should_Be_Able_To_Parse_ConnectionString_Without_VirtualHost_With_Parameters()
-		{
-			/* Setup */
-			const string connectionString = "username:password@host1,host2:1234?" +
-											"requestTimeout=10" +
-											"&publishConfirmTimeout=20" +
-											"&recoveryInterval=30" +
-											"&autoCloseConnection=false" +
-											"&persistentDeliveryMode=false" +
-											"&automaticRecovery=false" +
-											"&topologyRecovery=false";
+        [Fact]
+        public void Should_Be_Able_To_Parse_ConnectionString_Without_VirtualHost_With_Parameters()
+        {
+            /* Setup */
+            const string connectionString = "username:password@host1,host2:1234?" +
+                                            "requestTimeout=10" +
+                                            "&publishConfirmTimeout=20" +
+                                            "&recoveryInterval=30" +
+                                            "&autoCloseConnection=false" +
+                                            "&persistentDeliveryMode=false" +
+                                            "&automaticRecovery=false" +
+                                            "&topologyRecovery=false";
 
-			/* Test */
-			var config = ConnectionStringParser.Parse(connectionString);
+            /* Test */
+            var config = ConnectionStringParser.Parse(connectionString);
 
-			/* Assert */
-			Assert.Equal(expected: "username", actual: config.Username);
-			Assert.Equal(expected: "password", actual: config.Password);
-			Assert.Equal(expected: "/", actual: config.VirtualHost);
-			Assert.Equal(expected: "host1", actual: config.Hostnames[0]);
-			Assert.Equal(expected: "host2", actual: config.Hostnames[1]);
-			Assert.Equal(expected: 1234, actual: config.Port);
-			Assert.Equal(expected: TimeSpan.FromSeconds(10), actual: config.RequestTimeout);
-			Assert.Equal(expected: TimeSpan.FromSeconds(20), actual: config.PublishConfirmTimeout);
-			Assert.Equal(expected: TimeSpan.FromSeconds(30), actual: config.RecoveryInterval);
-			Assert.Equal(expected: false, actual: config.AutoCloseConnection);
-			Assert.Equal(expected: false, actual: config.PersistentDeliveryMode);
-			Assert.Equal(expected: false, actual: config.AutomaticRecovery);
-			Assert.Equal(expected: false, actual: config.TopologyRecovery);
-		}
+            /* Assert */
+            Assert.Equal(expected: "username", actual: config.Username);
+            Assert.Equal(expected: "password", actual: config.Password);
+            Assert.Equal(expected: "/", actual: config.VirtualHost);
+            Assert.Equal(expected: "host1", actual: config.Hostnames[0]);
+            Assert.Equal(expected: "host2", actual: config.Hostnames[1]);
+            Assert.Equal(expected: 1234, actual: config.Port);
+            Assert.Equal(expected: TimeSpan.FromSeconds(10), actual: config.RequestTimeout);
+            Assert.Equal(expected: TimeSpan.FromSeconds(20), actual: config.PublishConfirmTimeout);
+            Assert.Equal(expected: TimeSpan.FromSeconds(30), actual: config.RecoveryInterval);
+            Assert.Equal(expected: false, actual: config.AutoCloseConnection);
+            Assert.Equal(expected: false, actual: config.PersistentDeliveryMode);
+            Assert.Equal(expected: false, actual: config.AutomaticRecovery);
+            Assert.Equal(expected: false, actual: config.TopologyRecovery);
+        }
 
-		[Fact]
-		public void Should_Be_Able_To_Parse_ConnectionString_Without_Credentials_With_Port_And_VirtualHost_And_Parameters()
-		{
-			/* Setup */
-			const string connectionString = "host1,host2:1234/virtualHost?" +
-											"requestTimeout=10" +
-											"&publishConfirmTimeout=20" +
-											"&recoveryInterval=30" +
-											"&autoCloseConnection=false" +
-											"&persistentDeliveryMode=false" +
-											"&automaticRecovery=false" +
-											"&topologyRecovery=false";
+        [Fact]
+        public void Should_Be_Able_To_Parse_ConnectionString_Without_Credentials_With_Port_And_VirtualHost_And_Parameters()
+        {
+            /* Setup */
+            const string connectionString = "host1,host2:1234/virtualHost?" +
+                                            "requestTimeout=10" +
+                                            "&publishConfirmTimeout=20" +
+                                            "&recoveryInterval=30" +
+                                            "&autoCloseConnection=false" +
+                                            "&persistentDeliveryMode=false" +
+                                            "&automaticRecovery=false" +
+                                            "&topologyRecovery=false";
 
-			/* Test */
-			var config = ConnectionStringParser.Parse(connectionString);
+            /* Test */
+            var config = ConnectionStringParser.Parse(connectionString);
 
-			/* Assert */
-			Assert.Equal(expected: "guest", actual: config.Username);
-			Assert.Equal(expected: "guest", actual: config.Password);
-			Assert.Equal(expected: "virtualHost", actual: config.VirtualHost);
-			Assert.Equal(expected: "host1", actual: config.Hostnames[0]);
-			Assert.Equal(expected: "host2", actual: config.Hostnames[1]);
-			Assert.Equal(expected: 1234, actual: config.Port);
-			Assert.Equal(expected: TimeSpan.FromSeconds(10), actual: config.RequestTimeout);
-			Assert.Equal(expected: TimeSpan.FromSeconds(20), actual: config.PublishConfirmTimeout);
-			Assert.Equal(expected: TimeSpan.FromSeconds(30), actual: config.RecoveryInterval);
-			Assert.Equal(expected: false, actual: config.AutoCloseConnection);
-			Assert.Equal(expected: false, actual: config.PersistentDeliveryMode);
-			Assert.Equal(expected: false, actual: config.AutomaticRecovery);
-			Assert.Equal(expected: false, actual: config.TopologyRecovery);
-		}
+            /* Assert */
+            Assert.Equal(expected: "guest", actual: config.Username);
+            Assert.Equal(expected: "guest", actual: config.Password);
+            Assert.Equal(expected: "virtualHost", actual: config.VirtualHost);
+            Assert.Equal(expected: "host1", actual: config.Hostnames[0]);
+            Assert.Equal(expected: "host2", actual: config.Hostnames[1]);
+            Assert.Equal(expected: 1234, actual: config.Port);
+            Assert.Equal(expected: TimeSpan.FromSeconds(10), actual: config.RequestTimeout);
+            Assert.Equal(expected: TimeSpan.FromSeconds(20), actual: config.PublishConfirmTimeout);
+            Assert.Equal(expected: TimeSpan.FromSeconds(30), actual: config.RecoveryInterval);
+            Assert.Equal(expected: false, actual: config.AutoCloseConnection);
+            Assert.Equal(expected: false, actual: config.PersistentDeliveryMode);
+            Assert.Equal(expected: false, actual: config.AutomaticRecovery);
+            Assert.Equal(expected: false, actual: config.TopologyRecovery);
+        }
 
-		[Fact]
-		public void Should_Be_Able_To_Parse_ConnectionString_Without_VirtualHost_And_Port_With_Parameters()
-		{
-			/* Setup */
-			const string connectionString = "username:password@host1,host2?" +
-											"requestTimeout=10" +
-											"&publishConfirmTimeout=20" +
-											"&recoveryInterval=30" +
-											"&autoCloseConnection=false" +
-											"&persistentDeliveryMode=false" +
-											"&automaticRecovery=false" +
-											"&topologyRecovery=false";
+        [Fact]
+        public void Should_Be_Able_To_Parse_ConnectionString_Without_VirtualHost_And_Port_With_Parameters()
+        {
+            /* Setup */
+            const string connectionString = "username:password@host1,host2?" +
+                                            "requestTimeout=10" +
+                                            "&publishConfirmTimeout=20" +
+                                            "&recoveryInterval=30" +
+                                            "&autoCloseConnection=false" +
+                                            "&persistentDeliveryMode=false" +
+                                            "&automaticRecovery=false" +
+                                            "&topologyRecovery=false";
 
-			/* Test */
-			var config = ConnectionStringParser.Parse(connectionString);
+            /* Test */
+            var config = ConnectionStringParser.Parse(connectionString);
 
-			/* Assert */
-			Assert.Equal(expected: "username", actual: config.Username);
-			Assert.Equal(expected: "password", actual: config.Password);
-			Assert.Equal(expected: "/", actual: config.VirtualHost);
-			Assert.Equal(expected: "host1", actual: config.Hostnames[0]);
-			Assert.Equal(expected: "host2", actual: config.Hostnames[1]);
-			Assert.Equal(expected: 5672, actual: config.Port);
-			Assert.Equal(expected: TimeSpan.FromSeconds(10), actual: config.RequestTimeout);
-			Assert.Equal(expected: TimeSpan.FromSeconds(20), actual: config.PublishConfirmTimeout);
-			Assert.Equal(expected: TimeSpan.FromSeconds(30), actual: config.RecoveryInterval);
-			Assert.Equal(expected: false, actual: config.AutoCloseConnection);
-			Assert.Equal(expected: false, actual: config.PersistentDeliveryMode);
-			Assert.Equal(expected: false, actual: config.AutomaticRecovery);
-			Assert.Equal(expected: false, actual: config.TopologyRecovery);
-		}
+            /* Assert */
+            Assert.Equal(expected: "username", actual: config.Username);
+            Assert.Equal(expected: "password", actual: config.Password);
+            Assert.Equal(expected: "/", actual: config.VirtualHost);
+            Assert.Equal(expected: "host1", actual: config.Hostnames[0]);
+            Assert.Equal(expected: "host2", actual: config.Hostnames[1]);
+            Assert.Equal(expected: 5672, actual: config.Port);
+            Assert.Equal(expected: TimeSpan.FromSeconds(10), actual: config.RequestTimeout);
+            Assert.Equal(expected: TimeSpan.FromSeconds(20), actual: config.PublishConfirmTimeout);
+            Assert.Equal(expected: TimeSpan.FromSeconds(30), actual: config.RecoveryInterval);
+            Assert.Equal(expected: false, actual: config.AutoCloseConnection);
+            Assert.Equal(expected: false, actual: config.PersistentDeliveryMode);
+            Assert.Equal(expected: false, actual: config.AutomaticRecovery);
+            Assert.Equal(expected: false, actual: config.TopologyRecovery);
+        }
 
-		[Fact]
-		public void Should_Throw_Format_Exception_When_ConnectionString_Has_Bad_Port()
-		{
-			/* Setup */
-			const string connectionString = "username:password@host1,host2:port";
-			Exception exception = null;
+        [Fact]
+        public void Should_Throw_Format_Exception_When_ConnectionString_Has_Bad_Port()
+        {
+            /* Setup */
+            const string connectionString = "username:password@host1,host2:port";
+            Exception exception = null;
 
-			/* Test */
-			try
-			{
-				ConnectionStringParser.Parse(connectionString);
-			}
-			catch (Exception e)
-			{
-				exception = e;
-			}
+            /* Test */
+            try
+            {
+                ConnectionStringParser.Parse(connectionString);
+            }
+            catch (Exception e)
+            {
+                exception = e;
+            }
 
-			/* Assert */
-			Assert.NotNull(exception);
-			Assert.IsType(typeof(FormatException), exception);
-			Assert.Equal(expected: "The supplied port 'port' in the connection string is not a number", actual: exception.Message);
-		}
+            /* Assert */
+            Assert.NotNull(exception);
+            Assert.IsType(typeof(FormatException), exception);
+            Assert.Equal(expected: "The supplied port 'port' in the connection string is not a number", actual: exception.Message);
+        }
 
-		[Fact]
-		public void Should_Throw_Argument_Exception_When_ConnectionString_Has_Bad_Property()
-		{
-			/* Setup */
-			const string connectionString = "username:password@host1,host2?badproperty=true";
-			Exception exception = null;
+        [Fact]
+        public void Should_Throw_Argument_Exception_When_ConnectionString_Has_Bad_Property()
+        {
+            /* Setup */
+            const string connectionString = "username:password@host1,host2?badproperty=true";
+            Exception exception = null;
 
-			/* Test */
-			try
-			{
-				ConnectionStringParser.Parse(connectionString);
-			}
-			catch (Exception e)
-			{
-				exception = e;
-			}
+            /* Test */
+            try
+            {
+                ConnectionStringParser.Parse(connectionString);
+            }
+            catch (Exception e)
+            {
+                exception = e;
+            }
 
-			/* Assert */
-			Assert.NotNull(exception);
-			Assert.IsType(typeof(ArgumentException), exception);
-			Assert.Equal(expected: "No configuration property named 'badproperty'", actual: exception.Message);
-		}
+            /* Assert */
+            Assert.NotNull(exception);
+            Assert.IsType(typeof(ArgumentException), exception);
+            Assert.Equal(expected: "No configuration property named 'badproperty'", actual: exception.Message);
+        }
 
-	}
+    }
 }

--- a/test/RawRabbit.Tests/Common/NamingConventionsTests.cs
+++ b/test/RawRabbit.Tests/Common/NamingConventionsTests.cs
@@ -3,79 +3,79 @@ using Xunit;
 
 namespace RawRabbit.Tests.Common
 {
-	public class NamingConventionsTests
-	{
-		[Fact]
-		public void Should_Be_Able_To_Get_Application_Name_From_Console_App_Or_Service()
-		{
-			/* Setup */
-			var consoleAppUrl = @"\""Services\\Micro.Services.MagicMaker\\bin\\Micro.Services.MagicMaker.exe\"" ";
+    public class NamingConventionsTests
+    {
+        [Fact]
+        public void Should_Be_Able_To_Get_Application_Name_From_Console_App_Or_Service()
+        {
+            /* Setup */
+            var consoleAppUrl = @"\""Services\\Micro.Services.MagicMaker\\bin\\Micro.Services.MagicMaker.exe\"" ";
 
-			/* Test */
-			var consoleAppRes = NamingConventions.GetApplicationName(consoleAppUrl);
+            /* Test */
+            var consoleAppRes = NamingConventions.GetApplicationName(consoleAppUrl);
 
-			/* Assert */
-			Assert.Equal(expected: "micro_services_magicmaker", actual: consoleAppRes);
-		}
+            /* Assert */
+            Assert.Equal(expected: "micro_services_magicmaker", actual: consoleAppRes);
+        }
 
-		[Fact]
-		public void Should_Be_Able_To_Get_Application_Name_From_Console_App_Or_Service_With_Vshost()
-		{
-			/* Setup */
-			var consoleAppUrl = @"\""Services\\Micro.Services.MagicMaker\\bin\\Micro.Services.MagicMaker.vshost.exe\"" ";
+        [Fact]
+        public void Should_Be_Able_To_Get_Application_Name_From_Console_App_Or_Service_With_Vshost()
+        {
+            /* Setup */
+            var consoleAppUrl = @"\""Services\\Micro.Services.MagicMaker\\bin\\Micro.Services.MagicMaker.vshost.exe\"" ";
 
-			/* Test */
-			var consoleAppRes = NamingConventions.GetApplicationName(consoleAppUrl);
+            /* Test */
+            var consoleAppRes = NamingConventions.GetApplicationName(consoleAppUrl);
 
-			/* Assert */
-			Assert.Equal(expected: "micro_services_magicmaker", actual: consoleAppRes);
-		}
+            /* Assert */
+            Assert.Equal(expected: "micro_services_magicmaker", actual: consoleAppRes);
+        }
 
-		[Fact]
-		public void Should_Be_Able_To_Get_Application_Name_From_IIS_Hosted_App_With_ApplicationPool_Flag()
-		{
-			/* Setup */
-			var iisHostedApp = @"""c:\\windows\\system32\\inetsrv\\w3wp.exe -ap \""Application.Name\"" -v \""v4.0\"" -l \""webengine4.dll\"" -a \\\\.\\pipe\\iisipm6866bb0f-a36a-49b2-9ea8-d83ca69e873d -w \""\"" -m 0 -t 20 -ta 0""";
+        [Fact]
+        public void Should_Be_Able_To_Get_Application_Name_From_IIS_Hosted_App_With_ApplicationPool_Flag()
+        {
+            /* Setup */
+            var iisHostedApp = @"""c:\\windows\\system32\\inetsrv\\w3wp.exe -ap \""Application.Name\"" -v \""v4.0\"" -l \""webengine4.dll\"" -a \\\\.\\pipe\\iisipm6866bb0f-a36a-49b2-9ea8-d83ca69e873d -w \""\"" -m 0 -t 20 -ta 0""";
 
-			/* Test */
-			var iisHostedAppRes = NamingConventions.GetApplicationName(iisHostedApp);
+            /* Test */
+            var iisHostedAppRes = NamingConventions.GetApplicationName(iisHostedApp);
 
-			/* Assert */
-			Assert.Equal(expected: "application_name", actual: iisHostedAppRes);
-		}
+            /* Assert */
+            Assert.Equal(expected: "application_name", actual: iisHostedAppRes);
+        }
 
-		[Fact]
-		public void Should_Be_Able_To_Get_Application_Name_From_IIS_Hosted_App_With_Host_Flag()
-		{
-			/* Setup */
-			var iisHostedApp = @"""c:\\windows\\system32\\inetsrv\\w3wp.exe -ap \""Application.Name\"" -v \""v4.0\"" -l \""webengine4.dll\"" -a \\\\.\\pipe\\iisipm6866bb0f-a36a-49b2-9ea8-d83ca69e873d -h \""C:\\inetpub\\temp\\apppools\\voyager_dk\\voyager_dk.config\"" -w \""\"" -m 0 -t 20 -ta 0""";
+        [Fact]
+        public void Should_Be_Able_To_Get_Application_Name_From_IIS_Hosted_App_With_Host_Flag()
+        {
+            /* Setup */
+            var iisHostedApp = @"""c:\\windows\\system32\\inetsrv\\w3wp.exe -ap \""Application.Name\"" -v \""v4.0\"" -l \""webengine4.dll\"" -a \\\\.\\pipe\\iisipm6866bb0f-a36a-49b2-9ea8-d83ca69e873d -h \""C:\\inetpub\\temp\\apppools\\voyager_dk\\voyager_dk.config\"" -w \""\"" -m 0 -t 20 -ta 0""";
 
-			/* Test */
-			var iisHostedAppRes = NamingConventions.GetApplicationName(iisHostedApp);
+            /* Test */
+            var iisHostedAppRes = NamingConventions.GetApplicationName(iisHostedApp);
 
-			/* Assert */
-			Assert.Equal(expected: "application_name", actual: iisHostedAppRes);
-		}
+            /* Assert */
+            Assert.Equal(expected: "application_name", actual: iisHostedAppRes);
+        }
 
-		[Fact]
-		public void Should_Be_Able_To_Get_Appllication_Name_From_Dot_Net_Core_Hosted_Apps()
-		{
-			/* Setup */
-			var commandLime = new[]
-			{
-				"C:\\PathToNuget\\packages\\dotnet-test-xunit\\2.2.0-preview2-build1029\\lib\\netcoreapp1.0\\dotnet-test-xunit.dll",
-				"C:\\ProjectPath\\RawRabbit\\test\\RawRabbit.IntegrationTests\\bin\\Debug\\netcoreapp1.0\\RawRabbit.IntegrationTests.dll",
-				"--designtime",
-				"--port",
-				"55821",
-				"--wait-command"
-			};
+        [Fact]
+        public void Should_Be_Able_To_Get_Appllication_Name_From_Dot_Net_Core_Hosted_Apps()
+        {
+            /* Setup */
+            var commandLime = new[]
+            {
+                "C:\\PathToNuget\\packages\\dotnet-test-xunit\\2.2.0-preview2-build1029\\lib\\netcoreapp1.0\\dotnet-test-xunit.dll",
+                "C:\\ProjectPath\\RawRabbit\\test\\RawRabbit.IntegrationTests\\bin\\Debug\\netcoreapp1.0\\RawRabbit.IntegrationTests.dll",
+                "--designtime",
+                "--port",
+                "55821",
+                "--wait-command"
+            };
 
-			/* Test */
-			var appName = NamingConventions.GetApplicationName(commandLime);
+            /* Test */
+            var appName = NamingConventions.GetApplicationName(commandLime);
 
-			/* Assert */
-			Assert.Equal("rawrabbit_integrationtests", appName);
-		}
-	}
+            /* Assert */
+            Assert.Equal("rawrabbit_integrationtests", appName);
+        }
+    }
 }

--- a/test/RawRabbit.Tests/DependencyInjection/AutofacTests.cs
+++ b/test/RawRabbit.Tests/DependencyInjection/AutofacTests.cs
@@ -8,40 +8,40 @@ using Xunit;
 
 namespace RawRabbit.Tests.DependencyInjection
 {
-	public class AutofacTests
-	{
-		[Fact]
-		public async Task Should_Be_Able_To_Resolve_IBusClient()
-		{
-			/* Setup */
-			LogManager.CurrentFactory = new VoidLoggerFactory();
-			var builder = new ContainerBuilder();
-			builder.RegisterRawRabbit("guest:guest@localhost:5672/");
-			var container = builder.Build();
-			
-			/* Test */
-			var client = container.Resolve<IBusClient>();
-			await client.ShutdownAsync(TimeSpan.Zero);
+    public class AutofacTests
+    {
+        [Fact]
+        public async Task Should_Be_Able_To_Resolve_IBusClient()
+        {
+            /* Setup */
+            LogManager.CurrentFactory = new VoidLoggerFactory();
+            var builder = new ContainerBuilder();
+            builder.RegisterRawRabbit("guest:guest@localhost:5672/");
+            var container = builder.Build();
+            
+            /* Test */
+            var client = container.Resolve<IBusClient>();
+            await client.ShutdownAsync(TimeSpan.Zero);
 
-			/* Assert */
-			Assert.True(true, "Could resolve");
-		}
+            /* Assert */
+            Assert.True(true, "Could resolve");
+        }
 
-		[Fact]
-		public async Task Should_Be_Able_To_Resolve_BusClient_With_Advanced_Context()
-		{
-			/* Setup */
-			LogManager.CurrentFactory = new VoidLoggerFactory();
-			var builder = new ContainerBuilder();
-			builder.RegisterRawRabbit<AdvancedMessageContext>("guest:guest@localhost:5672/");
-			var container = builder.Build();
+        [Fact]
+        public async Task Should_Be_Able_To_Resolve_BusClient_With_Advanced_Context()
+        {
+            /* Setup */
+            LogManager.CurrentFactory = new VoidLoggerFactory();
+            var builder = new ContainerBuilder();
+            builder.RegisterRawRabbit<AdvancedMessageContext>("guest:guest@localhost:5672/");
+            var container = builder.Build();
 
-			/* Test */
-			var client = container.Resolve<IBusClient<AdvancedMessageContext>>();
-			await client.ShutdownAsync(TimeSpan.Zero);
+            /* Test */
+            var client = container.Resolve<IBusClient<AdvancedMessageContext>>();
+            await client.ShutdownAsync(TimeSpan.Zero);
 
-			/* Assert */
-			Assert.True(true, "Could resolve");
-		}
-	}
+            /* Assert */
+            Assert.True(true, "Could resolve");
+        }
+    }
 }

--- a/test/RawRabbit.Tests/DependencyInjection/NinjectTests.cs
+++ b/test/RawRabbit.Tests/DependencyInjection/NinjectTests.cs
@@ -10,38 +10,38 @@ using RawRabbit.Logging;
 
 namespace RawRabbit.Tests.DependencyInjection
 {
-	public class NinjectTests
-	{
-		[Fact]
-		public async Task Should_Be_Able_To_Resolve_IBusClient()
-		{
-			/* Setup */
-			LogManager.CurrentFactory = new VoidLoggerFactory();
-			var kernel = new StandardKernel();
-			kernel.RegisterRawRabbit("guest:guest@localhost:5672/");
+    public class NinjectTests
+    {
+        [Fact]
+        public async Task Should_Be_Able_To_Resolve_IBusClient()
+        {
+            /* Setup */
+            LogManager.CurrentFactory = new VoidLoggerFactory();
+            var kernel = new StandardKernel();
+            kernel.RegisterRawRabbit("guest:guest@localhost:5672/");
 
-			/* Test */
-			var client = kernel.Get<IBusClient>();
-			await client.ShutdownAsync(TimeSpan.Zero);
+            /* Test */
+            var client = kernel.Get<IBusClient>();
+            await client.ShutdownAsync(TimeSpan.Zero);
 
-			/* Assert */
-			Assert.True(true, "Could resolve");
-		}
+            /* Assert */
+            Assert.True(true, "Could resolve");
+        }
 
-		[Fact]
-		public async Task Should_Be_Able_To_Resolve_BusClient_With_Advanced_Context()
-		{
-			/* Setup */
-			LogManager.CurrentFactory = new VoidLoggerFactory();
-			var kernel = new StandardKernel();
-			kernel.RegisterRawRabbit<AdvancedMessageContext>("guest:guest@localhost:5672/");
+        [Fact]
+        public async Task Should_Be_Able_To_Resolve_BusClient_With_Advanced_Context()
+        {
+            /* Setup */
+            LogManager.CurrentFactory = new VoidLoggerFactory();
+            var kernel = new StandardKernel();
+            kernel.RegisterRawRabbit<AdvancedMessageContext>("guest:guest@localhost:5672/");
 
-			/* Test */
-			var client = kernel.Get<IBusClient<AdvancedMessageContext>>();
-			await client.ShutdownAsync(TimeSpan.Zero);
+            /* Test */
+            var client = kernel.Get<IBusClient<AdvancedMessageContext>>();
+            await client.ShutdownAsync(TimeSpan.Zero);
 
-			/* Assert */
-			Assert.True(true, "Could resolve");
-		}
-	}
+            /* Assert */
+            Assert.True(true, "Could resolve");
+        }
+    }
 }

--- a/test/RawRabbit.Tests/project.json
+++ b/test/RawRabbit.Tests/project.json
@@ -1,22 +1,22 @@
 ﻿{
-	"version": "1.0.0-*",
-	"authors": [ "par.dahlman" ],
-	"testRunner": "xunit",
+    "version": "1.0.0-*",
+    "authors": [ "par.dahlman" ],
+    "testRunner": "xunit",
 
-	"dependencies": {
-		"RawRabbit": { "target": "project" },
-		"RawRabbit.DependencyInjection.Autofac": { "target": "project" },
-		"RawRabbit.DependencyInjection.Ninject": { "target": "project" },
-		"RawRabbit.vNext": { "target": "project" },
-		"Moq": "4.5.16",
-		"xunit": "2.2.0-beta2-build3300",
-		"dotnet-test-xunit": "2.2.0-preview2-build1029"
-	},
-	"frameworks": {
-		"net46": {
-			"dependencies": {
-				"Microsoft.NETCore.Platforms": "1.0.1"
-			}
-		}
-	}
+    "dependencies": {
+        "RawRabbit": { "target": "project" },
+        "RawRabbit.DependencyInjection.Autofac": { "target": "project" },
+        "RawRabbit.DependencyInjection.Ninject": { "target": "project" },
+        "RawRabbit.vNext": { "target": "project" },
+        "Moq": "4.5.16",
+        "xunit": "2.2.0-beta2-build3300",
+        "dotnet-test-xunit": "2.2.0-preview2-build1029"
+    },
+    "frameworks": {
+        "net46": {
+            "dependencies": {
+                "Microsoft.NETCore.Platforms": "1.0.1"
+            }
+        }
+    }
 }

--- a/test/RawRabbit.Tests/rawrabbit.json
+++ b/test/RawRabbit.Tests/rawrabbit.json
@@ -1,24 +1,24 @@
 ﻿{
-	"Username": "guest",
-	"Password": "guest",
-	"VirtualHost": "/",
-	"Port": 5672,
-	"Hostnames": [ "localhost" ],
-	"RequestTimeout": "00:00:10",
-	"PublishConfirmTimeout": "00:00:01",
-	"RecoveryInterval": "00:00:10",
-	"PersistentDeliveryMode": true,
-	"AutoCloseConnection": true,
-	"AutomaticRecovery": true,
-	"TopologyRecovery": true,
-	"Exchange": {
-		"Durable": true,
-		"AutoDelete": true,
-		"Type": "Topic"
-	},
-	"Queue": {
-		"AutoDelete": true,
-		"Durable": true,
-		"Exclusive": true
-	}
+    "Username": "guest",
+    "Password": "guest",
+    "VirtualHost": "/",
+    "Port": 5672,
+    "Hostnames": [ "localhost" ],
+    "RequestTimeout": "00:00:10",
+    "PublishConfirmTimeout": "00:00:01",
+    "RecoveryInterval": "00:00:10",
+    "PersistentDeliveryMode": true,
+    "AutoCloseConnection": true,
+    "AutomaticRecovery": true,
+    "TopologyRecovery": true,
+    "Exchange": {
+        "Durable": true,
+        "AutoDelete": true,
+        "Type": "Topic"
+    },
+    "Queue": {
+        "AutoDelete": true,
+        "Durable": true,
+        "Exclusive": true
+    }
 }


### PR DESCRIPTION
### Description

This monster PR replaces all tabs with 4 spaces.

Quoting [Stylecop](http://stylecop.soyuz5.com/SA1027.html)

```
SA1027: TabsMustNotBeUsed

Cause

The C# code contains a tab character.

Rule Description

A violation of this rule occurs whenever the code contains a tab character.

Tabs should not be used within C# code, because the length of the tab character can vary depending upon the editor being used to view the code. This can cause the spacing and indexing of the code to vary from the developer’s original intention, and can in some cases make the code difficult to read.

For these reasons, tabs should not be used, and each level of indentation should consist of four spaces. This will ensure that the code looks the same no matter which editor is being used to view the code.

How to Fix Violations

To fix a violation of this rule, remove the tab character from the code.
```

Replacing tabs with spaces enables us to have a more compact code besides being editable on any editor without inconsistencies. In addition to adhering stylecop rules.

Merging this followed by PR #161 will be nice.

### Check List

- [x] All test passed.
- [x] Added documentation _(if applicable)_.
- [x] Tests added to ensure functionality.
- [x] Pull Request to `stable` branch.
