### PR TITLE
fix : When rabbitmq publish a message with a null header

### DIFF
--- a/src/RawRabbit/Pipe/Middleware/HeaderDeserializationMiddleware.cs
+++ b/src/RawRabbit/Pipe/Middleware/HeaderDeserializationMiddleware.cs
@@ -74,7 +74,7 @@ namespace RawRabbit.Pipe.Middleware
 				_logger.Debug("DeliveryEventArgs not found.");
 				return null;
 			}
-			if (!args.BasicProperties.Headers.ContainsKey(headerKey))
+			if (args.BasicProperties.Headers == null || !args.BasicProperties.Headers.ContainsKey(headerKey))
 			{
 				_logger.Info("BasicProperties Header does not contain {headerKey}", headerKey);
 				return null;


### PR DESCRIPTION

### Description

When rabbitmq publish a message with a null header，
HeaderDeserializationMiddleware->GetHeaderBytes will throw NullReferenceException

