### PR TITLE
Add possibility to configure queue Name Suffix with fluent configuration builder.

### DIFF
--- a/src/RawRabbit/Configuration/Queue/IQueueConfigurationBuilder.cs
+++ b/src/RawRabbit/Configuration/Queue/IQueueConfigurationBuilder.cs
@@ -3,6 +3,7 @@
 	public interface IQueueConfigurationBuilder
 	{
 		IQueueConfigurationBuilder WithName(string queueName);
+		IQueueConfigurationBuilder WithNameSuffix(string suffix);
 		IQueueConfigurationBuilder WithAutoDelete(bool autoDelete = true);
 		IQueueConfigurationBuilder WithDurability(bool durable = true);
 		IQueueConfigurationBuilder WithExclusivity(bool exclusive = true);


### PR DESCRIPTION
### Description

It's not passable to set queue name suffix on `Bus.SubscribeAsync` with fluent manner, because `IQueueConfigurationBuilder` doesn't has `WithNameSuffix` method, but `QueueConfigurationBuilder` has it.

``` c#
.WithQueue(cfg => cfg
                .WithNameSuffix("queue_prefix") // not exist
                .WithName("queue_name")
                .WithAutoDelete()
         ));
```

### Check List

- [x] All test passed.
- [x] Added documentation _(if applicable)_.
- [x] Tests added to ensure functionality.
- [x] Pull Request to `stable` branch.