### PR TITLE
Fixing : Get request on empty queue throws a null exception

### DIFF
--- a/src/RawRabbit.Operations.Get/GetOfTOperation.cs
+++ b/src/RawRabbit.Operations.Get/GetOfTOperation.cs
@@ -16,7 +16,7 @@ namespace RawRabbit
 		public static readonly Action<IPipeBuilder> DeserializedBodyGetPipe = pipe => pipe
 			.Use<GetConfigurationMiddleware>()
 			.Use<ConventionNamingMiddleware>()
-			.Use<ChannelCreationMiddleware>()
+			.Use<PooledChannelMiddleware>()
 			.Use<BasicGetMiddleware>()
 			.Use<BodyDeserializationMiddleware>(new MessageDeserializationOptions
 			{

--- a/src/RawRabbit.Operations.Get/GetOperation.cs
+++ b/src/RawRabbit.Operations.Get/GetOperation.cs
@@ -19,7 +19,7 @@ namespace RawRabbit
 			.Use<BasicGetMiddleware>()
 			.Use<AckableResultMiddleware>(new AckableResultOptions
 			{
-				DeliveryTagFunc = context => context.GetBasicGetResult().DeliveryTag,
+				DeliveryTagFunc = context => context.GetBasicGetResult()?.DeliveryTag ?? 0,
 				ContentFunc = context => context.GetBasicGetResult()
 			});
 

--- a/src/RawRabbit.Operations.Get/GetOperation.cs
+++ b/src/RawRabbit.Operations.Get/GetOperation.cs
@@ -15,7 +15,7 @@ namespace RawRabbit
 	{
 		public static readonly Action<IPipeBuilder> UntypedGetPipe = pipe => pipe
 			.Use<GetConfigurationMiddleware>()
-			.Use<ChannelCreationMiddleware>()
+			.Use<PooledChannelMiddleware>()
 			.Use<BasicGetMiddleware>()
 			.Use<AckableResultMiddleware>(new AckableResultOptions
 			{

--- a/src/RawRabbit.Operations.Get/Middleware/AckableResultMiddleware.cs
+++ b/src/RawRabbit.Operations.Get/Middleware/AckableResultMiddleware.cs
@@ -33,7 +33,7 @@ namespace RawRabbit.Operations.Get.Middleware
 		public AckableResultMiddleware(AckableResultOptions<TResult> options = null)
 		{
 			GetResultFunc = options?.ContentFunc;
-			ChannelFunc = options?.ChannelFunc ?? (context => context.GetChannel());
+			ChannelFunc = options?.ChannelFunc ?? (context => context.GetTransientChannel());
 			PostExecutionAction = options?.PostExecutionAction;
 			DeliveryTagFunc = options?.DeliveryTagFunc;
 		}

--- a/src/RawRabbit.Operations.Get/Middleware/BasicGetMiddleware.cs
+++ b/src/RawRabbit.Operations.Get/Middleware/BasicGetMiddleware.cs
@@ -23,7 +23,7 @@ namespace RawRabbit.Operations.Get.Middleware
 
 		public BasicGetMiddleware(BasicGetOptions options = null)
 		{
-			ChannelFunc = options?.ChannelFunc ?? (context => context.GetChannel());
+			ChannelFunc = options?.ChannelFunc ?? (context => context.GetTransientChannel());
 			QueueNameFunc = options?.QueueNameFunc ?? (context => context.GetGetConfiguration()?.QueueName);
 			AutoAckFunc = options?.AutoAckFunc ?? (context => context.GetGetConfiguration()?.AutoAck ?? false);
 			PostExecutionAction = options?.PostExecutionAction;


### PR DESCRIPTION
### Description

Fixing : Get request on empty queue throws a null exception
fix #323 

Fixing : Get Operation causing "ChannelAllocationException: The connection cannot support any more channels. Consider creating a new connection"

fix #325 
### Check List

- [ ] All test passed.
- [ ] Added documentation _(if applicable)_.
- [ X] Tests added to ensure functionality.
- [ ] Pull Request to `stable` branch.