### PR TITLE
Ensure the consumer cache gets flushed of cancelled and faulted tasks

### DIFF
--- a/src/RawRabbit/Consumer/ConsumerFactory.cs
+++ b/src/RawRabbit/Consumer/ConsumerFactory.cs
@@ -48,11 +48,14 @@ namespace RawRabbit.Consumer
 					return consumer;
 				});
 			});
-			if (lazyConsumerTask.Value.IsCompleted && lazyConsumerTask.Value.Result.Model.IsClosed)
+
+			if (lazyConsumerTask.Value.IsCompleted && (lazyConsumerTask.Value.IsCanceled || lazyConsumerTask.Value.IsFaulted ||
+				lazyConsumerTask.Value.Result.Model.IsClosed))
 			{
 				_consumerCache.TryRemove(consumerKey, out _);
 				return GetConsumerAsync(cfg, channel, token);
 			}
+
 			return lazyConsumerTask.Value;
 		}
 


### PR DESCRIPTION
### Description
Currently, the `_consumerCache` within the `ConsumerFactory` has bad `IBasicConsumer`'s  removed and swapped out for new ones. This mechanism uses the `Task.IsCompleted` method (https://docs.microsoft.com/en-us/dotnet/api/system.threading.tasks.task.iscompleted?view=net-6.0), which catches cancelled and faulted tasks as well. However, if the task is faulted/cancelled, then calling `Task.Result` on such a task will result in the error (or `TaskCanceledException`) to be thrown.

Because of this, if the task in the cache becomes cancelled or faulted for whatever reason (I experienced this myself with a cancelled task, though have no idea where it came from) then the error will remain in the cache and be thrown whenever the consumer for that key is retreived again

This PR is a simple change to the logic to treat faulted and cancelled tasks separately to successfully completed tasks.
