### PR TITLE
(#301) Recovery from connection failure

### DIFF
--- a/src/RawRabbit/Channel/ChannelFactory.cs
+++ b/src/RawRabbit/Channel/ChannelFactory.cs
@@ -82,7 +82,7 @@ namespace RawRabbit.Channel
 
 			_logger.Debug("Connection is recoverable. Waiting for 'Recovery' event to be triggered. ");
 			var recoverTcs = new TaskCompletionSource<IConnection>();
-			token.Register(() => recoverTcs.SetCanceled());
+			token.Register(() => recoverTcs.TrySetCanceled());
 
 			EventHandler<EventArgs> completeTask = null;
 			completeTask = (sender, args) =>

--- a/src/RawRabbit/Channel/StaticChannelPool.cs
+++ b/src/RawRabbit/Channel/StaticChannelPool.cs
@@ -53,10 +53,17 @@ namespace RawRabbit.Channel
 			do
 			{
 				_current = _current?.Next ?? Pool.First;
+				if (_current == null)
+				{
+					_logger.Debug("Unable to server channels. Pool empty.");
+					Monitor.Exit(_workLock);
+					return;
+				}
 				if (_current.Value.IsClosed)
 				{
 					Pool.Remove(_current);
 					if (Pool.Count != 0) continue;
+					Monitor.Exit(_workLock);
 					if (Recoverables.Count == 0)
 					{
 						throw new ChannelAvailabilityException("No open channels in pool and no recoverable channels");


### PR DESCRIPTION
Monitor is correctly released in StaticChannelPool in case of
connection failure.

### Description

This solves issue :  https://github.com/pardahlman/RawRabbit/issues/301



### Check List

- [ ] All test passed.
- [ ] Added documentation _(if applicable)_.
- [ ] Tests added to ensure functionality.
- [ ] Pull Request to `stable` branch.