### PR TITLE
Binding Queue with arguments to headers exchange.

### DIFF
--- a/src/RawRabbit.Enrichers.RetryLater/Middleware/RetryLaterMiddleware.cs
+++ b/src/RawRabbit.Enrichers.RetryLater/Middleware/RetryLaterMiddleware.cs
@@ -75,12 +75,12 @@ namespace RawRabbit.Middleware
 					{QueueArgument.MessageTtl, Convert.ToInt32(retryAck.Span.TotalMilliseconds)}
 				}
 			});
-			await TopologyProvider.BindQueueAsync(deadLetterQueueName, deadLeterExchangeName, deliveryArgs.RoutingKey);
+			await TopologyProvider.BindQueueAsync(deadLetterQueueName, deadLeterExchangeName, deliveryArgs.RoutingKey, deliveryArgs.BasicProperties.Headers);
 			using (var publishChannel = await ChannelFactory.CreateChannelAsync(token))
 			{
 				publishChannel.BasicPublish(deadLeterExchangeName, deliveryArgs.RoutingKey, false, deliveryArgs.BasicProperties, deliveryArgs.Body);
 			}
-			await TopologyProvider.UnbindQueueAsync(deadLetterQueueName, deadLeterExchangeName, deliveryArgs.RoutingKey);
+			await TopologyProvider.UnbindQueueAsync(deadLetterQueueName, deadLeterExchangeName, deliveryArgs.RoutingKey, deliveryArgs.BasicProperties.Headers);
 
 			context.Properties.AddOrReplace(PipeKey.MessageAcknowledgement, new Ack());
 			await Next.InvokeAsync(context, token);

--- a/src/RawRabbit/Common/TopologyProvider.cs
+++ b/src/RawRabbit/Common/TopologyProvider.cs
@@ -81,7 +81,7 @@ namespace RawRabbit.Common
 				return _completed;
 			}
 
-			var bindKey = $"{queue}_{exchange}_{routingKey}";
+			var bindKey = CreateBindKey(queue, exchange, routingKey, arguments);
 			if (_queueBinds.Contains(bindKey))
 			{
 				return _completed;
@@ -175,7 +175,9 @@ namespace RawRabbit.Common
 			var bindKey = $"{queue}_{exchange}_{routingKey}";
 			if (arguments != null && arguments.Count > 0)
 			{
-				bindKey = $"{bindKey}_{string.Join("_", arguments.Select(pair => $"{pair.Key}:{pair.Value}"))}";
+				// order the arguments, for the key to be identical no matter the ordering
+				IOrderedEnumerable<KeyValuePair<string, object>> orderedArguments = arguments.OrderBy(pair => pair.Key);
+				bindKey = $"{bindKey}_{string.Join("_", orderedArguments.Select(pair => $"{pair.Key}:{pair.Value}"))}";
 			}
 			return bindKey;
 		}

--- a/src/RawRabbit/Common/TopologyProvider.cs
+++ b/src/RawRabbit/Common/TopologyProvider.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using RabbitMQ.Client;
@@ -15,8 +16,8 @@ namespace RawRabbit.Common
 	{
 		Task DeclareExchangeAsync(ExchangeDeclaration exchange);
 		Task DeclareQueueAsync(QueueDeclaration queue);
-		Task BindQueueAsync(string queue, string exchange, string routingKey);
-		Task UnbindQueueAsync(string queue, string exchange, string routingKey);
+		Task BindQueueAsync(string queue, string exchange, string routingKey, IDictionary<string, object> arguments);
+		Task UnbindQueueAsync(string queue, string exchange, string routingKey, IDictionary<string, object> arguments);
 		bool IsDeclared(ExchangeDeclaration exchange);
 		bool IsDeclared(QueueDeclaration exchange);
 	}
@@ -68,7 +69,7 @@ namespace RawRabbit.Common
 			return scheduled.TaskCompletionSource.Task;
 		}
 
