### PR TITLE
Configuration bug. "localhost" is always present when not included in configured host list.

### DIFF
--- a/src/RawRabbit.Extensions/Client/IServiceCollectionExtension.cs
+++ b/src/RawRabbit.Extensions/Client/IServiceCollectionExtension.cs
@@ -14,6 +14,8 @@ using RawRabbit.Logging;
 
 namespace RawRabbit.Extensions.Client
 {
+	using System.Collections.Generic;
+
 	public static class IServiceCollectionExtension
 	{
 		public static IServiceCollection AddRawRabbitExtensions<TMessageContext>(this IServiceCollection collection) where  TMessageContext : IMessageContext
@@ -66,6 +68,7 @@ namespace RawRabbit.Extensions.Client
 			custom += ioc => ioc.AddSingleton(c =>
 			{
 				var mainCfg = RawRabbitConfiguration.Local;
+				mainCfg.Hostnames.Clear();
 				section.Bind(mainCfg);
 				mainCfg.Hostnames = mainCfg.Hostnames.Distinct(StringComparer.CurrentCultureIgnoreCase).ToList();
 				return mainCfg;

--- a/src/RawRabbit.Extensions/MessageSequence/Core/Abstraction/IMessageChainTopologyUtil.cs
+++ b/src/RawRabbit.Extensions/MessageSequence/Core/Abstraction/IMessageChainTopologyUtil.cs
@@ -5,9 +5,9 @@ namespace RawRabbit.Extensions.MessageSequence.Core.Abstraction
 {
 	public interface IMessageChainTopologyUtil
 	{
-		Task BindToExchange<T>(Guid globalMessaegId);
-		Task BindToExchange(Type messageType, Guid globalMessaegId);
-		Task UnbindFromExchange<T>(Guid globalMessaegId);
-		Task UnbindFromExchange(Type messageType, Guid globalMessaegId);
+		Task BindToExchange<T>(Guid globalMessageId);
+		Task BindToExchange(Type messageType, Guid globalMessageId);
+		Task UnbindFromExchange<T>(Guid globalMessageId);
+		Task UnbindFromExchange(Type messageType, Guid globalMessageId);
 	}
 }

--- a/src/RawRabbit.Extensions/MessageSequence/Core/MessageChainTopologyUtil.cs
+++ b/src/RawRabbit.Extensions/MessageSequence/Core/MessageChainTopologyUtil.cs
@@ -42,33 +42,33 @@ namespace RawRabbit.Extensions.MessageSequence.Core
 			InitializeConsumer();
 		}
 
-		public Task BindToExchange<TMessage>(Guid globalMessaegId)
+		public Task BindToExchange<TMessage>(Guid globalMessageId)
 		{
-			return BindToExchange(typeof(TMessage), globalMessaegId);
+			return BindToExchange(typeof(TMessage), globalMessageId);
 		}
 
-		public Task BindToExchange(Type messageType, Guid globalMessaegId)
+		public Task BindToExchange(Type messageType, Guid globalMessageId)
 		{
 			var chainConfig = _configEvaluator.GetConfiguration(messageType);
 			return _topologyProvider.BindQueueAsync(
 				_queueConfig,
 				chainConfig.Exchange,
-				$"{chainConfig.RoutingKey}.{globalMessaegId}"
+				$"{chainConfig.RoutingKey}.{globalMessageId}"
 			);
 		}
 
-		public Task UnbindFromExchange<TMessage>(Guid globalMessaegId)
+		public Task UnbindFromExchange<TMessage>(Guid globalMessageId)
 		{
-			return UnbindFromExchange(typeof(TMessage), globalMessaegId);
+			return UnbindFromExchange(typeof(TMessage), globalMessageId);
 		}
 
-		public Task UnbindFromExchange(Type messageType, Guid globalMessaegId)
+		public Task UnbindFromExchange(Type messageType, Guid globalMessageId)
 		{
 			var chainConfig = _configEvaluator.GetConfiguration(messageType);
 			return _topologyProvider.UnbindQueueAsync(
 				_queueConfig,
 				chainConfig.Exchange,
-				$"{chainConfig.RoutingKey}.{globalMessaegId}"
+				$"{chainConfig.RoutingKey}.{globalMessageId}"
 			);
 		}
 

--- a/src/RawRabbit.vNext/IServiceCollectionExtensions.cs
+++ b/src/RawRabbit.vNext/IServiceCollectionExtensions.cs
@@ -44,6 +44,7 @@ namespace RawRabbit.vNext
 				var builder = new ConfigurationBuilder();
 				config?.Invoke(builder);
 				var mainCfg = RawRabbitConfiguration.Local;
+				mainCfg.Hostnames.Clear();
 				builder.Build().Bind(mainCfg);
 				mainCfg.Hostnames = mainCfg.Hostnames.Distinct(StringComparer.CurrentCultureIgnoreCase).ToList();
 
@@ -55,7 +56,7 @@ namespace RawRabbit.vNext
 			}
 
 			collection
-				.AddSingleton< IConnectionFactory, ConnectionFactory>(provider =>
+				.AddSingleton<IConnectionFactory, ConnectionFactory>(provider =>
 				{
 					var cfg = provider.GetService<RawRabbitConfiguration>();
 					return new ConnectionFactory

--- a/src/RawRabbit/ErrorHandling/DefaultStrategy.cs
+++ b/src/RawRabbit/ErrorHandling/DefaultStrategy.cs
@@ -97,7 +97,7 @@ namespace RawRabbit.ErrorHandling
 
 		public virtual Task OnResponseRecievedException(IRawConsumer rawConsumer, IConsumerConfiguration cfg, BasicDeliverEventArgs args, TaskCompletionSource<object> responseTcs, Exception exception)
 		{
-			_logger.LogError($"An exception was thrown when recieving response to messaeg '{args.BasicProperties.MessageId}' with CorrelationId '{args.BasicProperties.CorrelationId}'.", exception);
+			_logger.LogError($"An exception was thrown when recieving response to message '{args.BasicProperties.MessageId}' with CorrelationId '{args.BasicProperties.CorrelationId}'.", exception);
 			responseTcs.TrySetException(exception);
 			return Task.FromResult(true);
 		}


### PR DESCRIPTION
### Description

When I provide a host name in my configuration, it does not replace the default host name "localhost", but adds it as a second host name. This causes all of my connections to be directed to localhost instead of my configured host.

### Check List

- [x ] All test passed.
- [x ] Added documentation _(if applicable)_.
- [x ] Tests added to ensure functionality.
- [x ] Pull Request to `stable` branch.