### PR TITLE
(#342 and #343) Making Proposed ClientConfiguration And ExecutionLock Changes

### DIFF
--- a/src/RawRabbit/Channel/ChannelFactory.cs
+++ b/src/RawRabbit/Channel/ChannelFactory.cs
@@ -31,7 +31,7 @@ namespace RawRabbit.Channel
 			try
 			{
 				_logger.Debug("Creating a new connection for {hostNameCount} hosts.", ClientConfig.Hostnames.Count);
-				Connection = ConnectionFactory.CreateConnection(ClientConfig.Hostnames);
+				Connection = ConnectionFactory.CreateConnection(ClientConfig.Hostnames, ClientConfig.ClientProvidedName);
 				Connection.ConnectionShutdown += (sender, args) =>
 					_logger.Warn("Connection was shutdown by {Initiator}. ReplyText {ReplyText}", args.Initiator, args.ReplyText);
 			}

--- a/src/RawRabbit/Common/ExclusiveLock.cs
+++ b/src/RawRabbit/Common/ExclusiveLock.cs
@@ -70,7 +70,10 @@ namespace RawRabbit.Common
 			{
 				await func(obj);
 			}
-			catch (Exception) { }
+			catch (Exception e)
+			{
+				_logger.ErrorException("Exception when performing exclusive executeasync", e);
+			}
 			finally
 			{
 				semaphore.Release();

--- a/src/RawRabbit/Configuration/RawRabbitConfiguration.cs
+++ b/src/RawRabbit/Configuration/RawRabbitConfiguration.cs
@@ -76,6 +76,8 @@ namespace RawRabbit.Configuration
 		public string Password { get; set; }
 		public int Port { get; set; }
 		public List<string> Hostnames { get; set; }
+		// Backwards Compatible, Customize Connection Label
+		public string ClientProvidedName { get; set; } = null;
 		public TimeSpan RecoveryInterval { get; set; }
 
 		public RawRabbitConfiguration()


### PR DESCRIPTION

### Description

Adds the ability to set Connection labels per RabbitMQ (5.x) implementation. It is also backwards compatible with pre-existing RawRabbit users. Labels located here:
![image](https://user-images.githubusercontent.com/1414138/39550807-95c82578-4e30-11e8-8671-09c82daa57b3.png)

Adds a line to log exceptions being currently missed with ExecuteAsync is called.

Commit Notes:
- Adds ClientProvidedName string for Configuration.
- Calls CreateConnection with the ClientProvidedName parameter.
- ExecutionLock added a ILog.ErrorException () call.

### Check List

- [x] All test passed.
- [ ] Added documentation _(if applicable)_.
- [ ] Tests added to ensure functionality.
- [ ] Pull Request to `stable` branch.