### PR TITLE
(#345) Allow messageTtl attribute to set the ttl to 0

### DIFF
--- a/src/RawRabbit.Enrichers.Attributes/Middleware/ConsumeAttributeMiddleware.cs
+++ b/src/RawRabbit.Enrichers.Attributes/Middleware/ConsumeAttributeMiddleware.cs
@@ -134,7 +134,7 @@ namespace RawRabbit.Enrichers.Attributes.Middleware
 			{
 				config.Queue.AutoDelete= attribute.AutoDelete;
 			}
-			if (attribute.MessageTtl > 0)
+			if (attribute.MessageTtl >= 0)
 			{
 				config.Queue.Arguments.AddOrReplace(QueueArgument.MessageTtl, attribute.MessageTtl);
 			}


### PR DESCRIPTION
### Description

Fixes #345 
Allows the Message TTL to be set to 0 via Attributes.

### Check List

- [ ] All test passed.
- [ ] Added documentation _(if applicable)_.
- [ ] Tests added to ensure functionality.
- [ ] Pull Request to `stable` branch.