### PR TITLE
Fix exception objects not being logged properly

### DIFF
--- a/src/RawRabbit/Pipe/Middleware/ExceptionHandlingMiddleware.cs
+++ b/src/RawRabbit/Pipe/Middleware/ExceptionHandlingMiddleware.cs
@@ -8,6 +8,7 @@ namespace RawRabbit.Pipe.Middleware
 	public class ExceptionHandlingOptions
 	{
 		public Func<Exception, IPipeContext, CancellationToken, Task> HandlingFunc { get; set; }
+
 		public Action<IPipeBuilder> InnerPipe { get; set; }
 	}
 
@@ -32,7 +33,7 @@ namespace RawRabbit.Pipe.Middleware
 			}
 			catch (Exception e)
 			{
-				_logger.Error("Exception thrown. Will be handled by Exception Handler", e);
+				_logger.Error(e, "Exception thrown. Will be handled by Exception Handler");
 				await OnExceptionAsync(e, context, token);
 			}
 		}


### PR DESCRIPTION
### Description

The order of arguments sent to `_logger.Error` in
`ExceptionHandlingMiddleware` was incorrect, causing exception objects
to not be logged properly. The exception object was passed in as a
format parameter, but as the log message didn't contain any formatting
placeholders, the exception object was lost in the resulting log output.

This change puts the exception object as the first argument, as the
Error log method requires.

This fixes #340.

### Check List

- [?] All test passed. There are tests that are failing in the current `2.0` so I'm not sure what to make of that.
- [X] Added documentation _(if applicable)_.
- [ ] Tests added to ensure functionality. Not sure how to test for log output correctness?
- [ ] Pull Request to `stable` branch. *N/A, this change is for 2.0.*