### PR TITLE
Ninject DI now targets .Net Standard 2.0 and Ninject 3.3.4

### DIFF
--- a/src/RawRabbit.DependencyInjection.Ninject/KernelExtension.cs
+++ b/src/RawRabbit.DependencyInjection.Ninject/KernelExtension.cs
@@ -5,18 +5,6 @@ namespace RawRabbit.DependencyInjection.Ninject
 {
 	public static class KernelExtension
 	{
-#if NETSTANDARD1_5
-		public static IKernelConfiguration RegisterRawRabbit(this IKernelConfiguration config, RawRabbitOptions options = null)
-		{
-			if (options != null)
-			{
-				config.Bind<RawRabbitOptions>().ToConstant(options);
-			}
-			config.Load<RawRabbitModule>();
-			return config;
-		}
-#endif
-#if NET451
 		public static IKernel RegisterRawRabbit(this IKernel config, RawRabbitOptions options = null)
 		{
 			if (options != null)
@@ -26,6 +14,5 @@ namespace RawRabbit.DependencyInjection.Ninject
 			config.Load<RawRabbitModule>();
 			return config;
 		}
-#endif
 	}
 }

--- a/src/RawRabbit.DependencyInjection.Ninject/RawRabbit.DependencyInjection.Ninject.csproj
+++ b/src/RawRabbit.DependencyInjection.Ninject/RawRabbit.DependencyInjection.Ninject.csproj
@@ -5,7 +5,7 @@
     <AssemblyTitle>RawRabbit.DependencyInjection.Ninject</AssemblyTitle>
     <VersionPrefix>2.0.0</VersionPrefix>
     <Authors>par.dahlman;Joshua Barron</Authors>
-    <TargetFrameworks>netstandard1.5;net451</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net451</TargetFrameworks>
     <AssemblyName>RawRabbit.DependencyInjection.Ninject</AssemblyName>
     <PackageId>RawRabbit.DependencyInjection.Ninject</PackageId>
     <PackageTags>rabbitmq;rawrabbit;ninject;ioc</PackageTags>
@@ -19,20 +19,19 @@
     <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netstandard1.5|AnyCPU'">
-    <DefineConstants>TRACE;DEBUG;NETSTANDARD1_5;LIBLOG_PORTABLE</DefineConstants>
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netstandard2.0|AnyCPU'">
+    <DefineConstants>TRACE;DEBUG;LIBLOG_PORTABLE</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\RawRabbit\RawRabbit.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.5' ">
-    <PackageReference Include="Ninject" Version="4.0.0-beta-0134" />
-  </ItemGroup>
+	<ItemGroup>
+    <PackageReference Include="Ninject" Version="3.3.4" />
+	</ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
-    <PackageReference Include="Ninject" Version="3.2.2" />
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>

--- a/src/RawRabbit.DependencyInjection.Ninject/RawRabbitModule.cs
+++ b/src/RawRabbit.DependencyInjection.Ninject/RawRabbitModule.cs
@@ -9,21 +9,6 @@ namespace RawRabbit.DependencyInjection.Ninject
 	{
 		public override void Load()
 		{
-#if NETSTANDARD1_5
-			KernelConfiguration
-				.Bind<IDependencyResolver>()
-				.ToMethod(context => new NinjectAdapter(context));
-
-			KernelConfiguration
-				.Bind<IInstanceFactory>()
-				.ToMethod(context => RawRabbitFactory.CreateInstanceFactory(context.Kernel.Get<RawRabbitOptions>()))
-				.InSingletonScope();
-
-			KernelConfiguration
-				.Bind<IBusClient>()
-				.ToMethod(context => context.Kernel.Get<IInstanceFactory>().Create());
-#endif
-#if NET451
 			Kernel
 				.Bind<IDependencyResolver>()
 				.ToMethod(context => new NinjectAdapter(context));
@@ -36,7 +21,6 @@ namespace RawRabbit.DependencyInjection.Ninject
 			Kernel
 				.Bind<IBusClient>()
 				.ToMethod(context => context.Kernel.Get<IInstanceFactory>().Create());
-#endif
 		}
 	}
 }


### PR DESCRIPTION
### Description

The Ninject 4.0 branch looks completely dead with no commits since 2014 and the latest 3.3.x Ninject package now supports .Net Standard 2.0. The purpose of the PR is to update the RawRabbit.DependencyInjection.Ninject package to use the latest Ninject and as a result also the netstandard2_0 target framework.

### Check List

- [x] All test passed.
- [ ] Added documentation _(if applicable)_.
- [ ] Tests added to ensure functionality.
- [ ] Pull Request to `stable` branch.