### PR TITLE
Moved IDisposable for InstanceFactory to the interface

### DIFF
--- a/src/RawRabbit/Instantiation/InstanceFactory.cs
+++ b/src/RawRabbit/Instantiation/InstanceFactory.cs
@@ -8,12 +8,12 @@ using RawRabbit.Subscription;
 
 namespace RawRabbit.Instantiation
 {
-	public interface IInstanceFactory
+	public interface IInstanceFactory : IDisposable
 	{
 		IBusClient Create();
 	}
 
-	public class InstanceFactory : IDisposable, IInstanceFactory
+	public class InstanceFactory : IInstanceFactory
 	{
 		private readonly IDependecyResolver _resolver;
 


### PR DESCRIPTION
Moved `IDisposable` for `InstanceFactory` to the interface so that the interface type can be returned as a disposable.

This becomes a problem when I depend on the `IInstanceFactory` and want to return a `IDisposable`

