### PR TITLE
fix: Changing all middlewares to use asynchronous policy execution. (fixes #232)

### DIFF
--- a/RawRabbit.sln
+++ b/RawRabbit.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26228.9
+VisualStudioVersion = 15.0.26403.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{7FCF8D3B-BA55-4C47-AC60-5CEF75418BEB}"
 EndProject

--- a/src/RawRabbit.Enrichers.Polly/Middleware/BasicPublishMiddleware.cs
+++ b/src/RawRabbit.Enrichers.Polly/Middleware/BasicPublishMiddleware.cs
@@ -3,6 +3,7 @@ using RabbitMQ.Client;
 using RawRabbit.Common;
 using RawRabbit.Pipe;
 using RawRabbit.Pipe.Middleware;
+using System.Threading.Tasks;
 
 namespace RawRabbit.Enrichers.Polly.Middleware
 {
@@ -21,8 +22,7 @@ namespace RawRabbit.Enrichers.Polly.Middleware
 				IPipeContext context)
 		{
 			var policy = context.GetPolicy(PolicyKeys.BasicPublish);
-			policy.Execute(
-				action: () => base.BasicPublish(channel, exchange, routingKey, mandatory, basicProps, body, context),
+			policy.ExecuteAsync(action: () => { base.BasicPublish(channel, exchange, routingKey, mandatory, basicProps, body, context); return Task.FromResult(0); },
 				contextData: new Dictionary<string, object>
 				{
 					[RetryKey.PipeContext] = context,
@@ -31,7 +31,7 @@ namespace RawRabbit.Enrichers.Polly.Middleware
 					[RetryKey.PublishMandatory] = mandatory,
 					[RetryKey.BasicProperties] = basicProps,
 					[RetryKey.PublishBody] = body,
-				});
+				}).GetAwaiter().GetResult();			
 		}
 	}
 }

--- a/src/RawRabbit.Enrichers.Polly/Middleware/BasicPublishMiddleware.cs
+++ b/src/RawRabbit.Enrichers.Polly/Middleware/BasicPublishMiddleware.cs
@@ -12,7 +12,7 @@ namespace RawRabbit.Enrichers.Polly.Middleware
 		public BasicPublishMiddleware(IExclusiveLock exclusive, BasicPublishOptions options = null)
 			: base(exclusive, options) { }
 
-		protected override void BasicPublish(
+		protected override async Task BasicPublish(
 				IModel channel,
 				string exchange,
 				string routingKey,
@@ -22,7 +22,7 @@ namespace RawRabbit.Enrichers.Polly.Middleware
 				IPipeContext context)
 		{
 			var policy = context.GetPolicy(PolicyKeys.BasicPublish);
-			policy.ExecuteAsync(action: () => { base.BasicPublish(channel, exchange, routingKey, mandatory, basicProps, body, context); return Task.FromResult(0); },
+			await policy.ExecuteAsync(action: () => { base.BasicPublish(channel, exchange, routingKey, mandatory, basicProps, body, context); return Task.FromResult(0); },
 				contextData: new Dictionary<string, object>
 				{
 					[RetryKey.PipeContext] = context,
@@ -31,7 +31,7 @@ namespace RawRabbit.Enrichers.Polly.Middleware
 					[RetryKey.PublishMandatory] = mandatory,
 					[RetryKey.BasicProperties] = basicProps,
 					[RetryKey.PublishBody] = body,
-				}).GetAwaiter().GetResult();			
+				});			
 		}
 	}
 }

--- a/src/RawRabbit.Enrichers.Polly/Middleware/ExplicitAckMiddleware.cs
+++ b/src/RawRabbit.Enrichers.Polly/Middleware/ExplicitAckMiddleware.cs
@@ -11,15 +11,16 @@ namespace RawRabbit.Enrichers.Polly.Middleware
 		public ExplicitAckMiddleware(INamingConventions conventions, ExplicitAckOptions options = null)
 				: base(conventions, options) { }
 
-		protected override Acknowledgement AcknowledgeMessage(IPipeContext context)
+		protected override async Task<Acknowledgement> AcknowledgeMessage(IPipeContext context)
 		{
 			var policy = context.GetPolicy(PolicyKeys.MessageAcknowledge);
-			return policy.ExecuteAsync(
+			var result = await policy.ExecuteAsync(
 				action: () => { return Task.FromResult(base.AcknowledgeMessage(context)); },
 				contextData: new Dictionary<string, object>
 				{
 					[RetryKey.PipeContext] = context
-				}).GetAwaiter().GetResult();
+				});
+			return await result;
 		}
 	}
 }

--- a/src/RawRabbit.Enrichers.Polly/Middleware/ExplicitAckMiddleware.cs
+++ b/src/RawRabbit.Enrichers.Polly/Middleware/ExplicitAckMiddleware.cs
@@ -2,6 +2,7 @@
 using RawRabbit.Common;
 using RawRabbit.Pipe;
 using RawRabbit.Pipe.Middleware;
