### PR TITLE
Use DefaultContractResolver with CamelCaseNamingStrategy

### DIFF
--- a/src/RawRabbit/DependencyInjection/RawRabbitDependencyRegisterExtension.cs
+++ b/src/RawRabbit/DependencyInjection/RawRabbitDependencyRegisterExtension.cs
@@ -1,5 +1,4 @@
 ﻿using System.Linq;
-using System.Runtime.Serialization.Formatters;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 using RabbitMQ.Client;
@@ -52,7 +51,7 @@ namespace RawRabbit.DependencyInjection
 					TypeNameAssemblyFormatHandling = TypeNameAssemblyFormatHandling.Simple,
 					Formatting = Formatting.None,
 					CheckAdditionalContent = true,
-					ContractResolver = new CamelCasePropertyNamesContractResolver(),
+					ContractResolver = new DefaultContractResolver { NamingStrategy = new CamelCaseNamingStrategy() },
 					ObjectCreationHandling = ObjectCreationHandling.Auto,
 					DefaultValueHandling = DefaultValueHandling.Ignore,
 					TypeNameHandling = TypeNameHandling.Auto,


### PR DESCRIPTION
Instead of CamelCasePropertyNamesContractResolver

### Description

CamelCasePropertyNamesContractResolver does not correctly serialize dictionaries, as keys are also camel-cased. This means that serializing them with this resolver and then deserializing results in a different set of keys, with all keys camelcased.

Related to: https://github.com/pardahlman/RawRabbit/issues/378

See also: https://github.com/JamesNK/Newtonsoft.Json/issues/1920