-		public Task BindQueueAsync(string queue, string exchange, string routingKey)
+		public Task BindQueueAsync(string queue, string exchange, string routingKey, IDictionary<string,object> arguments)
 		{
 			if (string.Equals(exchange, string.Empty))
 			{
@@ -89,20 +90,22 @@ namespace RawRabbit.Common
 			{
 				Queue = queue,
 				Exchange = exchange,
-				RoutingKey = routingKey
+				RoutingKey = routingKey,
+				Arguments = arguments
 			};
 			_topologyTasks.Enqueue(scheduled);
 			EnsureWorker();
 			return scheduled.TaskCompletionSource.Task;
 		}
 
-		public Task UnbindQueueAsync(string queue, string exchange, string routingKey)
+		public Task UnbindQueueAsync(string queue, string exchange, string routingKey, IDictionary<string, object> arguments)
 		{
 			var scheduled = new ScheduledUnbindQueueTask
 			{
 				Queue = queue,
 				Exchange = exchange,
-				RoutingKey = routingKey
+				RoutingKey = routingKey,
+				Arguments = arguments
 			};
 			_topologyTasks.Enqueue(scheduled);
 			EnsureWorker();
@@ -121,7 +124,7 @@ namespace RawRabbit.Common
 
 		private void BindQueueToExchange(ScheduledBindQueueTask bind)
 		{
-			var bindKey = $"{bind.Queue}_{bind.Exchange}_{bind.RoutingKey}";
+			string bindKey = CreateBindKey(bind);
 			if (_queueBinds.Contains(bindKey))
 			{
 				return;
@@ -133,8 +136,9 @@ namespace RawRabbit.Common
 			channel.QueueBind(
 				queue: bind.Queue,
 				exchange: bind.Exchange,
-				routingKey: bind.RoutingKey
-				);
+				routingKey: bind.RoutingKey,
+				arguments: bind.Arguments
+			);
 			_queueBinds.Add(bindKey);
 		}
 
@@ -147,13 +151,33 @@ namespace RawRabbit.Common
 				queue: bind.Queue,
 				exchange: bind.Exchange,
 				routingKey: bind.RoutingKey,
-				arguments: null
+				arguments: bind.Arguments
 			);
-			var bindKey = $"{bind.Queue}_{bind.Exchange}_{bind.RoutingKey}";
+			var bindKey = CreateBindKey(bind);
 			if (_queueBinds.Contains(bindKey))
 			{
 				_queueBinds.Remove(bindKey);
 			}
+		}
+		
+		private static string CreateBindKey(ScheduledBindQueueTask bind)
+		{
+			return CreateBindKey(bind.Queue, bind.Exchange, bind.RoutingKey, bind.Arguments);
+		}
+
+		private static string CreateBindKey(ScheduledUnbindQueueTask bind)
+		{
+			return CreateBindKey(bind.Queue, bind.Exchange, bind.RoutingKey, bind.Arguments);
+		}
+
+		private static string CreateBindKey(string queue, string exchange, string routingKey, IDictionary<string, object> arguments)
+		{
+			var bindKey = $"{queue}_{exchange}_{routingKey}";
+			if (arguments != null && arguments.Count > 0)
+			{
+				bindKey = $"{bindKey}_{string.Join("_", arguments.Select(pair => $"{pair.Key}:{pair.Value}"))}";
+			}
+			return bindKey;
 		}
 
 		private void DeclareQueue(QueueDeclaration queue)
@@ -331,6 +355,7 @@ namespace RawRabbit.Common
 			public string Exchange { get; set; }
 			public string Queue { get; set; }
 			public string RoutingKey { get; set; }
+			public IDictionary<string,object> Arguments { get; set; }
 		}
 
 		private class ScheduledUnbindQueueTask : ScheduledTopologyTask
@@ -338,6 +363,7 @@ namespace RawRabbit.Common
 			public string Exchange { get; set; }
 			public string Queue { get; set; }
 			public string RoutingKey { get; set; }
+			public IDictionary<string, object> Arguments { get; set; }
 		}
 		#endregion
 	}

--- a/src/RawRabbit/Pipe/Middleware/QueueBindMiddleware.cs
+++ b/src/RawRabbit/Pipe/Middleware/QueueBindMiddleware.cs
@@ -41,7 +41,7 @@ namespace RawRabbit.Pipe.Middleware
 
 		protected virtual Task BindQueueAsync(string queue, string exchange, string routingKey, IPipeContext context, CancellationToken ct)
 		{
-			return TopologyProvider.BindQueueAsync(queue, exchange, routingKey);
+			return TopologyProvider.BindQueueAsync(queue, exchange, routingKey, context.GetConsumeConfiguration()?.Arguments);
 		}
 
 		protected virtual string GetRoutingKey(IPipeContext context)

--- a/src/RawRabbit/RawRabbit.csproj
+++ b/src/RawRabbit/RawRabbit.csproj
@@ -5,7 +5,7 @@
     <AssemblyTitle>RawRabbit</AssemblyTitle>
     <VersionPrefix>2.0.0</VersionPrefix>
     <Authors>pardahlman;enrique-avalon</Authors>
-    <TargetFrameworks>netstandard1.5</TargetFrameworks>
+    <TargetFrameworks>netstandard1.5;net451</TargetFrameworks>
     <AssemblyName>RawRabbit</AssemblyName>
     <PackageId>RawRabbit</PackageId>
     <PackageTags>rabbitmq;rawrabbit;amqp</PackageTags>
@@ -22,9 +22,9 @@
     <PackageReference Include="Newtonsoft.Json" Version="10.0.1" />
   </ItemGroup>
 
-  <!--<ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
-  </ItemGroup>-->
+  </ItemGroup>
 
 </Project>

--- a/src/RawRabbit/RawRabbit.csproj
+++ b/src/RawRabbit/RawRabbit.csproj
@@ -5,7 +5,7 @@
     <AssemblyTitle>RawRabbit</AssemblyTitle>
     <VersionPrefix>2.0.0</VersionPrefix>
     <Authors>pardahlman;enrique-avalon</Authors>
-    <TargetFrameworks>netstandard1.5;net451</TargetFrameworks>
+    <TargetFrameworks>netstandard1.5</TargetFrameworks>
     <AssemblyName>RawRabbit</AssemblyName>
     <PackageId>RawRabbit</PackageId>
     <PackageTags>rabbitmq;rawrabbit;amqp</PackageTags>
@@ -22,9 +22,9 @@
     <PackageReference Include="Newtonsoft.Json" Version="10.0.1" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
+  <!--<ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
-  </ItemGroup>
+  </ItemGroup>-->
 
 </Project>


### PR DESCRIPTION
### Description

Adding basic support for binding a queue with arguments to a headers exchange.
Previously all arguments set on the Consume Configuration were ignored.

### Check List

- [ ] All test passed.
- [ ] Added documentation _(if applicable)_.
- [ ] Tests added to ensure functionality.
- [ ] Pull Request to `stable` branch.