+using System.Threading.Tasks;
 
 namespace RawRabbit.Enrichers.Polly.Middleware
 {
@@ -13,12 +14,12 @@ namespace RawRabbit.Enrichers.Polly.Middleware
 		protected override Acknowledgement AcknowledgeMessage(IPipeContext context)
 		{
 			var policy = context.GetPolicy(PolicyKeys.MessageAcknowledge);
-			return policy.Execute(
-				action: () => base.AcknowledgeMessage(context),
+			return policy.ExecuteAsync(
+				action: () => { return Task.FromResult(base.AcknowledgeMessage(context)); },
 				contextData: new Dictionary<string, object>
 				{
 					[RetryKey.PipeContext] = context
-				});
+				}).GetAwaiter().GetResult();
 		}
 	}
 }

--- a/src/RawRabbit.Enrichers.Polly/PipeContextExtensions.cs
+++ b/src/RawRabbit.Enrichers.Polly/PipeContextExtensions.cs
@@ -11,10 +11,10 @@ namespace RawRabbit.Enrichers.Polly
 			return context.Get(policyName, fallback);
 		}
 
-		public static IPipeContext UsePolicy(this IPipeContext context, Policy poliocy, string policyName = null)
+		public static IPipeContext UsePolicy(this IPipeContext context, Policy policy, string policyName = null)
 		{
 			policyName = policyName ?? PolicyKeys.DefaultPolicy;
-			context.Properties.TryAdd(policyName, poliocy);
+			context.Properties.TryAdd(policyName, policy);
 			return context;
 		}
 	}

--- a/src/RawRabbit/Pipe/Middleware/BasicPublishMiddleware.cs
+++ b/src/RawRabbit/Pipe/Middleware/BasicPublishMiddleware.cs
@@ -65,7 +65,7 @@ namespace RawRabbit.Pipe.Middleware
 			await Next.InvokeAsync(context, token);
 		}
 
-		protected virtual void BasicPublish(IModel channel, string exchange, string routingKey, bool mandatory, IBasicProperties basicProps, byte[] body, IPipeContext context)
+		protected virtual Task BasicPublish(IModel channel, string exchange, string routingKey, bool mandatory, IBasicProperties basicProps, byte[] body, IPipeContext context)
 		{
 			channel.BasicPublish(
 				exchange: exchange,
@@ -74,6 +74,7 @@ namespace RawRabbit.Pipe.Middleware
 				basicProperties: basicProps,
 				body: body
 			);
+			return Task.FromResult(0);
 		}
 
 		protected virtual void ExclusiveExecute(IModel channel, Action<IModel> action, CancellationToken token)

--- a/src/RawRabbit/Pipe/Middleware/ExplicitAckMiddleware.cs
+++ b/src/RawRabbit/Pipe/Middleware/ExplicitAckMiddleware.cs
@@ -42,7 +42,7 @@ namespace RawRabbit.Pipe.Middleware
 			var noAck = GetNoAck(context);
 			if (!noAck)
 			{
-				var ack = AcknowledgeMessage(context);
+				var ack = await AcknowledgeMessage(context);
 				if (AbortExecution(ack))
 				{
 					return;
@@ -51,7 +51,7 @@ namespace RawRabbit.Pipe.Middleware
 			await Next.InvokeAsync(context, token);
 		}
 		
-		protected virtual Acknowledgement AcknowledgeMessage(IPipeContext context)
+		protected virtual Task<Acknowledgement> AcknowledgeMessage(IPipeContext context)
 		{
 			var ack = (InvokationResultFunc(context) as Task<Acknowledgement>)?.Result;
 			if (ack == null)
@@ -64,22 +64,22 @@ namespace RawRabbit.Pipe.Middleware
 			if (ack is Ack)
 			{
 				HandleAck(ack as Ack, channel, deliveryArgs);
-				return ack;
+				return Task.FromResult(ack);
 			}
 			if (ack is Nack)
 			{
 				HandleNack(ack as Nack, channel, deliveryArgs);
-				return ack;
+				return Task.FromResult(ack);
 			}
 			if (ack is Reject)
 			{
 				HandleReject(ack as Reject, channel, deliveryArgs);
-				return ack;
+				return Task.FromResult(ack);
 			}
 			if (ack is Retry)
 			{
 				HandleRetry(ack as Retry, channel, deliveryArgs);
-				return ack;
+				return Task.FromResult(ack);
 			}
 
 			throw new NotSupportedException($"Unable to handle {ack.GetType()} as an Acknowledgement.");


### PR DESCRIPTION
### Description

This changes the Polly enricher to use asynchronous policy execution.  (fixes #232)

Note: I wasn't sure the best way to do this, but you might want to add some kind of detection in to reject the registration of synchronous policies, or add it to the docs.

### Check List

- [x ] All test passed.
- [x] Added documentation _(if applicable)_.
- [x] Tests added to ensure functionality.
- [ ] Pull Request to `stable` branch.