### PR TITLE
(#348) Fix Receive word misspelling

### DIFF
--- a/sample/RawRabbit.AspNet.Sample/Controllers/ValuesController.cs
+++ b/sample/RawRabbit.AspNet.Sample/Controllers/ValuesController.cs
@@ -27,7 +27,7 @@ namespace RawRabbit.AspNet.Sample.Controllers
 		[Route("api/values")]
 		public async Task<IActionResult> GetAsync()
 		{
-			_logger.LogDebug("Recieved Value Request.");
+			_logger.LogDebug("Received Value Request.");
 			var valueSequence = _busClient.ExecuteSequence(s => s
 				.PublishAsync(new ValuesRequested
 					{
@@ -48,7 +48,7 @@ namespace RawRabbit.AspNet.Sample.Controllers
 			}
 			catch (Exception e)
 			{
-				return StatusCode((int)HttpStatusCode.InternalServerError, $"No response recieved. Is the Console App started? \n\nException: {e}");
+				return StatusCode((int)HttpStatusCode.InternalServerError, $"No response received. Is the Console App started? \n\nException: {e}");
 			}
 
 			_logger.LogInformation("Successfully created {valueCount} values", valueSequence.Task.Result.Values.Count);

--- a/src/RawRabbit.Enrichers.GlobalExecutionId/GlobalExecutionIdPlugin.cs
+++ b/src/RawRabbit.Enrichers.GlobalExecutionId/GlobalExecutionIdPlugin.cs
@@ -19,7 +19,7 @@ namespace RawRabbit.Enrichers.GlobalExecutionId
 				// Subscriber
 				.Use<WildcardRoutingKeyMiddleware>()
 
-				// Message Recieved
+				// Message Received
 				.Use<HeaderDeserializationMiddleware>(new HeaderDeserializationOptions
 				{
 					HeaderKeyFunc = c => PropertyHeaders.GlobalExecutionId,

--- a/src/RawRabbit.Enrichers.GlobalExecutionId/Middleware/PersistGlobalExecutionIdMiddleware.cs
+++ b/src/RawRabbit.Enrichers.GlobalExecutionId/Middleware/PersistGlobalExecutionIdMiddleware.cs
@@ -16,7 +16,7 @@ namespace RawRabbit.Enrichers.GlobalExecutionId.Middleware
 	{
 		protected Func<IPipeContext, string> ExecutionIdFunc;
 
-		public override string StageMarker => Pipe.StageMarker.MessageRecieved;
+		public override string StageMarker => Pipe.StageMarker.MessageReceived;
 
 		public PersistGlobalExecutionIdMiddleware(PersistGlobalExecutionIdOptions options = null)
 		{

--- a/src/RawRabbit.Enrichers.MessageContext.Subscribe/MessageContextSubscibeStage.cs
+++ b/src/RawRabbit.Enrichers.MessageContext.Subscribe/MessageContextSubscibeStage.cs
@@ -2,7 +2,7 @@
 {
 	public enum MessageContextSubscibeStage
 	{
-		MessageRecieved,
+		MessageReceived,
 		MessageDeserialized,
 		MessageContextDeserialized,
 		MessageContextEnhanced,

--- a/src/RawRabbit.Enrichers.MessageContext.Subscribe/SubscribeMessageContextExtension.cs
+++ b/src/RawRabbit.Enrichers.MessageContext.Subscribe/SubscribeMessageContextExtension.cs
@@ -13,7 +13,7 @@ namespace RawRabbit
 	public static class SubscribeMessageContextExtension
 	{
 		public static readonly Action<IPipeBuilder> ConsumePipe = consume => consume
-			.Use<StageMarkerMiddleware>(StageMarkerOptions.For(StageMarker.MessageRecieved))
+			.Use<StageMarkerMiddleware>(StageMarkerOptions.For(StageMarker.MessageReceived))
 			.Use<HeaderDeserializationMiddleware>(new HeaderDeserializationOptions
 			{
 				HeaderKeyFunc = c => PropertyHeaders.Context,

--- a/src/RawRabbit.Enrichers.RetryLater/Middleware/RetryInformationExtractionMiddleware.cs
+++ b/src/RawRabbit.Enrichers.RetryLater/Middleware/RetryInformationExtractionMiddleware.cs
@@ -17,7 +17,7 @@ namespace RawRabbit.Middleware
 	{
 		private readonly IRetryInformationProvider _retryProvider;
 		protected Func<IPipeContext, BasicDeliverEventArgs> DeliveryArgsFunc;
-		public override string StageMarker => Pipe.StageMarker.MessageRecieved;
+		public override string StageMarker => Pipe.StageMarker.MessageReceived;
 
 		public RetryInformationExtractionMiddleware(IRetryInformationProvider retryProvider, RetryInformationExtractionOptions options = null)
 		{

--- a/src/RawRabbit.Operations.MessageSequence/StateMachine/MessageSequence.cs
+++ b/src/RawRabbit.Operations.MessageSequence/StateMachine/MessageSequence.cs
@@ -110,7 +110,7 @@ namespace RawRabbit.Operations.MessageSequence.StateMachine
 				.Configure(SequenceState.Active)
 				.InternalTransitionAsync(trigger, async (message, transition) =>
 				{
-					_logger.Debug("Recieved message of type {messageType} for sequence {sequenceId}.", transition.Trigger.Name, Model.Id);
+					_logger.Debug("Received message of type {messageType} for sequence {sequenceId}.", transition.Trigger.Name, Model.Id);
 					var matchFound = false;
 					do
 					{
@@ -124,7 +124,7 @@ namespace RawRabbit.Operations.MessageSequence.StateMachine
 						{
 							if (step.Optional)
 							{
-								_logger.Info("The step for {optionalMessageType} is optional. Skipping, as recieved message is of type {currentMessageType}.", step.Type.Name, typeof(TMessage).Name);
+								_logger.Info("The step for {optionalMessageType} is optional. Skipping, as received message is of type {currentMessageType}.", step.Type.Name, typeof(TMessage).Name);
 								Model.Skipped.Add(new ExecutionResult
 								{
 									Type = step.Type,

--- a/src/RawRabbit.Operations.Publish/Middleware/PublishAcknowledgeMiddleware.cs
+++ b/src/RawRabbit.Operations.Publish/Middleware/PublishAcknowledgeMiddleware.cs
@@ -135,7 +135,7 @@ namespace RawRabbit.Operations.Publish.Middleware
 						}
 						else
 						{
-							_logger.Info("Recieived ack for {deliveryTag}", args.DeliveryTag);
+							_logger.Info("Received ack for {deliveryTag}", args.DeliveryTag);
 							if (!dictionary.TryRemove(args.DeliveryTag, out var tcs))
 							{
 								_logger.Warn("Unable to find ack tcs for {deliveryTag}", args.DeliveryTag);

--- a/src/RawRabbit.Operations.Request/Middleware/ResponseConsumeMiddleware.cs
+++ b/src/RawRabbit.Operations.Request/Middleware/ResponseConsumeMiddleware.cs
@@ -15,7 +15,7 @@ namespace RawRabbit.Operations.Request.Middleware
 {
 	public class ResponseConsumerOptions
 	{
-		public Action<IPipeBuilder> ResponseRecieved { get; set; }
+		public Action<IPipeBuilder> ResponseReceived { get; set; }
 		public Func<IPipeContext, ConsumerConfiguration> ResponseConfigFunc { get; set; }
 		public Func<IPipeContext, string> CorrelationIdFunc { get; set; }
 		public Func<IPipeContext, bool> UseDedicatedConsumer { get; set; }
@@ -39,7 +39,7 @@ namespace RawRabbit.Operations.Request.Middleware
 			CorrelationidFunc = options?.CorrelationIdFunc ?? (context => context.GetBasicProperties()?.CorrelationId);
 			DedicatedConsumerFunc = options?.UseDedicatedConsumer ?? (context => context.GetDedicatedResponseConsumer());
 			ConsumerFactory = consumerFactory;
-			ResponsePipe = factory.Create(options.ResponseRecieved);
+			ResponsePipe = factory.Create(options.ResponseReceived);
 		}
 
 		public override async Task InvokeAsync(IPipeContext context, CancellationToken token)
@@ -77,7 +77,7 @@ namespace RawRabbit.Operations.Request.Middleware
 			await Next.InvokeAsync(context, token);
 			token.Register(() => responseTsc.TrySetCanceled());
 			await responseTsc.Task;
-			_logger.Info("Message '{messageId}' for correlatrion '{correlationId}' recieved.", responseTsc.Task.Result.BasicProperties.MessageId, correlationId);
+			_logger.Info("Message '{messageId}' for correlatrion '{correlationId}' received.", responseTsc.Task.Result.BasicProperties.MessageId, correlationId);
 			if (dedicatedConsumer)
 			{
 				_logger.Info("Disposing dedicated consumer on queue {queueName}", respondCfg.Consume.QueueName);
@@ -121,7 +121,7 @@ namespace RawRabbit.Operations.Request.Middleware
 		/// 
 		/// Instruct the Request operation to create a unique consumer for
 		/// the response queue. The consumer will be cancelled once the
-		/// response message is recieved.
+		/// response message is received.
 		/// </summary>
 		public static IRequestContext UseDedicatedResponseConsumer(this IRequestContext context, bool useDedicated = true)
 		{

--- a/src/RawRabbit.Operations.Request/RequestExtension.cs
+++ b/src/RawRabbit.Operations.Request/RequestExtension.cs
@@ -41,7 +41,7 @@ namespace RawRabbit
 				.Use<RequestTimeoutMiddleware>()
 				.Use<ResponseConsumeMiddleware>(new ResponseConsumerOptions
 				{
-					ResponseRecieved = p => p
+					ResponseReceived = p => p
 						.Use<ResponderExceptionMiddleware>()
 						.Use<BodyDeserializationMiddleware>(new MessageDeserializationOptions
 						{

--- a/src/RawRabbit.Operations.Respond/Core/RespondStage.cs
+++ b/src/RawRabbit.Operations.Respond/Core/RespondStage.cs
@@ -8,7 +8,7 @@
 		public const string ExchangeDeclared = "ExchangeDeclared";
 		public const string QueueBound = "ExchangeDeclared";
 		public const string ConsumerCreated = "ConsumerCreated";
-		public const string MessageRecieved = "MessageRecieved";
+		public const string MessageReceived = "MessageReceived";
 		public const string MessageDeserialized = "MessageDeserialized";
 		public const string HandlerInvoked = "HandlerInvoked";
 		public const string BasicPropertiesCreated = "BasicPropertiesCreated";

--- a/src/RawRabbit.Operations.Respond/RespondExtension.cs
+++ b/src/RawRabbit.Operations.Respond/RespondExtension.cs
@@ -15,7 +15,7 @@ namespace RawRabbit
 	public static class RespondExtension
 	{
 		public static readonly Action<IPipeBuilder> ConsumePipe = pipe => pipe
-			.Use<StageMarkerMiddleware>(StageMarkerOptions.For(StageMarker.MessageRecieved))
+			.Use<StageMarkerMiddleware>(StageMarkerOptions.For(StageMarker.MessageReceived))
 			.Use<RespondExceptionMiddleware>(new RespondExceptionOptions { InnerPipe = p => p
 				.Use<BodyDeserializationMiddleware>(new MessageDeserializationOptions
 				{

--- a/src/RawRabbit.Operations.Subscribe/SubscribeMessageExtension.cs
+++ b/src/RawRabbit.Operations.Subscribe/SubscribeMessageExtension.cs
@@ -13,7 +13,7 @@ namespace RawRabbit
 	public static class SubscribeMessageExtension
 	{
 		public static readonly Action<IPipeBuilder> ConsumePipe = pipe => pipe
-			.Use<StageMarkerMiddleware>(StageMarkerOptions.For(StageMarker.MessageRecieved))
+			.Use<StageMarkerMiddleware>(StageMarkerOptions.For(StageMarker.MessageReceived))
 			.Use<SubscriptionExceptionMiddleware>(new SubscriptionExceptionOptions { InnerPipe = p => p
 				.Use<BodyDeserializationMiddleware>()
 				.Use<StageMarkerMiddleware>(StageMarkerOptions.For(StageMarker.MessageDeserialized))

--- a/src/RawRabbit/Common/QueueArgument.cs
+++ b/src/RawRabbit/Common/QueueArgument.cs
@@ -4,7 +4,7 @@
 	{
 		/// <summary>
 		/// Indicates that the queue is a priority queue that honours the <br />
-		/// priority property of a recieved message.
+		/// priority property of a received message.
 		/// </summary>
 		public static readonly string MaxPriority = "x-max-priority";
 

--- a/src/RawRabbit/Pipe/Middleware/BodyDeserializationMiddleware.cs
+++ b/src/RawRabbit/Pipe/Middleware/BodyDeserializationMiddleware.cs
@@ -43,7 +43,7 @@ namespace RawRabbit.Pipe.Middleware
 				var msgContentType = GetMessageContentType(context);
 				if (!CanSerializeMessage(msgContentType))
 				{
-					throw new SerializationException($"Registered serializer supports {Serializer.ContentType}, recieved message uses {msgContentType}.");
+					throw new SerializationException($"Registered serializer supports {Serializer.ContentType}, received message uses {msgContentType}.");
 				}
 			}
 			var message = GetMessage(context);
@@ -60,7 +60,7 @@ namespace RawRabbit.Pipe.Middleware
 		{
 			if (string.IsNullOrEmpty(msgContentType))
 			{
-				_logger.Debug("Recieved message has no content type defined. Assuming it can be processed.");
+				_logger.Debug("Received message has no content type defined. Assuming it can be processed.");
 				return true;
 			}
 			return string.Equals(msgContentType, Serializer.ContentType, StringComparison.CurrentCultureIgnoreCase);

--- a/src/RawRabbit/Pipe/Middleware/HeaderDeserializationMiddleware.cs
+++ b/src/RawRabbit/Pipe/Middleware/HeaderDeserializationMiddleware.cs
@@ -124,6 +124,6 @@ namespace RawRabbit.Pipe.Middleware
 			return type;
 		}
 
-		public override string StageMarker => Pipe.StageMarker.MessageRecieved;
+		public override string StageMarker => Pipe.StageMarker.MessageReceived;
 	}
 }

--- a/src/RawRabbit/Pipe/StageMarker.cs
+++ b/src/RawRabbit/Pipe/StageMarker.cs
@@ -7,7 +7,7 @@
 		public const string PublishConfigured = "PublishConfigured";
 		public const string ConsumeConfigured = "ConsumeConfigured";
 		public const string BasicPropertiesCreated = "BasicPropertiesCreated";
-		public const string MessageRecieved = "MessageRecieved";
+		public const string MessageReceived = "MessageReceived";
 		public const string MessageDeserialized = "MessageDeserialized";
 		public const string HandlerInvoked = "HandlerInvoked";
 		public const string MessageAcknowledged = "MessageAcknowledged";

--- a/test/RawRabbit.IntegrationTests/Compatibility/LegacyClientTests.cs
+++ b/test/RawRabbit.IntegrationTests/Compatibility/LegacyClientTests.cs
@@ -35,10 +35,10 @@ namespace RawRabbit.IntegrationTests.Compatibility
 			var subscriber = RawRabbit.Compatibility.Legacy.RawRabbitFactory.CreateClient(_legacyConfig);
 			var message = new BasicMessage { Prop = "Hello, world!" };
 			var tsc = new TaskCompletionSource<BasicMessage>();
-			MessageContext recievedContext = null;
+			MessageContext receivedContext = null;
 			var subscription = subscriber.SubscribeAsync<BasicMessage>((msg, context) =>
 			{
-				recievedContext = context;
+				receivedContext = context;
 				tsc.TrySetResult(msg);
 				return Task.FromResult(0);
 			});
@@ -49,7 +49,7 @@ namespace RawRabbit.IntegrationTests.Compatibility
 
 			/* Assert */
 			Assert.Equal(message.Prop, tsc.Task.Result.Prop);
-			Assert.NotNull(recievedContext);
+			Assert.NotNull(receivedContext);
 
 			TestChannel.QueueDelete(subscription.QueueName, false, false);
 			TestChannel.ExchangeDelete("rawrabbit.integrationtests.testmessages", false);
@@ -65,10 +65,10 @@ namespace RawRabbit.IntegrationTests.Compatibility
 			var subscriber = RawRabbit.Compatibility.Legacy.RawRabbitFactory.CreateClient(_legacyConfig);
 			var message = new BasicMessage { Prop = "Hello, world!" };
 			var tsc = new TaskCompletionSource<BasicMessage>();
-			MessageContext recievedContext = null;
+			MessageContext receivedContext = null;
 			subscriber.SubscribeAsync<BasicMessage>((msg, context) =>
 			{
-				recievedContext = context;
+				receivedContext = context;
 				tsc.TrySetResult(msg);
 				return Task.FromResult(0);
 			}, cfg => cfg
@@ -95,7 +95,7 @@ namespace RawRabbit.IntegrationTests.Compatibility
 
 			/* Assert */
 			Assert.Equal(message.Prop, tsc.Task.Result.Prop);
-			Assert.NotNull(recievedContext);
+			Assert.NotNull(receivedContext);
 
 			(publisher as IDisposable)?.Dispose();
 			(subscriber as IDisposable)?.Dispose();
@@ -115,10 +115,10 @@ namespace RawRabbit.IntegrationTests.Compatibility
 			var subscriber = RawRabbit.Compatibility.Legacy.RawRabbitFactory.CreateClient<TestMessageContext>(_legacyConfig);
 			var message = new BasicMessage { Prop = "Hello, world!" };
 			var tsc = new TaskCompletionSource<BasicMessage>();
-			TestMessageContext recievedContext = null;
+			TestMessageContext receivedContext = null;
 			subscriber.SubscribeAsync<BasicMessage>((msg, context) =>
 			{
-				recievedContext = context;
+				receivedContext = context;
 				tsc.TrySetResult(msg);
 				return Task.FromResult(0);
 			}, cfg => cfg
@@ -145,7 +145,7 @@ namespace RawRabbit.IntegrationTests.Compatibility
 
 			/* Assert */
 			Assert.Equal(message.Prop, tsc.Task.Result.Prop);
-			Assert.Equal(recievedContext.Prop, propValue);
+			Assert.Equal(receivedContext.Prop, propValue);
 
 			(publisher as IDisposable)?.Dispose();
 			(subscriber as IDisposable)?.Dispose();
@@ -157,13 +157,13 @@ namespace RawRabbit.IntegrationTests.Compatibility
 			/* Setup */
 			var requester = RawRabbit.Compatibility.Legacy.RawRabbitFactory.CreateClient(_legacyConfig);
 			var responder = RawRabbit.Compatibility.Legacy.RawRabbitFactory.CreateClient(_legacyConfig);
-			MessageContext recievedContext = null;
-			BasicRequest recievedRequest = null;
+			MessageContext receivedContext = null;
+			BasicRequest receivedRequest = null;
 			var request = new BasicRequest {Number = 3};
 			var subscription = responder.RespondAsync<BasicRequest, BasicResponse>((req, context) =>
 			{
-				recievedRequest = req;
-				recievedContext = context;
+				receivedRequest = req;
+				receivedContext = context;
 				return Task.FromResult(new BasicResponse());
 			});
 
@@ -171,8 +171,8 @@ namespace RawRabbit.IntegrationTests.Compatibility
 			var response = await requester.RequestAsync<BasicRequest, BasicResponse>(request);
 
 			/* Assert */
-			Assert.Equal(recievedRequest.Number, request.Number);
-			Assert.NotNull(recievedContext);
+			Assert.Equal(receivedRequest.Number, request.Number);
+			Assert.NotNull(receivedContext);
 
 			TestChannel.QueueDelete(subscription.QueueName, false, false);
 			TestChannel.ExchangeDelete("rawrabbit.integrationtests.testmessages", false);
@@ -187,13 +187,13 @@ namespace RawRabbit.IntegrationTests.Compatibility
 			/* Setup */
 			var requester = RawRabbit.Compatibility.Legacy.RawRabbitFactory.CreateClient(_legacyConfig);
 			var responder = RawRabbit.Compatibility.Legacy.RawRabbitFactory.CreateClient(_legacyConfig);
-			MessageContext recievedContext = null;
-			BasicRequest recievedRequest = null;
+			MessageContext receivedContext = null;
+			BasicRequest receivedRequest = null;
 			var request = new BasicRequest { Number = 3 };
 			var subscription = responder.RespondAsync<BasicRequest, BasicResponse>((req, context) =>
 			{
-				recievedRequest = req;
-				recievedContext = context;
+				receivedRequest = req;
+				receivedContext = context;
 				return Task.FromResult(new BasicResponse());
 			}, cfg => cfg.
 				WithExchange(e => e
@@ -221,8 +221,8 @@ namespace RawRabbit.IntegrationTests.Compatibility
 			);
 
 			/* Assert */
-			Assert.Equal(recievedRequest.Number, request.Number);
-			Assert.NotNull(recievedContext);
+			Assert.Equal(receivedRequest.Number, request.Number);
+			Assert.NotNull(receivedContext);
 			Assert.NotNull(response);
 
 			(requester as IDisposable)?.Dispose();
@@ -242,12 +242,12 @@ namespace RawRabbit.IntegrationTests.Compatibility
 			);
 			var requester = RawRabbit.Compatibility.Legacy.RawRabbitFactory.CreateClient(_legacyConfig);
 			var responder = RawRabbit.Compatibility.Legacy.RawRabbitFactory.CreateClient<TestMessageContext>(_legacyConfig);
-			TestMessageContext recievedContext = null;
-			BasicRequest recievedRequest = null;
+			TestMessageContext receivedContext = null;
+			BasicRequest receivedRequest = null;
 			var sub = responder.RespondAsync<BasicRequest, BasicResponse>((req, context) =>
 			{
-				recievedContext = context;
-				recievedRequest = req;
+				receivedContext = context;
+				receivedRequest = req;
 				return Task.FromResult(new BasicResponse());
 			});
 
@@ -255,8 +255,8 @@ namespace RawRabbit.IntegrationTests.Compatibility
 			var response = await requester.RequestAsync<BasicRequest, BasicResponse>(new BasicRequest());
 
 			/* Assert */
-			Assert.Equal(recievedContext.Prop, propValue);
-			Assert.NotNull(recievedRequest);
+			Assert.Equal(receivedContext.Prop, propValue);
+			Assert.NotNull(receivedRequest);
 			Assert.NotNull(response);
 
 			TestChannel.QueueDelete(sub.QueueName, false, false);

--- a/test/RawRabbit.IntegrationTests/Enrichers/AttributeEnricherTests.cs
+++ b/test/RawRabbit.IntegrationTests/Enrichers/AttributeEnricherTests.cs
@@ -15,10 +15,10 @@ namespace RawRabbit.IntegrationTests.Enrichers
 			using (var subscriber = RawRabbitFactory.CreateTestClient())
 			{
 				/* Setup */
-				var recievedTcs = new TaskCompletionSource<AttributedMessage>();
-				await subscriber.SubscribeAsync<AttributedMessage>(recieved =>
+				var receivedTcs = new TaskCompletionSource<AttributedMessage>();
+				await subscriber.SubscribeAsync<AttributedMessage>(received =>
 				{
-					recievedTcs.TrySetResult(recieved);
+					receivedTcs.TrySetResult(received);
 					return Task.FromResult(true);
 				}, ctx => ctx
 					.UseSubscribeConfiguration(cfg => cfg
@@ -31,7 +31,7 @@ namespace RawRabbit.IntegrationTests.Enrichers
 
 				/* Test */
 				await publisher.PublishAsync(new AttributedMessage());
-				await recievedTcs.Task;
+				await receivedTcs.Task;
 
 				/* Assert */
 				Assert.True(true, "Routing successful");
@@ -45,10 +45,10 @@ namespace RawRabbit.IntegrationTests.Enrichers
 			using (var publisher = RawRabbitFactory.CreateTestClient())
 			{
 				/* Setup */
-				var recievedTcs = new TaskCompletionSource<AttributedMessage>();
-				await subscriber.SubscribeAsync<AttributedMessage>(recieved =>
+				var receivedTcs = new TaskCompletionSource<AttributedMessage>();
+				await subscriber.SubscribeAsync<AttributedMessage>(received =>
 				{
-					recievedTcs.TrySetResult(recieved);
+					receivedTcs.TrySetResult(received);
 					return Task.FromResult(true);
 				});
 
@@ -60,7 +60,7 @@ namespace RawRabbit.IntegrationTests.Enrichers
 								.WithType(ExchangeType.Topic))
 							.WithRoutingKey("my_key")
 				));
-				await recievedTcs.Task;
+				await receivedTcs.Task;
 
 				/* Assert */
 				Assert.True(true, "Routing successful");
@@ -78,10 +78,10 @@ namespace RawRabbit.IntegrationTests.Enrichers
 			using (var responder = RawRabbitFactory.CreateTestClient())
 			{
 				/* Setup */
-				var recievedTcs = new TaskCompletionSource<AttributedRequest>();
-				await responder.RespondAsync<AttributedRequest, AttributedResponse>(recieved =>
+				var receivedTcs = new TaskCompletionSource<AttributedRequest>();
+				await responder.RespondAsync<AttributedRequest, AttributedResponse>(received =>
 				{
-					recievedTcs.TrySetResult(recieved);
+					receivedTcs.TrySetResult(received);
 					return Task.FromResult(new AttributedResponse());
 				}, ctx => ctx.UseRespondConfiguration(cfg => cfg
 					.Consume(c => c
@@ -93,7 +93,7 @@ namespace RawRabbit.IntegrationTests.Enrichers
 
 				/* Test */
 				await requester.RequestAsync<AttributedRequest, AttributedResponse>(new AttributedRequest());
-				await recievedTcs.Task;
+				await receivedTcs.Task;
 
 				/* Assert */
 				Assert.True(true, "Routing successful");
@@ -107,10 +107,10 @@ namespace RawRabbit.IntegrationTests.Enrichers
 			using (var requester = RawRabbitFactory.CreateTestClient())
 			{
 				/* Setup */
-				var recievedTcs = new TaskCompletionSource<AttributedRequest>();
-				await responder.RespondAsync<AttributedRequest, AttributedResponse>(recieved =>
+				var receivedTcs = new TaskCompletionSource<AttributedRequest>();
+				await responder.RespondAsync<AttributedRequest, AttributedResponse>(received =>
 				{
-					recievedTcs.TrySetResult(recieved);
+					receivedTcs.TrySetResult(received);
 					return Task.FromResult(new AttributedResponse());
 				});
 
@@ -124,7 +124,7 @@ namespace RawRabbit.IntegrationTests.Enrichers
 							.WithRoutingKey("my_request_key")
 					)
 				));
-				await recievedTcs.Task;
+				await receivedTcs.Task;
 
 				/* Assert */
 				Assert.True(true, "Routing successful");
@@ -138,16 +138,16 @@ namespace RawRabbit.IntegrationTests.Enrichers
 			using (var requester = RawRabbitFactory.CreateTestClient(new RawRabbitOptions { Plugins = plugin => plugin.UseAttributeRouting() }))
 			{
 				/* Setup */
-				var recievedTcs = new TaskCompletionSource<AttributedRequest>();
-				await responder.RespondAsync<AttributedRequest, AttributedResponse>(recieved =>
+				var receivedTcs = new TaskCompletionSource<AttributedRequest>();
+				await responder.RespondAsync<AttributedRequest, AttributedResponse>(received =>
 				{
-					recievedTcs.TrySetResult(recieved);
+					receivedTcs.TrySetResult(received);
 					return Task.FromResult(new AttributedResponse());
 				});
 
 				/* Test */
 				await requester.RequestAsync<AttributedRequest, AttributedResponse>(new AttributedRequest());
-				await recievedTcs.Task;
+				await receivedTcs.Task;
 
 				/* Assert */
 				Assert.True(true, "Routing successful");
@@ -161,16 +161,16 @@ namespace RawRabbit.IntegrationTests.Enrichers
 			using (var subscriber = RawRabbitFactory.CreateTestClient(new RawRabbitOptions { Plugins = plugin => plugin.UseAttributeRouting() }))
 			{
 				/* Setup */
-				var recievedTcs = new TaskCompletionSource<AttributedMessage>();
-				await subscriber.SubscribeAsync<AttributedMessage>(recieved =>
+				var receivedTcs = new TaskCompletionSource<AttributedMessage>();
+				await subscriber.SubscribeAsync<AttributedMessage>(received =>
 				{
-					recievedTcs.TrySetResult(recieved);
+					receivedTcs.TrySetResult(received);
 					return Task.FromResult(new AttributedResponse());
 				});
 
 				/* Test */
 				await publisher.PublishAsync(new AttributedMessage());
-				await recievedTcs.Task;
+				await receivedTcs.Task;
 
 				/* Assert */
 				Assert.True(true, "Routing successful");

--- a/test/RawRabbit.IntegrationTests/Enrichers/MessageContextTests.cs
+++ b/test/RawRabbit.IntegrationTests/Enrichers/MessageContextTests.cs
@@ -23,10 +23,10 @@ namespace RawRabbit.IntegrationTests.Enrichers
 			using (var responder = RawRabbitFactory.CreateTestClient())
 			{
 				/* Setup */
-				MessageContext recievedContext = null;
+				MessageContext receivedContext = null;
 				await responder.RespondAsync<BasicRequest, BasicResponse, MessageContext>((request, context) =>
 					{
-						recievedContext = context;
+						receivedContext = context;
 						return Task.FromResult(new BasicResponse());
 					}
 				);
@@ -35,7 +35,7 @@ namespace RawRabbit.IntegrationTests.Enrichers
 				await requester.RequestAsync<BasicRequest, BasicResponse>();
 
 				/* Assert */
-				Assert.NotNull(recievedContext);
+				Assert.NotNull(receivedContext);
 			}
 		}
 

--- a/test/RawRabbit.IntegrationTests/Enrichers/ProtobufTests.cs
+++ b/test/RawRabbit.IntegrationTests/Enrichers/ProtobufTests.cs
@@ -11,7 +11,7 @@ namespace RawRabbit.IntegrationTests.Enrichers
 	public class ProtobufTests
 	{
 		[Fact]
-		public async Task Should_Deliver_And_Recieve_Messages_Serialized_With_Protobuf()
+		public async Task Should_Deliver_And_Reiieve_Messages_Serialized_With_Protobuf()
 		{
 			using (var client = RawRabbitFactory.CreateTestClient(new RawRabbitOptions{ Plugins = p => p.UseProtobuf() }))
 			{
@@ -48,10 +48,10 @@ namespace RawRabbit.IntegrationTests.Enrichers
 				await client.RespondAsync<ProtoRequest, ProtoResponse>(request => Task.FromResult(response));
 
 				/* Test */
-				var recieved = await client.RequestAsync<ProtoRequest, ProtoResponse>(new ProtoRequest());
+				var received = await client.RequestAsync<ProtoRequest, ProtoResponse>(new ProtoRequest());
 
 				/* Assert */
-				Assert.Equal(recieved.Id, response.Id);
+				Assert.Equal(received.Id, response.Id);
 			}
 		}
 

--- a/test/RawRabbit.IntegrationTests/Features/GenericMessagesTest.cs
+++ b/test/RawRabbit.IntegrationTests/Features/GenericMessagesTest.cs
@@ -19,9 +19,9 @@ namespace RawRabbit.IntegrationTests.Features
 				{
 					Prop = 7
 				};
-				await subscriber.SubscribeAsync<GenericMessage<int>>(recieved =>
+				await subscriber.SubscribeAsync<GenericMessage<int>>(received =>
 					{
-						doneTsc.TrySetResult(recieved);
+						doneTsc.TrySetResult(received);
 						return Task.FromResult(0);
 					} 
 				);

--- a/test/RawRabbit.IntegrationTests/Features/GracefulShutdownTest.cs
+++ b/test/RawRabbit.IntegrationTests/Features/GracefulShutdownTest.cs
@@ -39,13 +39,13 @@ namespace RawRabbit.IntegrationTests.Features
 			await singleton.PublishAsync(secondMsg);
 			await shutdownTask;
 
-			var secondRecieved = await singleton.GetAsync<BasicMessage>(get => get.WithAutoAck());
+			var secondReceived = await singleton.GetAsync<BasicMessage>(get => get.WithAutoAck());
 			await singleton.DeleteQueueAsync<BasicMessage>();
 			await singleton.DeleteExchangeAsync<BasicMessage>();
 			singleton.Dispose();
 
 			Assert.Equal(firstMsg.Prop, firstTsc.Task.Result.Prop);
-			Assert.Equal(secondMsg.Prop, secondRecieved.Content.Prop);
+			Assert.Equal(secondMsg.Prop, secondReceived.Content.Prop);
 		}
 	}
 }

--- a/test/RawRabbit.IntegrationTests/MessageSequence/MessageSequenceTests.cs
+++ b/test/RawRabbit.IntegrationTests/MessageSequence/MessageSequenceTests.cs
@@ -17,7 +17,7 @@ namespace RawRabbit.IntegrationTests.MessageSequence
 	public class MessageSequenceTests
 	{
 		[Fact]
-		public async Task Should_Create_Simple_Chain_Of_One_Send_And_Final_Recieve()
+		public async Task Should_Create_Simple_Chain_Of_One_Send_And_Final_Receive()
 		{	
 			/* Setup */
 			using (var client = RawRabbitFactory.CreateTestClient(new RawRabbitOptions
@@ -40,7 +40,7 @@ namespace RawRabbit.IntegrationTests.MessageSequence
 				await chain.Task;
 
 				/* Assert */
-				Assert.True(true, "Recieved Response");
+				Assert.True(true, "Received Response");
 			}
 		}
 
@@ -80,7 +80,7 @@ namespace RawRabbit.IntegrationTests.MessageSequence
 
 				/* Assert */
 				Assert.NotNull(secondTcs.Task.Result);
-				Assert.True(true, "Recieved Response");
+				Assert.True(true, "Received Response");
 			}
 		}
 
@@ -175,7 +175,7 @@ namespace RawRabbit.IntegrationTests.MessageSequence
 
 				/* Assert */
 				Assert.NotNull(secondTcs.Task.Result);
-				Assert.True(true, "Recieved Response");
+				Assert.True(true, "Received Response");
 			}
 		}
 

--- a/test/RawRabbit.IntegrationTests/PublishAndSubscribe/AcknowledgementSubscribeTests.cs
+++ b/test/RawRabbit.IntegrationTests/PublishAndSubscribe/AcknowledgementSubscribeTests.cs
@@ -18,19 +18,19 @@ namespace RawRabbit.IntegrationTests.PublishAndSubscribe
 			using (var subscriber = RawRabbitFactory.CreateTestClient())
 			{
 				/* Setup */
-				var recievedTcs = new TaskCompletionSource<BasicMessage>();
-				await subscriber.SubscribeAsync<BasicMessage>(async recieved =>
+				var receivedTcs = new TaskCompletionSource<BasicMessage>();
+				await subscriber.SubscribeAsync<BasicMessage>(async received =>
 				{
-					recievedTcs.TrySetResult(recieved);
+					receivedTcs.TrySetResult(received);
 				});
 				var message = new BasicMessage { Prop = "Hello, world!" };
 
 				/* Test */
 				await publisher.PublishAsync(message);
-				await recievedTcs.Task;
+				await receivedTcs.Task;
 
 				/* Assert */
-				Assert.Equal(message.Prop, recievedTcs.Task.Result.Prop);
+				Assert.Equal(message.Prop, receivedTcs.Task.Result.Prop);
 			}
 		}
 
@@ -41,20 +41,20 @@ namespace RawRabbit.IntegrationTests.PublishAndSubscribe
 			using (var subscriber = RawRabbitFactory.CreateTestClient())
 			{
 				/* Setup */
-				var recievedTcs = new TaskCompletionSource<BasicMessage>();
-				await subscriber.SubscribeAsync<BasicMessage>(async recieved =>
+				var receivedTcs = new TaskCompletionSource<BasicMessage>();
+				await subscriber.SubscribeAsync<BasicMessage>(async received =>
 				{
-					recievedTcs.TrySetResult(recieved);
+					receivedTcs.TrySetResult(received);
 					return new Ack();
 				});
 				var message = new BasicMessage { Prop = "Hello, world!" };
 
 				/* Test */
 				await publisher.PublishAsync(message);
-				await recievedTcs.Task;
+				await receivedTcs.Task;
 
 				/* Assert */
-				Assert.Equal(message.Prop, recievedTcs.Task.Result.Prop);
+				Assert.Equal(message.Prop, receivedTcs.Task.Result.Prop);
 			}
 		}
 
@@ -65,20 +65,20 @@ namespace RawRabbit.IntegrationTests.PublishAndSubscribe
 			using (var subscriber = RawRabbitFactory.CreateTestClient())
 			{
 				/* Setup */
-				var recievedTcs = new TaskCompletionSource<BasicMessage>();
-				await subscriber.SubscribeAsync<BasicMessage, MessageContext>(async (recieved, context) =>
+				var receivedTcs = new TaskCompletionSource<BasicMessage>();
+				await subscriber.SubscribeAsync<BasicMessage, MessageContext>(async (received, context) =>
 				{
-					recievedTcs.TrySetResult(recieved);
+					receivedTcs.TrySetResult(received);
 					return new Ack();
 				});
 				var message = new BasicMessage { Prop = "Hello, world!" };
 
 				/* Test */
 				await publisher.PublishAsync(message);
-				await recievedTcs.Task;
+				await receivedTcs.Task;
 
 				/* Assert */
-				Assert.Equal(message.Prop, recievedTcs.Task.Result.Prop);
+				Assert.Equal(message.Prop, receivedTcs.Task.Result.Prop);
 			}
 		}
 
@@ -92,14 +92,14 @@ namespace RawRabbit.IntegrationTests.PublishAndSubscribe
 				/* Setup */
 				var firstTsc = new TaskCompletionSource<BasicMessage>();
 				var secondTsc = new TaskCompletionSource<BasicMessage>();
-				await firstSubscriber.SubscribeAsync<BasicMessage>(async recieved =>
+				await firstSubscriber.SubscribeAsync<BasicMessage>(async received =>
 				{
-					firstTsc.TrySetResult(recieved);
+					firstTsc.TrySetResult(received);
 					return new Nack(requeue: false);
 				});
-				await secondSubscriber.SubscribeAsync<BasicMessage>(async recieved =>
+				await secondSubscriber.SubscribeAsync<BasicMessage>(async received =>
 				{
-					secondTsc.TrySetResult(recieved);
+					secondTsc.TrySetResult(received);
 					return new Nack(requeue: false);
 				});
 				var message = new BasicMessage { Prop = "Hello, world!" };
@@ -124,14 +124,14 @@ namespace RawRabbit.IntegrationTests.PublishAndSubscribe
 				/* Setup */
 				var firstTsc = new TaskCompletionSource<BasicMessage>();
 				var secondTsc = new TaskCompletionSource<BasicMessage>();
-				await firstSubscriber.SubscribeAsync<BasicMessage, MessageContext>(async (recieved, context) =>
+				await firstSubscriber.SubscribeAsync<BasicMessage, MessageContext>(async (received, context) =>
 				{
-					firstTsc.TrySetResult(recieved);
+					firstTsc.TrySetResult(received);
 					return new Nack(requeue: false);
 				});
-				await secondSubscriber.SubscribeAsync<BasicMessage, MessageContext>(async (recieved, context) =>
+				await secondSubscriber.SubscribeAsync<BasicMessage, MessageContext>(async (received, context) =>
 				{
-					secondTsc.TrySetResult(recieved);
+					secondTsc.TrySetResult(received);
 					return new Nack(requeue: false);
 				});
 				var message = new BasicMessage { Prop = "Hello, world!" };
@@ -156,14 +156,14 @@ namespace RawRabbit.IntegrationTests.PublishAndSubscribe
 				/* Setup */
 				var firstTsc = new TaskCompletionSource<BasicMessage>();
 				var secondTsc = new TaskCompletionSource<BasicMessage>();
-				await firstSubscriber.SubscribeAsync<BasicMessage>(async recieved =>
+				await firstSubscriber.SubscribeAsync<BasicMessage>(async received =>
 				{
-					firstTsc.TrySetResult(recieved);
+					firstTsc.TrySetResult(received);
 					return new Nack();
 				});
-				await secondSubscriber.SubscribeAsync<BasicMessage>(async recieved =>
+				await secondSubscriber.SubscribeAsync<BasicMessage>(async received =>
 				{
-					secondTsc.TrySetResult(recieved);
+					secondTsc.TrySetResult(received);
 					return new Ack();
 				});
 				var message = new BasicMessage { Prop = "Hello, world!" };
@@ -188,14 +188,14 @@ namespace RawRabbit.IntegrationTests.PublishAndSubscribe
 				/* Setup */
 				var firstTsc = new TaskCompletionSource<BasicMessage>();
 				var secondTsc = new TaskCompletionSource<BasicMessage>();
-				await firstSubscriber.SubscribeAsync<BasicMessage, MessageContext>(async (recieved, context) =>
+				await firstSubscriber.SubscribeAsync<BasicMessage, MessageContext>(async (received, context) =>
 				{
-					firstTsc.TrySetResult(recieved);
+					firstTsc.TrySetResult(received);
 					return new Nack();
 				});
-				await secondSubscriber.SubscribeAsync<BasicMessage, MessageContext>(async (recieved, context) =>
+				await secondSubscriber.SubscribeAsync<BasicMessage, MessageContext>(async (received, context) =>
 				{
-					secondTsc.TrySetResult(recieved);
+					secondTsc.TrySetResult(received);
 					return new Ack();
 				});
 				var message = new BasicMessage { Prop = "Hello, world!" };
@@ -220,14 +220,14 @@ namespace RawRabbit.IntegrationTests.PublishAndSubscribe
 				/* Setup */
 				var firstTsc = new TaskCompletionSource<BasicMessage>();
 				var secondTsc = new TaskCompletionSource<BasicMessage>();
-				await firstSubscriber.SubscribeAsync<BasicMessage>(async recieved =>
+				await firstSubscriber.SubscribeAsync<BasicMessage>(async received =>
 				{
-					firstTsc.TrySetResult(recieved);
+					firstTsc.TrySetResult(received);
 					return new Reject();
 				});
-				await secondSubscriber.SubscribeAsync<BasicMessage>(async recieved =>
+				await secondSubscriber.SubscribeAsync<BasicMessage>(async received =>
 				{
-					secondTsc.TrySetResult(recieved);
+					secondTsc.TrySetResult(received);
 					return new Ack();
 				});
 				var message = new BasicMessage { Prop = "Hello, world!" };
@@ -252,14 +252,14 @@ namespace RawRabbit.IntegrationTests.PublishAndSubscribe
 				/* Setup */
 				var firstTsc = new TaskCompletionSource<BasicMessage>();
 				var secondTsc = new TaskCompletionSource<BasicMessage>();
-				await firstSubscriber.SubscribeAsync<BasicMessage, MessageContext>(async (recieved, context) =>
+				await firstSubscriber.SubscribeAsync<BasicMessage, MessageContext>(async (received, context) =>
 				{
-					firstTsc.TrySetResult(recieved);
+					firstTsc.TrySetResult(received);
 					return new Reject();
 				});
-				await secondSubscriber.SubscribeAsync<BasicMessage, MessageContext>(async (recieved, context) =>
+				await secondSubscriber.SubscribeAsync<BasicMessage, MessageContext>(async (received, context) =>
 				{
-					secondTsc.TrySetResult(recieved);
+					secondTsc.TrySetResult(received);
 					return new Ack();
 				});
 				var message = new BasicMessage { Prop = "Hello, world!" };
@@ -284,12 +284,12 @@ namespace RawRabbit.IntegrationTests.PublishAndSubscribe
 				/* Setup */
 				var firstTsc = new TaskCompletionSource<DateTime>();
 				var secondTsc = new TaskCompletionSource<DateTime>();
-				await firstSubscriber.SubscribeAsync<BasicMessage>(async recieved =>
+				await firstSubscriber.SubscribeAsync<BasicMessage>(async received =>
 				{
 					firstTsc.TrySetResult(DateTime.Now);
 					return Retry.In(TimeSpan.FromSeconds(1));
 				});
-				await secondSubscriber.SubscribeAsync<BasicMessage>(async recieved =>
+				await secondSubscriber.SubscribeAsync<BasicMessage>(async received =>
 				{
 					secondTsc.TrySetResult(DateTime.Now);
 					return new Ack();
@@ -315,12 +315,12 @@ namespace RawRabbit.IntegrationTests.PublishAndSubscribe
 				/* Setup */
 				var firstTsc = new TaskCompletionSource<DateTime>();
 				var secondTsc = new TaskCompletionSource<DateTime>();
-				await firstSubscriber.SubscribeAsync<BasicMessage, MessageContext>(async (recieved, context) =>
+				await firstSubscriber.SubscribeAsync<BasicMessage, MessageContext>(async (received, context) =>
 				{
 					firstTsc.TrySetResult(DateTime.Now);
 					return Retry.In(TimeSpan.FromSeconds(1));
 				});
-				await secondSubscriber.SubscribeAsync<BasicMessage, MessageContext>(async (recieved, context) =>
+				await secondSubscriber.SubscribeAsync<BasicMessage, MessageContext>(async (received, context) =>
 				{
 					secondTsc.TrySetResult(DateTime.Now);
 					return new Ack();
@@ -346,18 +346,18 @@ namespace RawRabbit.IntegrationTests.PublishAndSubscribe
 				var firstTsc = new TaskCompletionSource<DateTime>();
 				var secondTsc = new TaskCompletionSource<DateTime>();
 				var thirdTsc = new TaskCompletionSource<DateTime>();
-				await subscriber.SubscribeAsync<BasicMessage>(async recieved =>
+				await subscriber.SubscribeAsync<BasicMessage>(async received =>
 				{
-					var recievedAt = DateTime.Now;
-					if (firstTsc.TrySetResult(recievedAt))
+					var receivedAt = DateTime.Now;
+					if (firstTsc.TrySetResult(receivedAt))
 					{
 						return Retry.In(TimeSpan.FromSeconds(1));
 					}
-					if (secondTsc.TrySetResult(recievedAt))
+					if (secondTsc.TrySetResult(receivedAt))
 					{
 						return Retry.In(TimeSpan.FromSeconds(1));
 					}
-					thirdTsc.TrySetResult(recievedAt);
+					thirdTsc.TrySetResult(receivedAt);
 					return new Ack();
 				});
 
@@ -383,26 +383,26 @@ namespace RawRabbit.IntegrationTests.PublishAndSubscribe
 				var thirdTsc = new TaskCompletionSource<DateTime>();
 				var forthTsc = new TaskCompletionSource<DateTime>();
 
-				await subscriber.SubscribeAsync<BasicMessage> (async recieved =>
+				await subscriber.SubscribeAsync<BasicMessage> (async received =>
 				{
-					var recievedAt = DateTime.Now;
-					if (firstTsc.TrySetResult(recievedAt))
+					var receivedAt = DateTime.Now;
+					if (firstTsc.TrySetResult(receivedAt))
 					{
 						await Task.Delay(TimeSpan.FromMilliseconds(100));
 						subscriber.PublishAsync(new NamespacedMessages());
 						return Retry.In(TimeSpan.FromSeconds(1));
 					}
-					thirdTsc.TrySetResult(recievedAt);
+					thirdTsc.TrySetResult(receivedAt);
 					return new Ack();
 				});
 				await subscriber.SubscribeAsync<NamespacedMessages>(async second =>
 				{
-					var recievedAt = DateTime.Now;
-					if (secondTsc.TrySetResult(recievedAt))
+					var receivedAt = DateTime.Now;
+					if (secondTsc.TrySetResult(receivedAt))
 						 {
 						return Retry.In(TimeSpan.FromSeconds(1));
 					}
-					forthTsc.TrySetResult(recievedAt);
+					forthTsc.TrySetResult(receivedAt);
 					return new Ack();
 				});
 

--- a/test/RawRabbit.IntegrationTests/PublishAndSubscribe/CancellationTests.cs
+++ b/test/RawRabbit.IntegrationTests/PublishAndSubscribe/CancellationTests.cs
@@ -16,13 +16,13 @@ namespace RawRabbit.IntegrationTests.PublishAndSubscribe
 			{
 				/* Setup */
 				var message = new BasicMessage {Prop = Guid.NewGuid().ToString()};
-				var recievedTcs = new TaskCompletionSource<BasicMessage>();
+				var receivedTcs = new TaskCompletionSource<BasicMessage>();
 				var sendCts = new CancellationTokenSource();
-				await subscriber.SubscribeAsync<BasicMessage>(recieved =>
+				await subscriber.SubscribeAsync<BasicMessage>(received =>
 				{
-					if (recieved.Prop == message.Prop)
+					if (received.Prop == message.Prop)
 					{
-						recievedTcs.TrySetResult(recieved);
+						receivedTcs.TrySetResult(received);
 					}
 					return Task.FromResult(true);
 				});
@@ -30,10 +30,10 @@ namespace RawRabbit.IntegrationTests.PublishAndSubscribe
 				/* Test */
 				sendCts.CancelAfter(TimeSpan.FromTicks(400));
 				var publishTask = publisher.PublishAsync(new BasicMessage(), token: sendCts.Token);
-				recievedTcs.Task.Wait(100);
+				receivedTcs.Task.Wait(100);
 
 				/* Assert */
-				Assert.False(recievedTcs.Task.IsCompleted, "Message was sent, even though execution was cancelled.");
+				Assert.False(receivedTcs.Task.IsCompleted, "Message was sent, even though execution was cancelled.");
 				Assert.True(publishTask.IsCanceled, "The publish task should be cancelled.");
 			}
 		}

--- a/test/RawRabbit.IntegrationTests/PublishAndSubscribe/ConfigurationTests.cs
+++ b/test/RawRabbit.IntegrationTests/PublishAndSubscribe/ConfigurationTests.cs
@@ -24,20 +24,20 @@ namespace RawRabbit.IntegrationTests.PublishAndSubscribe
 			using (var subscriber = RawRabbitFactory.CreateTestClient())
 			{
 				/* Setup */
-				var recievedTcs = new TaskCompletionSource<BasicMessage>();
-				await subscriber.SubscribeAsync<BasicMessage>(recieved =>
+				var receivedTcs = new TaskCompletionSource<BasicMessage>();
+				await subscriber.SubscribeAsync<BasicMessage>(received =>
 				{
-					recievedTcs.TrySetResult(recieved);
+					receivedTcs.TrySetResult(received);
 					return Task.FromResult(true);
 				});
 				var message = new BasicMessage {Prop = "Hello, world!"};
 
 				/* Test */
 				await publisher.PublishAsync(message);
-				await recievedTcs.Task;
+				await receivedTcs.Task;
 
 				/* Assert */
-				Assert.Equal(message.Prop, recievedTcs.Task.Result.Prop);
+				Assert.Equal(message.Prop, receivedTcs.Task.Result.Prop);
 			}
 		}
 
@@ -48,10 +48,10 @@ namespace RawRabbit.IntegrationTests.PublishAndSubscribe
 			using (var subscriber = RawRabbitFactory.CreateTestClient())
 			{
 				/* Setup */
-				var recievedTcs = new TaskCompletionSource<BasicDeliverEventArgs>();
-				await subscriber.SubscribeAsync<BasicMessage, BasicDeliverEventArgs>((recieved, args) =>
+				var receivedTcs = new TaskCompletionSource<BasicDeliverEventArgs>();
+				await subscriber.SubscribeAsync<BasicMessage, BasicDeliverEventArgs>((received, args) =>
 				{
-					recievedTcs.TrySetResult(args);
+					receivedTcs.TrySetResult(args);
 					return Task.FromResult(true);
 				}, ctx => ctx.UseMessageContext(c => c.GetDeliveryEventArgs()));
 				var message = new BasicMessage { Prop = "Hello, world!" };
@@ -60,10 +60,10 @@ namespace RawRabbit.IntegrationTests.PublishAndSubscribe
 				await publisher.PublishAsync(message, ctx => ctx
 					.UsePublishConfiguration(cfg => cfg
 						.WithProperties(props => props.Headers.Add("foo", "bar"))));
-				await recievedTcs.Task;
+				await receivedTcs.Task;
 
 				/* Assert */
-				Assert.True(recievedTcs.Task.Result.BasicProperties.Headers.ContainsKey("foo"));
+				Assert.True(receivedTcs.Task.Result.BasicProperties.Headers.ContainsKey("foo"));
 			}
 		}
 
@@ -74,10 +74,10 @@ namespace RawRabbit.IntegrationTests.PublishAndSubscribe
 			using (var subscriber = RawRabbitFactory.CreateTestClient())
 			{
 				/* Setup */
-				var recievedTcs = new TaskCompletionSource<BasicMessage>();
-				await subscriber.SubscribeAsync<BasicMessage>(recieved =>
+				var receivedTcs = new TaskCompletionSource<BasicMessage>();
+				await subscriber.SubscribeAsync<BasicMessage>(received =>
 				{
-					recievedTcs.TrySetResult(recieved);
+					receivedTcs.TrySetResult(received);
 					return Task.FromResult(true);
 				}, ctx => ctx
 					.UseSubscribeConfiguration(cfg => cfg
@@ -90,10 +90,10 @@ namespace RawRabbit.IntegrationTests.PublishAndSubscribe
 
 				/* Test */
 				await publisher.PublishAsync(message, ctx => ctx.UsePublishConfiguration(cfg => cfg.OnExchange("custom_exchange")));
-				await recievedTcs.Task;
+				await receivedTcs.Task;
 
 				/* Assert */
-				Assert.Equal(message.Prop, recievedTcs.Task.Result.Prop);
+				Assert.Equal(message.Prop, receivedTcs.Task.Result.Prop);
 			}
 		}
 
@@ -104,10 +104,10 @@ namespace RawRabbit.IntegrationTests.PublishAndSubscribe
 			using (var subscriber = RawRabbitFactory.CreateTestClient())
 			{
 				/* Setup */
-				var recievedTcs = new TaskCompletionSource<BasicMessage>();
-				await subscriber.SubscribeAsync<BasicMessage>(recieved =>
+				var receivedTcs = new TaskCompletionSource<BasicMessage>();
+				await subscriber.SubscribeAsync<BasicMessage>(received =>
 				{
-					recievedTcs.TrySetResult(recieved);
+					receivedTcs.TrySetResult(received);
 					return Task.FromResult(true);
 				}, ctx => ctx
 					.UseSubscribeConfiguration(cfg => cfg
@@ -133,10 +133,10 @@ namespace RawRabbit.IntegrationTests.PublishAndSubscribe
 						.OnExchange("custom_exchange")
 						.WithRoutingKey("custom_key")
 				));
-				await recievedTcs.Task;
+				await receivedTcs.Task;
 
 				/* Assert */
-				Assert.Equal(message.Prop, recievedTcs.Task.Result.Prop);
+				Assert.Equal(message.Prop, receivedTcs.Task.Result.Prop);
 			}
 		}
 

--- a/test/RawRabbit.IntegrationTests/PublishAndSubscribe/MultipleOperationsTests.cs
+++ b/test/RawRabbit.IntegrationTests/PublishAndSubscribe/MultipleOperationsTests.cs
@@ -14,16 +14,16 @@ namespace RawRabbit.IntegrationTests.PublishAndSubscribe
 			using (var subscriber = RawRabbitFactory.CreateTestClient())
 			{
 				/* Setup */
-				var recievedCount = 0;
+				var receivedCount = 0;
 				const int sendCount = 2000;
 				var publishTasks = new Task[sendCount];
-				var recievedTcs = new TaskCompletionSource<int>();
-				await subscriber.SubscribeAsync<BasicMessage>(recieved =>
+				var receivedTcs = new TaskCompletionSource<int>();
+				await subscriber.SubscribeAsync<BasicMessage>(received =>
 				{
-					Interlocked.Increment(ref recievedCount);
-					if (recievedCount == sendCount)
+					Interlocked.Increment(ref receivedCount);
+					if (receivedCount == sendCount)
 					{
-						recievedTcs.TrySetResult(recievedCount);
+						receivedTcs.TrySetResult(receivedCount);
 					}
 					return Task.FromResult(true);
 				});
@@ -34,9 +34,9 @@ namespace RawRabbit.IntegrationTests.PublishAndSubscribe
 					publishTasks[i] = publisher.PublishAsync(new BasicMessage());
 				}
 				Task.WaitAll(publishTasks);
-				await recievedTcs.Task;
+				await receivedTcs.Task;
 				/* Assert */
-				Assert.Equal(recievedTcs.Task.Result, sendCount);
+				Assert.Equal(receivedTcs.Task.Result, sendCount);
 			}
 		}
 
@@ -49,7 +49,7 @@ namespace RawRabbit.IntegrationTests.PublishAndSubscribe
 				/* Setup */
 				const int sendCount = 2000;
 				var publishTasks = new Task[sendCount];
-				await responder.RespondAsync<BasicRequest, BasicResponse>(recieved =>
+				await responder.RespondAsync<BasicRequest, BasicResponse>(received =>
 					Task.FromResult(new BasicResponse())
 				);
 

--- a/test/RawRabbit.IntegrationTests/Rpc/AcknowledgementRespondTests.cs
+++ b/test/RawRabbit.IntegrationTests/Rpc/AcknowledgementRespondTests.cs
@@ -25,10 +25,10 @@ namespace RawRabbit.IntegrationTests.Rpc
 				);
 
 				/* Test */
-				var recieved = await requester.RequestAsync<BasicRequest, BasicResponse>(new BasicRequest());
+				var received = await requester.RequestAsync<BasicRequest, BasicResponse>(new BasicRequest());
 
 				/* Assert */
-				Assert.Equal(recieved.Prop, sent.Prop);
+				Assert.Equal(received.Prop, sent.Prop);
 			}
 		}
 
@@ -48,10 +48,10 @@ namespace RawRabbit.IntegrationTests.Rpc
 				);
 
 				/* Test */
-				var recieved = await requester.RequestAsync<BasicRequest, BasicResponse>(new BasicRequest());
+				var received = await requester.RequestAsync<BasicRequest, BasicResponse>(new BasicRequest());
 
 				/* Assert */
-				Assert.Equal(recieved.Prop, sent.Prop);
+				Assert.Equal(received.Prop, sent.Prop);
 			}
 		}
 
@@ -80,11 +80,11 @@ namespace RawRabbit.IntegrationTests.Rpc
 				);
 
 				/* Test */
-				var recieved = await requester.RequestAsync<BasicRequest, BasicResponse>(new BasicRequest());
+				var received = await requester.RequestAsync<BasicRequest, BasicResponse>(new BasicRequest());
 				await firstTsc.Task;
 				await secondTsc.Task;
 				/* Assert */
-				Assert.Equal(recieved.Prop, sent.Prop);
+				Assert.Equal(received.Prop, sent.Prop);
 			}
 		}
 
@@ -113,11 +113,11 @@ namespace RawRabbit.IntegrationTests.Rpc
 				);
 
 				/* Test */
-				var recieved = await requester.RequestAsync<BasicRequest, BasicResponse>(new BasicRequest());
+				var received = await requester.RequestAsync<BasicRequest, BasicResponse>(new BasicRequest());
 				await firstTsc.Task;
 				await secondTsc.Task;
 				/* Assert */
-				Assert.Equal(recieved.Prop, sent.Prop);
+				Assert.Equal(received.Prop, sent.Prop);
 			}
 		}
 	}

--- a/test/RawRabbit.IntegrationTests/Rpc/RpcFundamentalTests.cs
+++ b/test/RawRabbit.IntegrationTests/Rpc/RpcFundamentalTests.cs
@@ -24,10 +24,10 @@ namespace RawRabbit.IntegrationTests.Rpc
 				);
 
 				/* Test */
-				var recieved = await requester.RequestAsync<BasicRequest, BasicResponse>(new BasicRequest());
+				var received = await requester.RequestAsync<BasicRequest, BasicResponse>(new BasicRequest());
 
 				/* Assert */
-				Assert.Equal(recieved.Prop, sent.Prop);
+				Assert.Equal(received.Prop, sent.Prop);
 			}
 		}
 
@@ -53,7 +53,7 @@ namespace RawRabbit.IntegrationTests.Rpc
 				);
 
 				/* Test */
-				var recieved = await requester.RequestAsync<BasicRequest, BasicResponse>(new BasicRequest(), ctx => ctx
+				var received = await requester.RequestAsync<BasicRequest, BasicResponse>(new BasicRequest(), ctx => ctx
 					.UseRequestConfiguration(cfg => cfg
 						.PublishRequest(p => p
 							.OnDeclaredExchange(e => e
@@ -75,7 +75,7 @@ namespace RawRabbit.IntegrationTests.Rpc
 					));
 
 				/* Assert */
-				Assert.Equal(recieved.Prop, sent.Prop);
+				Assert.Equal(received.Prop, sent.Prop);
 			}
 		}
 

--- a/test/RawRabbit.IntegrationTests/Rpc/RpcTimeoutTests.cs
+++ b/test/RawRabbit.IntegrationTests/Rpc/RpcTimeoutTests.cs
@@ -10,7 +10,7 @@ namespace RawRabbit.IntegrationTests.Rpc
 	public class RpcTimeoutTests
 	{
 		[Fact]
-		public async Task Should_Throw_Timeout_Exception_If_Response_Is_Not_Recieved()
+		public async Task Should_Throw_Timeout_Exception_If_Response_Is_Not_Received()
 		{
 			using (var requester = RawRabbitFactory.CreateTestClient())
 			{
@@ -54,7 +54,7 @@ namespace RawRabbit.IntegrationTests.Rpc
 		}
 
 		[Fact]
-		public async Task Should_Not_Time_out_If_Response_Is_Recieved()
+		public async Task Should_Not_Time_out_If_Response_Is_Received()
 		{
 			using (var requester = RawRabbitFactory.CreateTestClient())
 			using (var responder = RawRabbitFactory.CreateTestClient())

--- a/test/RawRabbit.PerformanceTest/MessageContextBenchmarks.cs
+++ b/test/RawRabbit.PerformanceTest/MessageContextBenchmarks.cs
@@ -13,8 +13,8 @@ namespace RawRabbit.PerformanceTest
 		private MessageA _messageA;
 		private IBusClient _withContext;
 		private MessageB _messageB;
-		public event EventHandler MessageRecieved;
-		public delegate void MessageRecievedEventHandler(EventHandler e);
+		public event EventHandler MessageReceived;
+		public delegate void MessageReceivedEventHandler(EventHandler e);
 
 		[Setup]
 		public void Setup()
@@ -29,12 +29,12 @@ namespace RawRabbit.PerformanceTest
 			_messageB = new MessageB();
 			_withoutContext.SubscribeAsync<MessageA>(message =>
 			{
-				MessageRecieved(message, EventArgs.Empty);
+				MessageReceived(message, EventArgs.Empty);
 				return _completedTask;
 			});
 			_withContext.SubscribeAsync<MessageB, MessageContext>((message, context) =>
 			{
-				MessageRecieved(message, EventArgs.Empty);
+				MessageReceived(message, EventArgs.Empty);
 				return _completedTask;
 			});
 		}
@@ -53,12 +53,12 @@ namespace RawRabbit.PerformanceTest
 		{
 			var msgTsc = new TaskCompletionSource<Message>();
 
-			EventHandler onMessageRecieved = (sender, args) => { msgTsc.TrySetResult(sender as Message); };
-			MessageRecieved += onMessageRecieved;
+			EventHandler onMessageReceived = (sender, args) => { msgTsc.TrySetResult(sender as Message); };
+			MessageReceived += onMessageReceived;
 
 			_withContext.PublishAsync(_messageB);
 			await msgTsc.Task;
-			MessageRecieved -= onMessageRecieved;
+			MessageReceived -= onMessageReceived;
 		}
 
 		[Benchmark]
@@ -66,12 +66,12 @@ namespace RawRabbit.PerformanceTest
 		{
 			var msgTsc = new TaskCompletionSource<Message>();
 
-			EventHandler onMessageRecieved = (sender, args) => { msgTsc.TrySetResult(sender as Message); };
-			MessageRecieved += onMessageRecieved;
+			EventHandler onMessageReceived = (sender, args) => { msgTsc.TrySetResult(sender as Message); };
+			MessageReceived += onMessageReceived;
 
 			_withoutContext.PublishAsync(_messageA);
 			await msgTsc.Task;
-			MessageRecieved -= onMessageRecieved;
+			MessageReceived -= onMessageReceived;
 		}
 
 

--- a/test/RawRabbit.PerformanceTest/PubSubBenchmarks.cs
+++ b/test/RawRabbit.PerformanceTest/PubSubBenchmarks.cs
@@ -12,8 +12,8 @@ namespace RawRabbit.PerformanceTest
 		private IBusClient _busClient;
 		private Task _completedTask;
 		private Message _message;
-		public event EventHandler MessageRecieved;
-		public delegate void MessageRecievedEventHandler(EventHandler e);
+		public event EventHandler MessageReceived;
+		public delegate void MessageReceivedEventHandler(EventHandler e);
 
 		[Setup]
 		public void Setup()
@@ -23,7 +23,7 @@ namespace RawRabbit.PerformanceTest
 			_message = new Message();
 			_busClient.SubscribeAsync<Message>(message =>
 			{
-				MessageRecieved(message, EventArgs.Empty);
+				MessageReceived(message, EventArgs.Empty);
 				return _completedTask;
 			});
 		}
@@ -40,12 +40,12 @@ namespace RawRabbit.PerformanceTest
 		{
 			var msgTsc = new TaskCompletionSource<Message>();
 
-			EventHandler onMessageRecieved = (sender, args) => { msgTsc.TrySetResult(sender as Message); };
-			MessageRecieved += onMessageRecieved;
+			EventHandler onMessageReceived = (sender, args) => { msgTsc.TrySetResult(sender as Message); };
+			MessageReceived += onMessageReceived;
 
 			_busClient.PublishAsync(_message, ctx => ctx.UsePublishAcknowledge(false));
 			await msgTsc.Task;
- 			MessageRecieved -= onMessageRecieved;
+ 			MessageReceived -= onMessageReceived;
 		}
 
 		[Benchmark]
@@ -53,12 +53,12 @@ namespace RawRabbit.PerformanceTest
 		{
 			var msgTsc = new TaskCompletionSource<Message>();
 
-			EventHandler onMessageRecieved = (sender, args) => { msgTsc.TrySetResult(sender as Message); };
-			MessageRecieved += onMessageRecieved;
+			EventHandler onMessageReceived = (sender, args) => { msgTsc.TrySetResult(sender as Message); };
+			MessageReceived += onMessageReceived;
 
 			_busClient.PublishAsync(_message);
 			await msgTsc.Task;
-			MessageRecieved -= onMessageRecieved;
+			MessageReceived -= onMessageReceived;
 		}
 
 		[Benchmark]
@@ -66,15 +66,15 @@ namespace RawRabbit.PerformanceTest
 		{
 			var msgTsc = new TaskCompletionSource<Message>();
 
-			EventHandler onMessageRecieved = (sender, args) => { msgTsc.TrySetResult(sender as Message); };
-			MessageRecieved += onMessageRecieved;
+			EventHandler onMessageReceived = (sender, args) => { msgTsc.TrySetResult(sender as Message); };
+			MessageReceived += onMessageReceived;
 
 			_busClient.PublishAsync(_message, ctx => ctx
 				.UsePublishConfiguration(cfg => cfg
 					.WithProperties(p => p.DeliveryMode = 1))
 			);
 			await msgTsc.Task;
-			MessageRecieved -= onMessageRecieved;
+			MessageReceived -= onMessageReceived;
 		}
 
 		[Benchmark]
@@ -82,15 +82,15 @@ namespace RawRabbit.PerformanceTest
 		{
 			var msgTsc = new TaskCompletionSource<Message>();
 
-			EventHandler onMessageRecieved = (sender, args) => { msgTsc.TrySetResult(sender as Message); };
-			MessageRecieved += onMessageRecieved;
+			EventHandler onMessageReceived = (sender, args) => { msgTsc.TrySetResult(sender as Message); };
+			MessageReceived += onMessageReceived;
 
 			_busClient.PublishAsync(_message, ctx => ctx
 				.UsePublishConfiguration(cfg => cfg
 					.WithProperties(p => p.DeliveryMode = 2))
 			);
 			await msgTsc.Task;
-			MessageRecieved -= onMessageRecieved;
+			MessageReceived -= onMessageReceived;
 		}
 	}
 

--- a/test/RawRabbit.PerformanceTest/RpcBenchmarks.cs
+++ b/test/RawRabbit.PerformanceTest/RpcBenchmarks.cs
@@ -12,8 +12,8 @@ namespace RawRabbit.PerformanceTest
 		private IBusClient _busClient;
 		private Request _request;
 		private Respond _respond;
-		public event EventHandler MessageRecieved;
-		public delegate void MessageRecievedEventHandler(EventHandler e);
+		public event EventHandler MessageReceived;
+		public delegate void MessageReceivedEventHandler(EventHandler e);
 
 		[Setup]
 		public void Setup()


### PR DESCRIPTION
### Description
#348 
Receive English word is known to be commonly misspelled as Recieve. This
commit fixes it as it is widely used in variable and constants names,
classes, enums, log debug messages, XML comments and unit tests.

### Check List

- [ ] All test passed.